### PR TITLE
Remove trailing whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ VERSION=$(shell cat globals/config.ml |grep version |perl -p -e 's/.*"(.*)".*/$$
 ##############################################################################
 TOP=$(shell pwd)
 
-SRC=test.ml main.ml 
+SRC=test.ml main.ml
 
 TARGET=yacfe
 PROGS=yacfe
@@ -72,37 +72,37 @@ BYTECODE_STATIC=-custom
 # Top rules
 ##############################################################################
 
-all: 
-	$(MAKE) rec 
-	$(MAKE) $(PROGS) 
-opt: 
-	$(MAKE) rec.opt 
-	$(MAKE) $(OPTPROGS) 
+all:
+	$(MAKE) rec
+	$(MAKE) $(PROGS)
+opt:
+	$(MAKE) rec.opt
+	$(MAKE) $(OPTPROGS)
 all.opt: opt
 top: $(EXEC).top
 
 #note: old: was before all: rec $(EXEC) ... but can not do that cos make -j20
 #could try to compile $(EXEC) before rec. So here force sequentiality.
 rec:
-	set -e; for i in $(MAKESUBDIRS); do $(MAKE) -C $$i all || exit 1; done 
+	set -e; for i in $(MAKESUBDIRS); do $(MAKE) -C $$i all || exit 1; done
 rec.opt:
-	set -e; for i in $(MAKESUBDIRS); do $(MAKE) -C $$i all.opt || exit 1; done 
+	set -e; for i in $(MAKESUBDIRS); do $(MAKE) -C $$i all.opt || exit 1; done
 
 $(EXEC): $(LIBS) $(OBJS)
 	$(OCAMLC) $(BYTECODE_STATIC) -o $@ $(SYSLIBS) $^
 
-$(EXEC).opt: $(LIBS:.cma=.cmxa) $(OPTOBJS) 
+$(EXEC).opt: $(LIBS:.cma=.cmxa) $(OPTOBJS)
 	$(OCAMLOPT) $(STATIC) -o $@ $(SYSLIBS:.cma=.cmxa) $^
 
 
-$(EXEC).top: $(LIBS) $(OBJS) 
+$(EXEC).top: $(LIBS) $(OBJS)
 	$(OCAMLMKTOP) -o $@ $(SYSLIBS) $^
 
 clean::
 	rm -f $(EXEC) $(EXEC).opt $(EXEC).top
 
 clean::
-	set -e; for i in $(MAKESUBDIRS); do $(MAKE) -C $$i clean; done 
+	set -e; for i in $(MAKESUBDIRS); do $(MAKE) -C $$i clean; done
 
 depend::
 	set -e; for i in $(MAKESUBDIRS); do $(MAKE) -C $$i depend; done
@@ -171,19 +171,19 @@ OCAMLVERSION=$(shell ocaml -version |perl -p -e 's/.*version (.*)/$$1/;')
 #  make package
 #  make website
 
-# To test you can try compile and run yacfe from different instances 
-# like my ~/c-yacfe, ~/release/yacfe, and the /tmp/yacfe-0.X 
-# downloaded from the website. 
+# To test you can try compile and run yacfe from different instances
+# like my ~/c-yacfe, ~/release/yacfe, and the /tmp/yacfe-0.X
+# downloaded from the website.
 
 # For 'make srctar' it must done from a clean
-# repo such as ~/release/yacfe. 
+# repo such as ~/release/yacfe.
 # For the 'make bintar' I can do it from my original repo.
 
 
-package: 
-	make srctar 
-#	make bintar 
-#	make staticbintar 
+package:
+	make srctar
+#	make bintar
+#	make staticbintar
 #	make bytecodetar
 
 srctar:
@@ -215,9 +215,9 @@ bytecodetar: all
 	rm -f $(TMP)/$(PACKAGE)
 
 clean::
-	rm -f $(PACKAGE) 
-	rm -f $(PACKAGE)-bin-x86.tgz 
-	rm -f $(PACKAGE)-bin-x86-static.tgz 
+	rm -f $(PACKAGE)
+	rm -f $(PACKAGE)-bin-x86.tgz
+	rm -f $(PACKAGE)-bin-x86-static.tgz
 	rm -f $(PACKAGE)-bin-bytecode-$(OCAMLVERSION).tgz
 
 ocamlversion:
@@ -247,7 +247,7 @@ website:
 #TXT=$(wildcard *.txt)
 syncwiki:
 #	unison ~/public_html/wiki/wiki-LFS/data/pages/ docs/wiki/
-#	set -e; for i in $(TXT); do unison $$i docs/wiki/$$i; done 
+#	set -e; for i in $(TXT); do unison $$i docs/wiki/$$i; done
 
 
 ##############################################################################
@@ -267,17 +267,17 @@ clean::
 
 test:
 # -parse_c big-files/
-# -parse_c pb_parsing/ 
+# -parse_c pb_parsing/
 # -parse_c pb_parsing_ecoop/
 
 PARSECMD=./spatch.opt -D standard.h -filter_define_error -filter_classic_passed \
 	  -dir
 
-testparsing2: 
-	$(PARSECMD) -parse_c ~/kernels/git/linux-2.6/sound/ > /tmp/parse_sound_filter 2>&1 
-	$(PARSECMD) -parse_c ~/kernels/git/linux-2.6/drivers/  > /tmp/parse_drivers_filter 2>&1 
-	$(PARSECMD) -parse_c ~/kernels/git/linux-2.6/  > /tmp/parse_c_filter 2>&1 
-	$(PARSECMD) -parse_h ~/kernels/git/linux-2.6/  > /tmp/parse_h_filter 2>&1 
+testparsing2:
+	$(PARSECMD) -parse_c ~/kernels/git/linux-2.6/sound/ > /tmp/parse_sound_filter 2>&1
+	$(PARSECMD) -parse_c ~/kernels/git/linux-2.6/drivers/  > /tmp/parse_drivers_filter 2>&1
+	$(PARSECMD) -parse_c ~/kernels/git/linux-2.6/  > /tmp/parse_c_filter 2>&1
+	$(PARSECMD) -parse_h ~/kernels/git/linux-2.6/  > /tmp/parse_h_filter 2>&1
 	$(PARSECMD) -parse_ch ~/kernels/git/linux-2.6/ > /tmp/parse_ch_filter 2>&1
 
 testparsing3:
@@ -294,7 +294,7 @@ testparsing4:
 cp_4mpi:
 	echo no copy needed yet
 
-test_mpi: opt yacfe.opt cp_4mpi 
+test_mpi: opt yacfe.opt cp_4mpi
 	time mpirun -p4pg env-machines-onlyme.pg ./yacfe.opt -parse_all /home/pad/software-src/devel/sparse-git
 
 ##############################################################################
@@ -310,7 +310,7 @@ test_mpi: opt yacfe.opt cp_4mpi
 .ml.cmx:
 	$(OCAMLOPT)  -c $<
 
-.ml.mldepend: 
+.ml.mldepend:
 	$(OCAMLC) -i $<
 
 clean::

--- a/bugs.txt
+++ b/bugs.txt
@@ -1,4 +1,4 @@
-Send a mail to yoann.padioleau@gmail.com with [Yacfe] 
+Send a mail to yoann.padioleau@gmail.com with [Yacfe]
 in the beginning of the subject.
 
 

--- a/changes.txt
+++ b/changes.txt
@@ -18,13 +18,13 @@ and will enable the -dump_c
 
 * 0.3
 
-** Documentation: 
-- extended readme.txt to explain how to quickly evaluate how much yacfe 
+** Documentation:
+- extended readme.txt to explain how to quickly evaluate how much yacfe
   can parse your C source code
 - improve yacfe-internal.pdf (based on CC'09 anonymous reviewers feedback).
 
 ** Language:
-- reorganize the way we parse C identifiers, especially concatenated cpp 
+- reorganize the way we parse C identifiers, especially concatenated cpp
   identifiers as in a##b. This may lead to some regressions as we may
   not parse as much code as before.
 - allow for with a declartion in the first header element, as in C++
@@ -40,7 +40,7 @@ and will enable the -dump_c
   such a problematic identifier. Helps to build a macro configuration file.
   (suggested by a CC'09 anonymous reviewer).
 - better handling of cpp "constructed" identifiers as in a##b, that in
-  the futur will make it easier to match over those idents. 
+  the futur will make it easier to match over those idents.
   cf tests/pb_parsing_macro.c. Thanks to Ali-Erdem Ozcan for pointing
   out the problem. A new "parsing hack hint" is also available:
   YACFE_IDENT_BUILDER, cf standard.h.
@@ -51,12 +51,12 @@ and will enable the -dump_c
 - new semantics for the -macro_file option, by default now expand macros
   only when necessary. To force use the -macro_file_builtins option instead.
 - a new -extract_macros command line action to help the parser. Works with
-  the -macro_file option. e.g. 
+  the -macro_file option. e.g.
     $ ./spatch -extract_macros ~/linux > /tmp/alldefs.h
     $ ./spatch -macro_file /tmp/alldefs.h -sp_file foo.cocci -dir ~/linux
-- better parsing of declare macro at toplevel and in structure. 
+- better parsing of declare macro at toplevel and in structure.
   cf -text xfield
-- handling of special coccinelle comments 
+- handling of special coccinelle comments
   /* {{coccinelle:skip_start}} */ and
   /* {{coccinelle:skip_end}} */
   allowing to give more hints to the C parser.
@@ -64,7 +64,7 @@ and will enable the -dump_c
 
 ** Applications:
 - GUI a la lxr and kscope that internally also uses glimpse and SmPL queries.
-- advanced code visualizer using semantic information to give visual 
+- advanced code visualizer using semantic information to give visual
   feedbacks (function pointer expression, globals in bigger size, multi_def
   functions underlines, etc)
 - caller/callee protocol checker
@@ -97,11 +97,11 @@ and will enable the -dump_c
   and handling of union and anonymous nested structure
   => on sparse now get 95% of typing coverage (vs 30% in yacfe 0.2)
 - allowing back typedef names for fieldname
-- better parsing of declare macro at toplevel and in structure. 
+- better parsing of declare macro at toplevel and in structure.
   cf -text xfield
 - for type inference for an assignment, take the type of the right-hand
   side expression, not the type of the assigned variable
-- consider the ident tokens also in the 2 lines before the error line for the 
+- consider the ident tokens also in the 2 lines before the error line for the
   10-most-problematic-parsing-errors diagnostic.
 - bugfix in parser, better error message.
   Thanks to Ali-Erdem OZCAN <ali-erdem.ozcan@st.com> for the bug report.
@@ -111,7 +111,7 @@ and will enable the -dump_c
 
 ** Language:
 - more ifdef in the ast
-- some support for attributes. 
+- some support for attributes.
 
 ** Bugfix:
 - complete missing cases in pretty_print_c.ml
@@ -119,7 +119,7 @@ and will enable the -dump_c
 ** Misc:
 - packagize a little (a readme.txt, configure, etc)
 
-** Documentation: 
+** Documentation:
 - readme.txt
 - demos/zero_to_null.ml
 
@@ -128,12 +128,12 @@ and will enable the -dump_c
 ** first public release of the source code (September 2008)
 (wait public release of coccinelle, from which yacfe is extracted)
 
-** Documentation: 
+** Documentation:
 - yacfe-internal.pdf (draft of paper submitted to CC'09).
 
-* beta 
+* beta
 
-** 2008: 
+** 2008:
 
 - first parsing_c++/ tentative.
 
@@ -148,7 +148,7 @@ and will enable the -dump_c
 - cpp directives and ifdef in ast (less passing) for CC'09 paper.
 
 
-** 2007: 
+** 2007:
 
 
 *** Features:
@@ -158,16 +158,16 @@ and will enable the -dump_c
 *** Parsing:
 - Parsing_hacks views and fresh tokens support.
 
-*** Language: 
+*** Language:
 - Support for define macro body, especially useful to improve stat
   when parsing header files.
 - Many cpp extensions.
 
 
-** 2006: 
+** 2006:
 
 *** Features:
-- matcher_c/ (using monad trick) with cocci_vs_c.ml, 
+- matcher_c/ (using monad trick) with cocci_vs_c.ml,
   pattern.ml, transformation.ml
 - unparsing, unparse_c.ml, pretty_print_c.ml
 - control_flow_c.ml, ast_to_flow.ml, flow_to_ast.ml (deprecated now)
@@ -177,29 +177,29 @@ and will enable the -dump_c
 - Parsing_hacks lookahead() and basic typedef inference handling
   in parsing_hacks.ml and token_helpers.ml
 
-*** Language: 
-- Many gcc extensions. 
+*** Language:
+- Many gcc extensions.
 - A few cpp extensions.
 
 
 * alpha
 
-** 2005: 
+** 2005:
 
 *** Parsing:
 - parse_c.ml, parsing driver with error recovery (for Eurosys'06)
   but that still pass over most cpp directives and macros.
 
 *** Features:
-- Statistics on Linux 
+- Statistics on Linux
 
-** 2002: 
+** 2002:
 
 *** Features:
 - First tentative of C type checker.
 
 *** Language:
-- Basic AST, lexer, grammar, inspired by 
+- Basic AST, lexer, grammar, inspired by
    http://www.lysator.liu.se/c/ANSI-C-grammar-l.html
    http://www.lysator.liu.se/c/ANSI-C-grammar-y.html
   in ast_c.ml, lexer_c.mll, parser_c.mly, and initial

--- a/commons/Makefile.common
+++ b/commons/Makefile.common
@@ -114,7 +114,7 @@ install: all all.opt
 
 install-findlib: all all.opt
 	ocamlfind install $(LIBNAME) META \
-    $(LIBNAME).cma $(LIBNAME).cmxa $(LIBNAME).a *.cmi $(EXPORTSRC) 
+    $(LIBNAME).cma $(LIBNAME).cmxa $(LIBNAME).a *.cmi $(EXPORTSRC)
 
 uninstall-findlib:
 	ocamlfind remove $(LIBNAME)

--- a/commons/common.ml
+++ b/commons/common.ml
@@ -696,14 +696,14 @@ let rec find_some_opt p = function
       |	Some v -> Some v
       |	None -> find_some_opt p l
 
-let find_some p xs = 
+let find_some p xs =
   match find_some_opt p xs with
   | None -> raise Not_found
   | Some x -> x
 
-let rec find_opt f xs = 
+let rec find_opt f xs =
   find_some_opt (fun x -> if f x then Some x else None) xs
-  
+
 
 (*****************************************************************************)
 (* Regexp, can also use PCRE *)
@@ -865,7 +865,7 @@ let realpath2 path =
 
 let realpath2 path =
   let stat = Unix.stat path in
-  let dir, suffix = 
+  let dir, suffix =
     match stat.Unix.st_kind with
     | Unix.S_DIR -> path, ""
     | _ -> Filename.dirname path, Filename.basename path
@@ -1057,7 +1057,7 @@ let group_by f xs =
 
   (* could use Set *)
   let hkeys = Hashtbl.create 101 in
-  
+
   xs |> List.iter (fun x ->
     let k = f x in
     Hashtbl.replace hkeys k true;
@@ -1071,7 +1071,7 @@ let group_by_multi fkeys xs =
 
   (* could use Set *)
   let hkeys = Hashtbl.create 101 in
-  
+
   xs |> List.iter (fun x ->
     let ks = fkeys x in
     ks |> List.iter (fun k ->
@@ -1276,7 +1276,7 @@ let main_boilerplate f =
         ))
        (fun()->
          if !profile <> ProfNone
-         then begin 
+         then begin
            pr2 (profile_diagnostic ());
            Gc.print_stat stderr;
          end;

--- a/commons/common.mli
+++ b/commons/common.mli
@@ -54,9 +54,9 @@ val cat :      filename -> string list
 val write_file : file:filename -> string -> unit
 val read_file : filename -> string
 
-val with_open_outfile : 
+val with_open_outfile :
   filename -> ((string -> unit) * out_channel -> 'a) -> 'a
-val with_open_infile : 
+val with_open_infile :
   filename -> (in_channel -> 'a) -> 'a
 
 exception CmdError of Unix.process_status * string
@@ -103,7 +103,7 @@ val push : 'a -> 'a stack ref -> unit
 val hash_of_list : ('a * 'b) list -> ('a, 'b) Hashtbl.t
 val hash_to_list : ('a, 'b) Hashtbl.t -> ('a * 'b) list
 
-type 'a hashset = ('a, bool) Hashtbl.t 
+type 'a hashset = ('a, bool) Hashtbl.t
 val hashset_of_list : 'a list -> 'a hashset
 val hashset_to_list : 'a hashset -> 'a list
 
@@ -129,10 +129,10 @@ type cmdline_options = arg_spec_full list
 type options_with_title = string * string * arg_spec_full list
 type cmdline_sections = options_with_title list
 
-(* A wrapper around Arg modules that have more logical argument order, 
+(* A wrapper around Arg modules that have more logical argument order,
  * and returns the remaining args.
  *)
-val parse_options : 
+val parse_options :
   cmdline_options -> Arg.usage_msg -> string array -> string list
 (* Another wrapper that does Arg.align automatically *)
 val usage : Arg.usage_msg -> cmdline_options -> unit
@@ -140,24 +140,24 @@ val usage : Arg.usage_msg -> cmdline_options -> unit
 (* Work with the options_with_title type way to organize a long
  * list of command line switches.
  *)
-val short_usage : 
+val short_usage :
   Arg.usage_msg -> short_opt:cmdline_options -> unit
-val long_usage : 
-  Arg.usage_msg -> short_opt:cmdline_options -> long_opt:cmdline_sections -> 
+val long_usage :
+  Arg.usage_msg -> short_opt:cmdline_options -> long_opt:cmdline_sections ->
   unit
 
 (* With the options_with_title way, we don't want the default -help and --help
  * so need adapter of Arg module, not just wrapper.
  *)
 val arg_align2 : cmdline_options -> cmdline_options
-val arg_parse2 : 
-  cmdline_options -> Arg.usage_msg -> (unit -> unit) (* short_usage func *) -> 
+val arg_parse2 :
+  cmdline_options -> Arg.usage_msg -> (unit -> unit) (* short_usage func *) ->
   string list
 
 (* The action lib. Useful to debug supart of your system. cf some of
  * my main.ml for example of use. *)
 type flag_spec   = Arg.key * Arg.spec * Arg.doc
-type action_spec = Arg.key * Arg.doc * action_func 
+type action_spec = Arg.key * Arg.doc * action_func
    and action_func = (string list -> unit)
 
 type cmdline_actions = action_spec list
@@ -167,16 +167,16 @@ val mk_action_0_arg : (unit -> unit)                       -> action_func
 val mk_action_1_arg : (string -> unit)                     -> action_func
 val mk_action_2_arg : (string -> string -> unit)           -> action_func
 val mk_action_3_arg : (string -> string -> string -> unit) -> action_func
-val mk_action_4_arg : (string -> string -> string -> string -> unit) -> 
+val mk_action_4_arg : (string -> string -> string -> string -> unit) ->
   action_func
 
 val mk_action_n_arg : (string list -> unit) -> action_func
 
-val options_of_actions: 
+val options_of_actions:
   string ref (* the action ref *) -> cmdline_actions -> cmdline_options
-val do_action: 
+val do_action:
   Arg.key -> string list (* args *) -> cmdline_actions -> unit
-val action_list: 
+val action_list:
   cmdline_actions -> Arg.key list
 
 
@@ -190,10 +190,10 @@ val finalize :       (unit -> 'a) -> (unit -> 'b) -> 'a
 
 val save_excursion : 'a ref -> 'a -> (unit -> 'b) -> 'b
 
-val memoized : 
+val memoized :
   ?use_cache:bool -> ('a, 'b) Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
 
-exception UnixExit of int 
+exception UnixExit of int
 
 exception Timeout
 val timeout_function :
@@ -213,8 +213,8 @@ val report_if_take_time : int -> string -> (unit -> 'a) -> 'a
 (* similar to profile_code but print some information during execution too *)
 val profile_code2 : string -> (unit -> 'a) -> 'a
 
-(* creation of /tmp files, a la gcc 
- * ex: new_temp_file "cocci" ".c" will give "/tmp/cocci-3252-434465.c" 
+(* creation of /tmp files, a la gcc
+ * ex: new_temp_file "cocci" ".c" will give "/tmp/cocci-3252-434465.c"
  *)
 val _temp_files_created : string list ref
 val save_tmp_files : bool ref
@@ -225,8 +225,8 @@ val erase_this_temp_file : filename -> unit
 (* val realpath: filename -> filename *)
 val fullpath: filename -> filename
 
-val cache_computation : 
-  ?verbose:bool -> ?use_cache:bool -> filename  -> string (* extension *) -> 
+val cache_computation :
+  ?verbose:bool -> ?use_cache:bool -> filename  -> string (* extension *) ->
   (unit -> 'a) -> 'a
 
 val filename_without_leading_path : string -> filename -> filename

--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -2130,10 +2130,10 @@ let dbe_of_filename_nodot file =
  * let dbe_of_filename_noext_ok file =
  *   ...
  *   if Str.string_match re_be base 0
- *   then 
+ *   then
  *     let (b, e) = matched2 base in
  *     (dir, b, e)
- * 
+ *
  *  That way files like foo.md5sum.c would not be considered .c
  *  but .md5sum.c, but then it has too many disadvantages because
  *  then regular files like qemu.root.c would not be considered
@@ -5917,7 +5917,7 @@ module Infix = struct
   let (=~) = (=~)
 end
 
-(* based on code found in cameleon from maxence guesdon 
+(* based on code found in cameleon from maxence guesdon
  * alt: use Digest.string! far faster!
  *)
 let md5sum_of_string s =

--- a/commons/common2.mli
+++ b/commons/common2.mli
@@ -7,7 +7,7 @@
 (* Flags *)
 (*****************************************************************************)
 (*s: common.mli globals flags *)
-(* see the corresponding section for the use of those flags. See also 
+(* see the corresponding section for the use of those flags. See also
  * the "Flags and actions" section at the end of this file.
  *)
 
@@ -41,7 +41,7 @@ val typing_sux_test : unit -> unit
 (*****************************************************************************)
 (* Module side effect *)
 (*****************************************************************************)
-(* 
+(*
  * I define a few unit tests via some let _ = example (... = ...).
  * I also initialize the random seed, cf _init_random .
  * I also set Gc.stack_size, cf _init_gc_stack .
@@ -88,22 +88,22 @@ end
 (*
  * Another related trick, found via Jon Harrop to have an extended standard
  * lib is to do something like
- * 
+ *
  * module List = struct
  *  include List
  *  val map2 : ...
  * end
- * 
+ *
  * And then can put this "module extension" somewhere to open it.
  *)
 
 
 
-(* This module defines the Timeout and UnixExit exceptions.  
- * You  have to make sure that those exn are not intercepted. So 
+(* This module defines the Timeout and UnixExit exceptions.
+ * You  have to make sure that those exn are not intercepted. So
  * avoid exn handler such as try (...) with _ -> cos Timeout will not bubble up
- * enough. In such case, add a case before such as  
- * with Timeout -> raise Timeout | _ -> ... 
+ * enough. In such case, add a case before such as
+ * with Timeout -> raise Timeout | _ -> ...
  * The same is true for UnixExit (see below).
  *)
 (*x: common.mli basic features *)
@@ -119,9 +119,9 @@ val reset_pr_indent : unit -> unit
  * They also add the _prefix_pr, for instance used in MPI to show which
  * worker is talking.
  * update: for pr2, it can also print into a log file.
- * 
+ *
  * The use of 2 in pr2 is because 2 is under UNIX the second descriptor
- * which corresponds to stderr. 
+ * which corresponds to stderr.
  *)
 val _prefix_pr : string ref
 
@@ -162,9 +162,9 @@ val sprintf : ('a, unit, string) format -> 'a
 val spf : ('a, unit, string) format -> 'a
 
 (* default = stderr *)
-val _chan : out_channel ref 
+val _chan : out_channel ref
 (* generate & use a /tmp/debugml-xxx file *)
-val start_log_file : unit -> unit 
+val start_log_file : unit -> unit
 
 (* see flag: val verbose_level : int ref *)
 val log : string -> unit
@@ -230,9 +230,9 @@ val time_func : (unit -> 'a) -> 'a
 (*old: val example : bool -> unit, PB with js_of_ocaml? *)
 val example : bool -> unit
 (* generate failwith <string> when pb *)
-val example2 : string -> bool -> unit 
+val example2 : string -> bool -> unit
 (* use Dumper to report when pb *)
-val assert_equal : 'a -> 'a -> unit 
+val assert_equal : 'a -> 'a -> unit
 
 val _list_bool : (string * bool) list ref
 val example3 : string -> bool -> unit
@@ -240,11 +240,11 @@ val test_all : unit -> unit
 
 
 (* regression testing *)
-type score_result = Ok | Pb of string 
+type score_result = Ok | Pb of string
 type score =      (string (* usually a filename *), score_result) Hashtbl.t
 type score_list = (string (* usually a filename *) * score_result) list
 val empty_score : unit -> score
-val regression_testing : 
+val regression_testing :
   score -> filename (* old score file on disk (usually in /tmp) *) -> unit
 val regression_testing_vs: score -> score -> score
 val total_scores : score -> int (* good *) * int (* total *)
@@ -270,7 +270,7 @@ val frequencyl : (int * 'a) list -> 'a gen
 
 val laws : string -> ('a -> bool) -> 'a gen -> 'a option
 
-(* example of use: 
+(* example of use:
  * let b = laws "unit" (fun x -> reverse [x] = [x])    ig
  *)
 
@@ -339,7 +339,7 @@ val adjust_pp_with_indent : (unit -> unit) -> unit
 val adjust_pp_with_indent_and_header : string -> (unit -> unit) -> unit
 
 
-val mk_str_func_of_assoc_conv: 
+val mk_str_func_of_assoc_conv:
   ('a * string) list -> (string -> 'a) * ('a -> string)
 (*x: common.mli basic features *)
 (*****************************************************************************)
@@ -397,31 +397,31 @@ val save_excursion : 'a ref -> 'a -> (unit -> 'b) -> 'b
 val save_excursion_and_disable : bool ref -> (unit -> 'b) -> 'b
 val save_excursion_and_enable :  bool ref -> (unit -> 'b) -> 'b
 
-val memoized : 
+val memoized :
   ?use_cache:bool -> ('a, 'b) Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
 
 val cache_in_ref : 'a option ref -> (unit -> 'a) -> 'a
 
 
 (* take file from which computation is done, an extension, and the function
- * and will compute the function only once and then save result in 
+ * and will compute the function only once and then save result in
  * file ^ extension
  *)
-val cache_computation : 
-  ?verbose:bool -> ?use_cache:bool -> filename  -> string (* extension *) -> 
+val cache_computation :
+  ?verbose:bool -> ?use_cache:bool -> filename  -> string (* extension *) ->
   (unit -> 'a) -> 'a
 
-(* a more robust version where the client describes the dependencies of the 
- * computation so it will relaunch the computation in 'f' if needed. 
+(* a more robust version where the client describes the dependencies of the
+ * computation so it will relaunch the computation in 'f' if needed.
  *)
 val cache_computation_robust :
-  filename -> 
-  string (* extension for marshalled object *) -> 
-  (filename list * 'x) -> 
-  string (* extension for marshalled dependencies *) -> 
-  (unit -> 'a) -> 
+  filename ->
+  string (* extension for marshalled object *) ->
+  (filename list * 'x) ->
+  string (* extension for marshalled dependencies *) ->
+  (unit -> 'a) ->
   'a
-  
+
 val oncef : ('a -> unit) -> ('a -> unit)
 val once: bool ref -> (unit -> unit) -> unit
 
@@ -434,7 +434,7 @@ val before_leaving : ('a -> unit) -> 'a -> 'a
 (*****************************************************************************)
 
 (* how ensure really atomic file creation ? hehe :) *)
-exception FileAlreadyLocked 
+exception FileAlreadyLocked
 val acquire_file_lock : filename -> unit
 val release_file_lock : filename -> unit
 (*x: common.mli basic features *)
@@ -458,7 +458,7 @@ val string_of_exn : exn -> string
 
 val exn_to_s_with_backtrace : exn -> string
 
-type error = Error of string 
+type error = Error of string
 
 type evotype = unit
 val evoval : evotype
@@ -471,7 +471,7 @@ val _check_stack: bool ref
 
 val check_stack_size: int -> unit
 val check_stack_nbfiles: int -> unit
- 
+
 (* internally common.ml set Gc. parameters *)
 val _init_gc_stack : unit
 (*x: common.mli basic features *)
@@ -499,14 +499,14 @@ val (=:=) : bool   -> bool   -> bool
 
 (* the evil generic (=). I define another symbol to more easily detect
  * it, cos the '=' sign is syntaxically overloaded in caml. It is also
- * used to define function. 
+ * used to define function.
  *)
 val (=*=): 'a -> 'a -> bool
 
 (* if want to restrict the use of '=', uncomment this:
  *
  * val (=): unit -> unit -> bool
- * 
+ *
  * But it will not forbid you to use caml functions like List.find, List.mem
  * which internaly use this convenient but evolution-unfriendly (=)
 *)
@@ -600,7 +600,7 @@ val int_of_all : string -> int
 val ( += ) : int ref -> int -> unit
 val ( -= ) : int ref -> int -> unit
 
-val pourcent: int -> int -> int 
+val pourcent: int -> int -> int
 val pourcent_float: int -> int -> float
 val pourcent_float_of_floats: float -> float -> float
 
@@ -608,7 +608,7 @@ val pourcent_good_bad: int -> int -> int
 val pourcent_good_bad_float: int -> int -> float
 
 type 'a max_with_elem = int ref * 'a ref
-val update_max_with_elem: 
+val update_max_with_elem:
   'a max_with_elem -> is_better:(int -> int ref -> bool) -> int * 'a -> unit
 
 (*x: common.mli for basic types *)
@@ -630,7 +630,7 @@ val numd_float : float numdict
 val testd : 'a numdict -> 'a -> 'a
 
 
-module ArithFloatInfix : sig 
+module ArithFloatInfix : sig
     val (+) : float -> float -> float
     val (-) : float -> float -> float
     val (/) : float -> float -> float
@@ -772,9 +772,9 @@ val showCodeHex : int list -> unit
 val size_mo_ko : int -> string
 val size_ko : int -> string
 
-val edit_distance: string -> string -> int 
+val edit_distance: string -> string -> int
 
-val md5sum_of_string : string -> string 
+val md5sum_of_string : string -> string
 
 val wrap: ?width:int -> string -> string
 
@@ -814,7 +814,7 @@ val split_list_regexp : string -> string list -> (string * string list) list
 val split_list_regexp_noheading : string
 
 val all_match : string (* regexp *) -> string -> string list
-val global_replace_regexp : 
+val global_replace_regexp :
   string (* regexp *) -> (string -> string) -> string -> string
 
 val regular_words: string -> string list
@@ -853,7 +853,7 @@ val filename_of_db : (string * filename) -> filename
 val dbe_of_filename : filename -> string * string * string
 val dbe_of_filename_nodot : filename -> string * string * string
 (* Left (d,b,e) | Right (d,b)  if file has no extension *)
-val dbe_of_filename_safe : 
+val dbe_of_filename_safe :
   filename -> (string * string * string,  string * string) either
 val dbe_of_filename_noext_ok : filename -> string * string * string
 
@@ -891,7 +891,7 @@ type filepos = {
 (*****************************************************************************)
 (* i18n *)
 (*****************************************************************************)
-type langage = 
+type langage =
   | English
   | Francais
   | Deutsch
@@ -902,7 +902,7 @@ type langage =
 
 (* can also use ocamlcalendar, but heavier, use many modules ... *)
 
-type month = 
+type month =
   | Jan  | Feb  | Mar  | Apr  | May  | Jun
   | Jul  | Aug  | Sep  | Oct  | Nov  | Dec
 type year = Year of int
@@ -1056,7 +1056,7 @@ val cmd_to_list :            ?verbose:bool -> string -> string list (* alias *)
 
 val command2 : string -> unit
 val _batch_mode: bool ref
-val command_safe: ?verbose:bool -> 
+val command_safe: ?verbose:bool ->
   filename (* executable *) -> string list (* args *) -> int
 
 val y_or_no: string -> bool
@@ -1106,7 +1106,7 @@ val unixname: unit -> string
 
 
 val glob : string -> filename list
-val files_of_dir_or_files : 
+val files_of_dir_or_files :
   string (* ext *) -> string list -> filename list
 val files_of_dir_or_files_no_vcs :
   string (* ext *) -> string list -> filename list
@@ -1130,19 +1130,19 @@ val file_perm_of : u:rwx -> g:rwx -> o:rwx -> Unix.file_perm
 val has_env : string -> bool
 
 (* scheme spirit. do a finalize so no leak. *)
-val with_open_outfile_append : 
+val with_open_outfile_append :
   filename -> ((string -> unit) * out_channel -> 'a) -> 'a
 
-val with_open_stringbuf : 
+val with_open_stringbuf :
   (((string -> unit) * Buffer.t) -> unit) -> string
 
 exception Timeout
 
-(* subtil: have to make sure that Timeout is not intercepted before here. So 
+(* subtil: have to make sure that Timeout is not intercepted before here. So
  * avoid exn handler such as try (...) with _ -> cos Timeout will not bubble up
- * enough. In such case, add a case before such as  
- * with Timeout -> raise Timeout | _ -> ... 
- * 
+ * enough. In such case, add a case before such as
+ * with Timeout -> raise Timeout | _ -> ...
+ *
  * The same is true for UnixExit (see below).
  *)
 val timeout_function :
@@ -1159,11 +1159,11 @@ val with_tmp_dir: (dirname -> 'a) -> 'a
  * exit and do something before exiting. There is exn handler for exit 0
  * so better never use exit 0 but instead use an exception and just at
  * the very toplevel transform this exn in a unix exit code.
- * 
+ *
  * subtil: same problem than with Timeout. Do not intercept such exception
  * with some blind try (...) with _ -> ...
  *)
-exception UnixExit of int 
+exception UnixExit of int
 val exn_to_real_unixexit : (unit -> 'a) -> 'a
 (*e: common.mli for basic types *)
 
@@ -1294,7 +1294,7 @@ val exclude : ('a -> bool) -> 'a list -> 'a list
  * line. Here we delete any repeated line (here list element).
  *)
 val uniq : 'a list -> 'a list
-val uniq_eff: 'a list -> 'a list 
+val uniq_eff: 'a list -> 'a list
 val big_union_eff: 'a list list -> 'a list
 
 val has_no_duplicate: 'a list -> bool
@@ -1330,7 +1330,7 @@ val and_list : bool list -> bool
 
 val sum_float : float list -> float
 val sum_int : int list -> int
-val avg_list: int list -> float 
+val avg_list: int list -> float
 
 val return_when : ('a -> 'b option) -> 'a list -> 'b
 
@@ -1339,7 +1339,7 @@ val grep_with_previous : ('a -> 'a -> bool) -> 'a list -> 'a list
 val iter_with_previous : ('a -> 'a -> 'b) -> 'a list -> unit
 val iter_with_previous_opt : ('a option -> 'a -> 'b) -> 'a list -> unit
 
-val iter_with_before_after : 
+val iter_with_before_after :
  ('a list -> 'a -> 'a list -> unit) -> 'a list -> unit
 
 val get_pair : 'a list -> ('a * 'a) list
@@ -1378,7 +1378,7 @@ val array_find_index_via_elem : ('a -> bool) -> 'a array -> int
 (* for better type checking, as sometimes when have an 'int array', can
  * easily mess up the index from the value.
  *)
-type idx = Idx of int 
+type idx = Idx of int
 val next_idx: idx -> idx
 val int_of_idx: idx -> int
 
@@ -1398,13 +1398,13 @@ type 'a matrix = 'a array array
 
 val map_matrix : ('a -> 'b) -> 'a matrix -> 'b matrix
 
-val make_matrix_init: 
+val make_matrix_init:
   nrow:int -> ncolumn:int -> (int -> int -> 'a) -> 'a matrix
 
-val iter_matrix: 
+val iter_matrix:
   (int -> int -> 'a -> unit) -> 'a matrix -> unit
 
-val nb_rows_matrix: 'a matrix -> int 
+val nb_rows_matrix: 'a matrix -> int
 val nb_columns_matrix: 'a matrix -> int
 
 val rows_of_matrix: 'a matrix -> 'a list list
@@ -1469,19 +1469,19 @@ val ( $@$ ) : 'a list -> 'a list -> 'a list
 
 val nub : 'a list -> 'a list
 
-(* use internally a hash and return 
- * - the common part, 
- * - part only in a, 
+(* use internally a hash and return
+ * - the common part,
+ * - part only in a,
  * - part only in b
  *)
-val diff_set_eff : 'a list -> 'a list -> 
+val diff_set_eff : 'a list -> 'a list ->
   'a list * 'a list * 'a list
 (*x: common.mli for collection types *)
 (*****************************************************************************)
 (* Set as normal list *)
 (*****************************************************************************)
 
-(* cf above *) 
+(* cf above *)
 (*x: common.mli for collection types *)
 (*****************************************************************************)
 (* Set as sorted list *)
@@ -1565,7 +1565,7 @@ val lookup_list2 : 'a -> ('a, 'b) assoc list -> 'b * int
 val assoc_opt : 'a -> ('a, 'b) assoc -> 'b option
 val assoc_with_err_msg : 'a -> ('a, 'b) assoc -> 'b
 
-type order = HighFirst | LowFirst 
+type order = HighFirst | LowFirst
 val compare_order: order -> 'a -> 'a -> int
 
 val sort_by_val_lowfirst: ('a,'b) assoc -> ('a * 'b) list
@@ -1628,8 +1628,8 @@ val intintmap_string_of_t : 'a -> 'b -> string
 (* Note that Hashtbl keep old binding to a key so if want a hash
  * of a list, then can use the Hashtbl as is. Use Hashtbl.find_all then
  * to get the list of bindings
- * 
- * Note that Hashtbl module use different convention :( the object is 
+ *
+ * Note that Hashtbl module use different convention :( the object is
  * the first argument, not last as for List or Map.
  *)
 
@@ -1646,7 +1646,7 @@ val hremove : 'a -> ('a, 'b) Hashtbl.t -> unit
 
 val hfind_default : 'a -> (unit -> 'b) -> ('a, 'b) Hashtbl.t -> 'b
 val hfind_option : 'a -> ('a, 'b) Hashtbl.t -> 'b option
-val hupdate_default : 
+val hupdate_default :
   'a -> update:('b -> 'b) -> default:(unit -> 'b) -> ('a, 'b) Hashtbl.t -> unit
 
 val add1: int -> int
@@ -1657,7 +1657,7 @@ val hash_to_list_unsorted : ('a, 'b) Hashtbl.t -> ('a * 'b) list
 val hash_of_list : ('a * 'b) list -> ('a, 'b) Hashtbl.t
 
 
-val hkeys : ('a, 'b) Hashtbl.t -> 'a list 
+val hkeys : ('a, 'b) Hashtbl.t -> 'a list
 
 (* hunion h1 h2  adds all binding in h2 into h1 *)
 val hunion: ('a, 'b) Hashtbl.t -> ('a, 'b) Hashtbl.t -> unit
@@ -1666,7 +1666,7 @@ val hunion: ('a, 'b) Hashtbl.t -> ('a, 'b) Hashtbl.t -> unit
 (* Hash sets *)
 (*****************************************************************************)
 
-type 'a hashset = ('a, bool) Hashtbl.t 
+type 'a hashset = ('a, bool) Hashtbl.t
 
 
 (* common use of hashset, in a hash of hash *)
@@ -1678,7 +1678,7 @@ val hashset_union: 'a hashset -> 'a hashset -> unit
 (* hashset_inter h1 h2  removes all elements in h1 not in h2 *)
 val hashset_inter: 'a hashset -> 'a hashset -> unit
 
-val hashset_to_set : 
+val hashset_to_set :
  < fromlist : ('a ) list -> 'c; .. > -> ('a, 'b) Hashtbl.t -> 'c
 
 val hashset_to_list : 'a hashset -> 'a list
@@ -1688,7 +1688,7 @@ val hashset_of_list : 'a list -> 'a hashset
 (* Hash  with default value *)
 (*****************************************************************************)
 type ('a, 'b) hash_with_default =
-  < add : 'a -> 'b -> unit; 
+  < add : 'a -> 'b -> unit;
     to_list : ('a * 'b) list;
     to_h: ('a, 'b) Hashtbl.t;
     update : 'a -> ('b -> 'b) -> unit;
@@ -1696,7 +1696,7 @@ type ('a, 'b) hash_with_default =
   >
 
 val hash_with_default: (unit -> 'b) ->
-  < add : 'a -> 'b -> unit; 
+  < add : 'a -> 'b -> unit;
     to_list : ('a * 'b) list;
     to_h: ('a, 'b) Hashtbl.t;
     update : 'a -> ('b -> 'b) -> unit;
@@ -1747,12 +1747,12 @@ type 'a tree2 = Tree of 'a * ('a tree2) list
 val tree2_iter : ('a -> unit) -> 'a tree2 -> unit
 
 
-type ('a, 'b) tree = 
+type ('a, 'b) tree =
   | Node of 'a * ('a, 'b) tree list
   | Leaf of 'b
 
-val map_tree: 
-  fnode:('a -> 'abis) -> 
+val map_tree:
+  fnode:('a -> 'abis) ->
   fleaf:('b -> 'bbis) ->
   ('a, 'b) tree -> ('abis, 'bbis) tree
 
@@ -1766,21 +1766,21 @@ val tree_of_files: filename list -> (dirname, (string * filename)) tree
 (*****************************************************************************)
 
 (* no empty tree, must have one root at least *)
-type 'a treeref = 
-  | NodeRef of 'a *   'a treeref list ref 
+type 'a treeref =
+  | NodeRef of 'a *   'a treeref list ref
 
-val treeref_node_iter: 
+val treeref_node_iter:
   (('a * 'a treeref list ref) -> unit) -> 'a treeref -> unit
-val treeref_node_iter_with_parents: 
-  (('a * 'a treeref list ref) -> ('a list) -> unit) -> 
+val treeref_node_iter_with_parents:
+  (('a * 'a treeref list ref) -> ('a list) -> unit) ->
   'a treeref -> unit
 
-val find_treeref: 
-  (('a * 'a treeref list ref) -> bool) -> 
+val find_treeref:
+  (('a * 'a treeref list ref) -> bool) ->
   'a treeref -> 'a treeref
 
-val treeref_children_ref: 
-  'a treeref -> 'a treeref list ref 
+val treeref_children_ref:
+  'a treeref -> 'a treeref list ref
 
 val find_treeref_with_parents_some:
  ('a * 'a treeref list ref -> 'a list -> 'c option) ->
@@ -1791,29 +1791,29 @@ val find_multi_treeref_with_parents_some:
  'a treeref -> 'c list
 
 
-(* Leaf can seem redundant, but sometimes want to directly see if 
+(* Leaf can seem redundant, but sometimes want to directly see if
  * a children is a leaf without looking if the list is empty.
  *)
-type ('a, 'b) treeref2 = 
-  | NodeRef2 of 'a * ('a, 'b) treeref2 list ref 
+type ('a, 'b) treeref2 =
+  | NodeRef2 of 'a * ('a, 'b) treeref2 list ref
   | LeafRef2 of 'b
 
 
-val find_treeref2: 
-  (('a * ('a, 'b) treeref2 list ref) -> bool) -> 
+val find_treeref2:
+  (('a * ('a, 'b) treeref2 list ref) -> bool) ->
   ('a, 'b) treeref2 -> ('a, 'b) treeref2
 
-val treeref_node_iter_with_parents2: 
-  (('a * ('a, 'b) treeref2 list ref) -> ('a list) -> unit) -> 
+val treeref_node_iter_with_parents2:
+  (('a * ('a, 'b) treeref2 list ref) -> ('a list) -> unit) ->
   ('a, 'b) treeref2 -> unit
 
-val treeref_node_iter2: 
+val treeref_node_iter2:
   (('a * ('a, 'b) treeref2 list ref) -> unit) -> ('a, 'b) treeref2 -> unit
 
 (*
 
 
-val treeref_children_ref: ('a, 'b) treeref -> ('a, 'b) treeref list ref 
+val treeref_children_ref: ('a, 'b) treeref -> ('a, 'b) treeref list ref
 
 val find_treeref_with_parents_some:
  ('a * ('a, 'b) treeref list ref -> 'a list -> 'c option) ->
@@ -1987,7 +1987,7 @@ val new_scope : ('a, 'b) scoped_env ref -> unit
 val del_scope : ('a, 'b) scoped_env ref -> unit
 
 val do_in_new_scope : ('a, 'b) scoped_env ref -> (unit -> unit) -> unit
-  
+
 val add_in_scope : ('a, 'b) scoped_env ref -> 'a * 'b -> unit
 
 

--- a/commons/credits.txt
+++ b/commons/credits.txt
@@ -1,4 +1,4 @@
-Thanks to 
+Thanks to
  - Richard Jones for his dumper.ml module (public domain?)
  - Jane Street for the backtrace module and lib-sexp/ (LGPL)
  - Martin Jambon, Mika Illouz and Gert Stolpmann for lib-json/ (BSD-like)

--- a/commons/deprecated/backtrace.ml
+++ b/commons/deprecated/backtrace.ml
@@ -1,8 +1,8 @@
 open Common
 
-(* 
+(*
  * src: Jane Street Core library.
- * update: Normally no more needed in OCaml 3.11 as part of the 
+ * update: Normally no more needed in OCaml 3.11 as part of the
  *  default runtime.
  *)
 external print : unit -> unit = "print_exception_backtrace_stub" "noalloc"
@@ -15,7 +15,7 @@ external print : unit -> unit = "print_exception_backtrace_stub" "noalloc"
 exception MyNot_Found
 
 let foo1 () =
-  if 1=1 
+  if 1=1
   then raise MyNot_Found
   else 2
 
@@ -24,7 +24,7 @@ let foo2 () =
 
 let test_backtrace () =
   (try ignore(foo2 ())
-  with exn -> 
+  with exn ->
     pr2 (Common.exn_to_s exn);
     print();
     failwith "other exn"
@@ -32,7 +32,7 @@ let test_backtrace () =
   print_string "ok cool\n";
   ()
 
-let actions () = 
+let actions () =
   [
   "-test_backtrace", "   ",
   Common.mk_action_0_arg test_backtrace;

--- a/commons/deprecated/sexp_common.ml
+++ b/commons/deprecated/sexp_common.ml
@@ -6,28 +6,28 @@ let sexp_of_either _of_a _of_b =
   function
   | Left v1 -> let v1 = _of_a v1 in Sexp.List [ Sexp.Atom "Left"; v1 ]
   | Right v1 -> let v1 = _of_b v1 in Sexp.List [ Sexp.Atom "Right"; v1 ]
-  
+
 let sexp_of_either3 _of_a _of_b _of_c =
   function
   | Left3 v1 -> let v1 = _of_a v1 in Sexp.List [ Sexp.Atom "Left3"; v1 ]
   | Middle3 v1 -> let v1 = _of_b v1 in Sexp.List [ Sexp.Atom "Middle3"; v1 ]
   | Right3 v1 -> let v1 = _of_c v1 in Sexp.List [ Sexp.Atom "Right3"; v1 ]
-  
- 
+
+
 let sexp_of_filename v = Conv.sexp_of_string v
 let sexp_of_dirname v = Conv.sexp_of_string v
-  
+
 let sexp_of_set _of_a = Conv.sexp_of_list _of_a
-  
+
 let sexp_of_assoc _of_a _of_b =
   Conv.sexp_of_list
     (fun (v1, v2) ->
        let v1 = _of_a v1 and v2 = _of_b v2 in Sexp.List [ v1; v2 ])
-  
+
 let sexp_of_hashset _of_a = Conv.sexp_of_hashtbl _of_a Conv.sexp_of_bool
-  
+
 let sexp_of_stack _of_a = Conv.sexp_of_list _of_a
-  
+
 
 
 let sexp_of_score_result =
@@ -35,10 +35,10 @@ let sexp_of_score_result =
   | Common2.Ok -> Sexp.Atom "Ok"
   | Common2.Pb v1 ->
       let v1 = Conv.sexp_of_string v1 in Sexp.List [ Sexp.Atom "Pb"; v1 ]
-  
+
 let sexp_of_score v =
   Conv.sexp_of_hashtbl Conv.sexp_of_string sexp_of_score_result v
-  
+
 let sexp_of_score_list v =
   Conv.sexp_of_list
     (fun (v1, v2) ->

--- a/commons/dumper.ml
+++ b/commons/dumper.ml
@@ -1,6 +1,6 @@
 (* Dump an OCaml value into a printable string.
  * By Richard W.M. Jones (rich@annexia.org).
- * dumper.ml 1.2 2005/02/06 12:38:21 rich Exp 
+ * dumper.ml 1.2 2005/02/06 12:38:21 rich Exp
  *)
 
 open Printf

--- a/commons/dumper.mli
+++ b/commons/dumper.mli
@@ -1,6 +1,6 @@
 (* Dump an OCaml value into a printable string.
  * By Richard W.M. Jones (rich@annexia.org).
- * dumper.mli 1.1 2005/02/03 23:07:47 rich Exp 
+ * dumper.mli 1.1 2005/02/03 23:07:47 rich Exp
  *)
 
 val dump : 'a -> string

--- a/commons/file_type.ml
+++ b/commons/file_type.ml
@@ -6,13 +6,13 @@
  * modify it under the terms of the GNU Lesser General Public License
  * version 2.1 as published by the Free Software Foundation, with the
  * special exception on linking described in file license.txt.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
  *)
-open Common 
+open Common
 
 (*****************************************************************************)
 (* Prelude *)
@@ -23,7 +23,7 @@ open Common
 (*****************************************************************************)
 
 (* see also dircolors.el and LFS *)
-type file_type = 
+type file_type =
   | PL of pl_type
   | Obj  of string (* .o, .a, .aux, .bak, etc *)
   | Binary of string
@@ -33,14 +33,14 @@ type file_type =
   | Archive of string (* tgz, rpm, etc *)
   | Other of string
 
- and pl_type = 
+ and pl_type =
   | ML of string  (* mli, ml, mly, mll *)
   | Haskell of string
   | Lisp of lisp_type
   | Prolog of string
   | Makefile
   | Script of string (* sh, csh, awk, sed, etc *)
-  | C of string | Cplusplus of string | ObjectiveC of string 
+  | C of string | Cplusplus of string | ObjectiveC of string
   | Java | Csharp
   | Perl | Python | Ruby | Lua
   | Erlang | Go | Rust
@@ -55,7 +55,7 @@ type file_type =
 
    and lisp_type = CommonLisp | Elisp | Scheme
 
-   and webpl_type = 
+   and webpl_type =
      | Php of string (* php or phpt or script *)
      | Js | Coffee
      | Css
@@ -74,12 +74,12 @@ type file_type =
 (* this function is used by codemap and archi_parse and called for each
  * filenames, so it has to be fast!
  *)
-let file_type_of_file2 file = 
+let file_type_of_file2 file =
   let (d,b,e) = Common2.dbe_of_filename_noext_ok file in
   match e with
 
-  | "ml" | "mli" 
-  | "mly" | "mll"    
+  | "ml" | "mli"
+  | "mly" | "mll"
       -> PL (ML e)
   | "mlb" (* mlburg *)
   | "mlp" (* used in some source *)
@@ -104,14 +104,14 @@ let file_type_of_file2 file =
   | "bet" -> PL Beta
 
   (* todo detect false C file, look for "Mode: Objective-C++" string in file ?
-   * can also be a c++, use Parser_cplusplus.is_problably_cplusplus_file 
+   * can also be a c++, use Parser_cplusplus.is_problably_cplusplus_file
    *)
   | "c" -> PL (C e)
   | "h" -> PL (C e)
   (* todo? have a PL of xxx_kind * pl_kind ?  *)
   | "y" | "l" -> PL (C e)
 
-  | "hpp" -> PL (Cplusplus e) | "hxx" -> PL (Cplusplus e) 
+  | "hpp" -> PL (Cplusplus e) | "hxx" -> PL (Cplusplus e)
   | "hh" -> PL (Cplusplus e)
   | "cpp" -> PL (Cplusplus e) | "C" -> PL (Cplusplus e)
   | "cc" -> PL (Cplusplus e)  | "cxx" -> PL (Cplusplus e)
@@ -136,7 +136,7 @@ let file_type_of_file2 file =
   | "logic" -> PL (Prolog "logic") (* datalog of logicblox *)
   | "dtl" -> PL (Prolog "dtl") (* bddbddb *)
   | "dl" -> PL (Prolog "dl") (* datalog *)
-  | "perl" -> PL Perl 
+  | "perl" -> PL Perl
   | "py" -> PL Python
   | "rb" -> PL Ruby
 
@@ -208,21 +208,21 @@ let file_type_of_file2 file =
   | "nw" | "web" -> Text e
   | "ms" -> Text e
 
-  | "org" 
+  | "org"
   | "md" | "rest" | "textile" | "wiki" | "rst"
     -> Text e
 
   | "rtf" -> Text e
 
-  | "cmi" | "cmo" | "cmx" | "cma" | "cmxa" 
+  | "cmi" | "cmo" | "cmx" | "cma" | "cmxa"
   | "annot" | "cmt" | "cmti"
   | "o" | "a"
-  | "pyc" 
+  | "pyc"
   | "log"
-  | "toc" | "brf"  
+  | "toc" | "brf"
   | "out" | "output"
   | "hi"
-  | "msi" 
+  | "msi"
       -> Obj e
   (* pad: I use it to store marshalled data *)
   | "db" -> Obj e
@@ -231,9 +231,9 @@ let file_type_of_file2 file =
   | "apcarc"  | "serialized" | "wsdl" | "dat"  | "train" ->  Obj e
   | "facts" -> Obj e (* logicblox *)
   (* pad specific, cached git blame info *)
-  | "git_annot" -> Obj e 
+  | "git_annot" -> Obj e
   (* pad specific, codegraph cached data *)
-  | "marshall" | "matrix" -> Obj e 
+  | "marshall" | "matrix" -> Obj e
 
   | "byte" | "top" -> Binary e
 
@@ -274,7 +274,7 @@ let file_type_of_file2 file =
   | _ when Common2.filesize file > 300_000 -> Obj e
   | _ -> Other e
 
-let file_type_of_file a = 
+let file_type_of_file a =
   Common.profile_code "file_type_of_file" (fun () -> file_type_of_file2 a)
 
 
@@ -288,21 +288,21 @@ let is_textual_file file =
   (* if this contains weird code then pfff_visual crash *)
   | PL (Web Sql) -> false
 
-  | PL _ 
+  | PL _
   | Text _ -> true
   | _ -> false
 
-let webpl_type_of_file file = 
+let webpl_type_of_file file =
   match file_type_of_file file with
   | PL (Web x) -> Some x
   | _ -> None
 
 
 (*
-let detect_pl_of_file file = 
+let detect_pl_of_file file =
   raise Todo
 
-let string_of_pl x = 
+let string_of_pl x =
   raise Todo
   | C -> "c"
   | Cplusplus -> "c++"
@@ -311,10 +311,10 @@ let string_of_pl x =
   | Web _ -> raise Todo
 *)
 
-let is_syncweb_obj_file file = 
+let is_syncweb_obj_file file =
   file =~ ".*md5sum_"
 
-let is_json_filename filename = 
+let is_json_filename filename =
   filename =~ ".*\\.json$"
   (*
   match File_type.file_type_of_file filename with

--- a/commons/file_type.mli
+++ b/commons/file_type.mli
@@ -9,7 +9,7 @@ type file_type =
   | Archive of string
   | Other of string
 
- and pl_type = 
+ and pl_type =
   | ML of string | Haskell of string | Lisp of lisp_type
   | Prolog of string
   | Makefile
@@ -28,7 +28,7 @@ type file_type =
 
    and lisp_type = CommonLisp | Elisp | Scheme
 
-   and webpl_type = 
+   and webpl_type =
      | Php of string
      | Js | Coffee
      | Css
@@ -41,10 +41,10 @@ type file_type =
    | Video of string
 
 
-val file_type_of_file: 
+val file_type_of_file:
   Common.filename -> file_type
 
-val is_textual_file: 
+val is_textual_file:
   Common.filename -> bool
 val is_syncweb_obj_file:
   Common.filename -> bool
@@ -52,7 +52,7 @@ val is_json_filename:
   Common.filename -> bool
 
 (* specialisations *)
-val webpl_type_of_file: 
+val webpl_type_of_file:
   Common.filename -> webpl_type option
 
 (* val string_of_pl: pl_kind -> string *)

--- a/commons/map_.ml
+++ b/commons/map_.ml
@@ -22,7 +22,7 @@
         Empty
       | Node of 'a t * key * 'a * 'a t * int
 *)
-  type ('key, 'v) t = 
+  type ('key, 'v) t =
       Empty
     | Node of ('key, 'v) t * 'key * 'v * ('key, 'v) t * int
 

--- a/commons/oUnit.ml
+++ b/commons/oUnit.ml
@@ -36,7 +36,7 @@ let bracket set_up f tear_down () =
       f fixture;
       tear_down fixture
     with
-	e -> 
+	e ->
 	  tear_down fixture;
 	  raise e
 
@@ -49,7 +49,7 @@ exception Todo of string
 let todo msg =
   raise (Todo msg)
 
-let assert_failure msg = 
+let assert_failure msg =
   failwith ("OUnit: " ^ msg)
 
 let assert_bool ~msg b =
@@ -63,19 +63,19 @@ let assert_equal ?(cmp = ( = )) ?printer ?msg expected actual  =
   let p = Dumper.dump in
 
   let get_error_string _ =
-    match printer, msg with 
-	None, None -> 
-          (Format.sprintf "expected: %s but got: %s" 
-              (p expected) (p actual)) 
-      | None, Some s -> 
+    match printer, msg with
+	None, None ->
+          (Format.sprintf "expected: %s but got: %s"
+              (p expected) (p actual))
+      | None, Some s ->
           (Format.sprintf "%s\nnot equal, expected: %s but got: %s" s
             (p expected) (p actual))
-      | Some p, None -> (Format.sprintf "expected: %s but got: %s" 
+      | Some p, None -> (Format.sprintf "expected: %s but got: %s"
 			   (p expected) (p actual))
-      | Some p, Some s -> (Format.sprintf "%s\nexpected: %s but got: %s" 
+      | Some p, Some s -> (Format.sprintf "%s\nexpected: %s but got: %s"
 			     s (p expected) (p actual))
   in
-    if not (cmp expected actual) then 
+    if not (cmp expected actual) then
       assert_failure (get_error_string ())
 
 let raises f =
@@ -85,16 +85,16 @@ let raises f =
   with
       e -> Some e
 
-let assert_raises ?msg exn (f: unit -> 'a) = 
+let assert_raises ?msg exn (f: unit -> 'a) =
   let pexn = Printexc.to_string in
   let get_error_string _ =
-    let str = Format.sprintf 
+    let str = Format.sprintf
       "expected exception %s, but no exception was raised." (pexn exn)
     in
       match msg with
 	  None -> assert_failure str
 	| Some s -> assert_failure (Format.sprintf "%s\n%s" s str)
-  in    
+  in
     match raises f with
 	None -> assert_failure (get_error_string ())
       | Some e -> assert_equal ?msg ~printer:pexn exn e
@@ -102,16 +102,16 @@ let assert_raises ?msg exn (f: unit -> 'a) =
 (* Compare floats up to a given relative error *)
 let cmp_float ?(epsilon = 0.00001) a b =
   abs_float (a -. b) <= epsilon *. (abs_float a) ||
-    abs_float (a -. b) <= epsilon *. (abs_float b) 
-      
+    abs_float (a -. b) <= epsilon *. (abs_float b)
+
 (* Now some handy shorthands *)
 let (@?) msg a = assert_bool msg a
 
 (* The type of test function *)
-type test_fun = unit -> unit 
+type test_fun = unit -> unit
 
 (* The type of tests *)
-type test = 
+type test =
     TestCase of test_fun
   | TestList of test list
   | TestLabel of string * test
@@ -124,7 +124,7 @@ let (>:::) s l = TestLabel(s, TestList(l)) (* infix *)
 (* Utility function to manipulate test *)
 let rec test_decorate g tst =
   match tst with
-    | TestCase f -> 
+    | TestCase f ->
         TestCase (g f)
     | TestList tst_lst ->
         TestList (List.map (test_decorate g) tst_lst)
@@ -132,8 +132,8 @@ let rec test_decorate g tst =
         TestLabel (str, test_decorate g tst)
 
 (* Return the number of available tests *)
-let rec test_case_count test = 
-  match test with 
+let rec test_case_count test =
+  match test with
       TestCase _ -> 1
     | TestLabel (_, t) -> test_case_count t
     | TestList l -> List.fold_left (fun c t -> c + test_case_count t) 0 l
@@ -141,46 +141,46 @@ let rec test_case_count test =
 type node = ListItem of int | Label of string
 type path = node list
 
-let string_of_node node = 
+let string_of_node node =
   match node with
       ListItem n -> (string_of_int n)
     | Label s -> s
 
 let string_of_path path =
-  List.fold_left 
-    (fun a l -> 
-       if a = "" then 
+  List.fold_left
+    (fun a l ->
+       if a = "" then
 	 l
-       else 
+       else
 	 l ^ ":" ^ a) "" (List.map string_of_node path)
-    
+
 (* Some helper function, they are generally applicable *)
 (* Applies function f in turn to each element in list. Function f takes
    one element, and integer indicating its location in the list *)
-let mapi f l = 
-  let rec rmapi cnt l = 
-    match l with 
-	[] -> [] 
-      | h::t -> (f h cnt)::(rmapi (cnt + 1) t) 
+let mapi f l =
+  let rec rmapi cnt l =
+    match l with
+	[] -> []
+      | h::t -> (f h cnt)::(rmapi (cnt + 1) t)
   in
     rmapi 0 l
 
 let fold_lefti f accu l =
-  let rec rfold_lefti cnt accup l = 
-    match l with 
+  let rec rfold_lefti cnt accup l =
+    match l with
 	[] -> accup
       | h::t -> rfold_lefti (cnt + 1) (f accup h cnt) t
   in
     rfold_lefti 0 accu l
 
 (* Returns all possible paths in the test. The order is from test case
-   to root 
+   to root
 *)
-let test_case_paths test = 
-  let rec tcps path test = 
-    match test with 
-	TestCase _ -> [path] 
-      | TestList tests -> 
+let test_case_paths test =
+  let rec tcps path test =
+    match test with
+	TestCase _ -> [path]
+      | TestList tests ->
 	  List.concat (mapi (fun t i -> tcps ((ListItem i)::path) t) tests)
       | TestLabel (l, t) -> tcps ((Label l)::path) t
   in
@@ -191,12 +191,12 @@ module SetTestPath = Set.Make(String)
 
 let test_filter only test =
   let set_test =
-    List.fold_left 
+    List.fold_left
       (fun st str -> SetTestPath.add str st)
       SetTestPath.empty
       only
   in
-  let foldi f acc lst = 
+  let foldi f acc lst =
     List.fold_left
       (fun (i, acc) e ->
          let nacc =
@@ -219,7 +219,7 @@ let test_filter only test =
               None
           | TestList tst_lst ->
               let (_, ntst_lst) =
-                foldi 
+                foldi
                   (fun i ntst_lst tst ->
                      let nntst_lst =
                        match filter_test ((ListItem i) :: path) tst with
@@ -239,7 +239,7 @@ let test_filter only test =
                   Some (TestList ntst_lst)
           | TestLabel (lbl, tst) ->
               let ntst =
-                filter_test 
+                filter_test
                   ((Label lbl) :: path)
                   tst
               in
@@ -262,14 +262,14 @@ type test_result =
   | RTodo of path * string
 
 let is_success = function
-    RSuccess _  -> true 
-  | RFailure _ | RError _  | RSkip _ | RTodo _ -> false 
+    RSuccess _  -> true
+  | RFailure _ | RError _  | RSkip _ | RTodo _ -> false
 
 let is_failure = function
     RFailure _ -> true
   | RSuccess _ | RError _  | RSkip _ | RTodo _ -> false
 
-let is_error = function 
+let is_error = function
     RError _ -> true
   | RSuccess _ | RFailure _ | RSkip _ | RTodo _ -> false
 
@@ -289,61 +289,61 @@ let result_flavour = function
   | RTodo _ -> "Todo"
 
 let result_path = function
-    RSuccess path 
-  | RError (path, _) 
-  | RFailure (path, _) 
+    RSuccess path
+  | RError (path, _)
+  | RFailure (path, _)
   | RSkip (path, _)
   | RTodo (path, _) -> path
 
 let result_msg = function
     RSuccess _ -> "Success"
-  | RError (_, msg) 
-  | RFailure (_, msg) 
+  | RError (_, msg)
+  | RFailure (_, msg)
   | RSkip (_, msg)
   | RTodo (_, msg) -> msg
 
 (* Returns true if the result list contains successes only *)
-let rec was_successful results = 
-  match results with 
+let rec was_successful results =
+  match results with
       [] -> true
-    | RSuccess _::t 
+    | RSuccess _::t
     | RSkip _::t -> was_successful t
     | RFailure _::_
-    | RError _::_ 
+    | RError _::_
     | RTodo _::_ -> false
 
 (* Events which can happen during testing *)
 type test_event =
-    EStart of path 
+    EStart of path
   | EEnd of path
   | EResult of test_result
 
 (* Run all tests, report starts, errors, failures, and return the results *)
 let perform_test report test =
   let run_test_case f path =
-    try 
+    try
       f ();
       RSuccess path
     with
 	Failure s -> RFailure (path, s)
       | Skip s -> RSkip (path, s)
       | Todo s -> RTodo (path, s)
-      | s -> RError (path, (Printexc.to_string s ^ " " ^ 
+      | s -> RError (path, (Printexc.to_string s ^ " " ^
                                Printexc.get_backtrace ()))
   in
-  let rec run_test path results test = 
-    match test with 
-	TestCase(f) -> 
+  let rec run_test path results test =
+    match test with
+	TestCase(f) ->
 	  report (EStart path);
 	  let result = run_test_case f path in
 	    report (EResult result);
 	    report (EEnd path);
 	    result::results
       | TestList (tests) ->
-	  fold_lefti 
+	  fold_lefti
 	    (fun results t cnt -> run_test ((ListItem cnt)::path) results t)
 	    results tests
-      | TestLabel (label, t) -> 
+      | TestLabel (label, t) ->
 	  run_test ((Label label)::path) results t
   in
     run_test [] [] test
@@ -357,16 +357,16 @@ let time_fun f x y =
 (* A simple (currently too simple) text based test runner *)
 let run_test_tt ?(verbose=false) test =
   let printf = Format.printf in
-  let separator1 = 
+  let separator1 =
     "======================================================================" in
-  let separator2 = 
+  let separator2 =
     "----------------------------------------------------------------------" in
   let string_of_result = function
       RSuccess _ ->
 	if verbose then "ok\n" else "."
     | RFailure (_, _) ->
 	if verbose then "FAIL\n" else "F"
-    | RError (_, _) -> 
+    | RError (_, _) ->
 	if verbose then "ERROR\n" else "E"
     | RSkip (_, _) ->
 	if verbose then "SKIP\n" else "S"
@@ -374,61 +374,61 @@ let run_test_tt ?(verbose=false) test =
         if verbose then "TODO\n" else "T"
   in
   let report_event = function
-      EStart p -> 
+      EStart p ->
 	if verbose then printf "%s ... " (string_of_path p)
     | EEnd _ -> ()
-    | EResult result -> 
+    | EResult result ->
 	printf "%s@?" (string_of_result result);
   in
-  let print_result_list results = 
-      List.iter 
-	(fun result -> printf "%s\n%s: %s\n\n%s\n%s\n" 
-	   separator1 
-	   (result_flavour result) 
-	   (string_of_path (result_path result)) 
-	   (result_msg result) 
-	   separator2) 
+  let print_result_list results =
+      List.iter
+	(fun result -> printf "%s\n%s: %s\n\n%s\n%s\n"
+	   separator1
+	   (result_flavour result)
+	   (string_of_path (result_path result))
+	   (result_msg result)
+	   separator2)
 	results
   in
-    
+
   (* Now start the test *)
   let running_time, results = time_fun perform_test report_event test in
   let errors = List.filter is_error results in
   let failures = List.filter is_failure results in
   let skips = List.filter is_skip results in
   let todos = List.filter is_todo results in
-    
+
     if not verbose then printf "\n";
 
     (* Print test report *)
     print_result_list errors;
-    print_result_list failures;    
-    printf "Ran: %d tests in: %.2f seconds.\n" 
+    print_result_list failures;
+    printf "Ran: %d tests in: %.2f seconds.\n"
       (List.length results) running_time;
 
     (* Print final verdict *)
-    if was_successful results then 
+    if was_successful results then
       (
         if skips = [] then
           printf "OK"
-        else 
+        else
           printf "OK: Cases: %d Skip: %d\n"
             (test_case_count test) (List.length skips)
       )
     else
-      printf "FAILED: Cases: %d Tried: %d Errors: %d Failures: %d Skip:%d Todo:%d\n" 
-	(test_case_count test) (List.length results) 
+      printf "FAILED: Cases: %d Tried: %d Errors: %d Failures: %d Skip:%d Todo:%d\n"
+	(test_case_count test) (List.length results)
 	(List.length errors) (List.length failures)
         (List.length skips) (List.length todos);
 
     (* Return the results possibly for further processing *)
     results
-      
+
 (* Call this one from you test suites *)
-let run_test_tt_main suite = 
-  let verbose = ref false in 
+let run_test_tt_main suite =
+  let verbose = ref false in
   let only_test = ref [] in
-    
+
     Arg.parse
       (Arg.align
          [("-verbose", Arg.Set verbose, " Run the test in verbose mode.");
@@ -438,15 +438,15 @@ let run_test_tt_main suite =
       )
       (fun x -> raise (Arg.Bad ("Bad argument : " ^ x)))
       ("usage: " ^ Sys.argv.(0) ^ " [-verbose] [-only-test path]*");
-    
-    let nsuite = 
+
+    let nsuite =
       if !only_test = [] then
         (
           suite
-        ) 
+        )
       else
         (
-          match test_filter !only_test suite with 
+          match test_filter !only_test suite with
             | Some tst ->
                 tst
             | None ->

--- a/commons/oUnit.mli
+++ b/commons/oUnit.mli
@@ -1,7 +1,7 @@
 (***********************************************************************)
 (* The OUnit library                                                   *)
 (*                                                                     *)
-(* Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008              *) 
+(* Copyright (C) 2002, 2003, 2004, 2005, 2006, 2007, 2008              *)
 (* Maas-Maarten Zeeman.                                                *)
 
 (*
@@ -32,63 +32,63 @@ the use or other dealings in the software.
 
     To uses this library link with
       [ocamlc oUnit.cmo]
-    or 
+    or
       [ocamlopt oUnit.cmx]
- 
+
     @author Maas-Maarten Zeeman
 *)
 
-(** {5 Assertions} 
+(** {5 Assertions}
 
     Assertions are the basic building blocks of unittests. *)
 
 (** Signals a failure. This will raise an exception with the specified
-    string. 
+    string.
 
     @raise Failure to signal a failure *)
 val assert_failure : string -> 'a
 
-(** Signals a failure when bool is false. The string identifies the 
+(** Signals a failure when bool is false. The string identifies the
     failure.
-    
+
     @raise Failure to signal a failure *)
 val assert_bool : msg:string -> bool -> unit
 
-(** Shorthand for assert_bool 
+(** Shorthand for assert_bool
 
     @raise Failure to signal a failure *)
 val ( @? ) : string -> bool -> unit
 
 (** Signals a failure when the string is non-empty. The string identifies the
-    failure. 
-    
-    @raise Failure to signal a failure *) 
+    failure.
+
+    @raise Failure to signal a failure *)
 val assert_string : string -> unit
 
 
 (** Compares two values, when they are not equal a failure is signaled.
-    The cmp parameter can be used to pass a different compare function. 
-    This parameter defaults to ( = ). The optional printer can be used 
-    to convert the value to string, so a nice error message can be 
-    formatted. When msg is also set it can be used to identify the failure. 
+    The cmp parameter can be used to pass a different compare function.
+    This parameter defaults to ( = ). The optional printer can be used
+    to convert the value to string, so a nice error message can be
+    formatted. When msg is also set it can be used to identify the failure.
 
     @raise Failure description *)
-val assert_equal : ?cmp:('a -> 'a -> bool) ->  ?printer:('a -> string) -> 
+val assert_equal : ?cmp:('a -> 'a -> bool) ->  ?printer:('a -> string) ->
                    ?msg:string -> 'a -> 'a -> unit
 
-(** Asserts if the expected exception was raised. When msg is set it can 
+(** Asserts if the expected exception was raised. When msg is set it can
     be used to identify the failure
 
     @raise Failure description *)
 val assert_raises : ?msg:string -> exn -> (unit -> 'a) -> unit
 
-(** {5 Skipping tests } 
-  
+(** {5 Skipping tests }
+
    In certain condition test can be written but there is no point running it, because they
    are not significant (missing OS features for example). In this case this is not a failure
    nor a success. Following function allow you to escape test, just as assertion but without
    the same error status.
-  
+
    A test skipped is counted as success. A test todo is counted as failure.  *)
 
 (** [skip cond msg] If [cond] is true, skip the test for the reason explain in [msg].
@@ -139,9 +139,9 @@ val (>:::) : string -> test list -> test
 
    Examples:
 
-   - ["test1" >: TestCase((fun _ -> ()))] =>  
+   - ["test1" >: TestCase((fun _ -> ()))] =>
    [TestLabel("test2", TestCase((fun _ -> ())))]
-   - ["test2" >:: (fun _ -> ())] => 
+   - ["test2" >:: (fun _ -> ())] =>
    [TestLabel("test2", TestCase((fun _ -> ())))]
 
    - ["test-suite" >::: ["test2" >:: (fun _ -> ());]] =>
@@ -166,7 +166,7 @@ type path = node list (** The path to the test (in reverse order). *)
 (** Make a string from a node *)
 val string_of_node : node -> string
 
-(** Make a string from a path. The path will be reversed before it is 
+(** Make a string from a path. The path will be reversed before it is
     tranlated into a string *)
 val string_of_path : path -> string
 
@@ -183,9 +183,9 @@ type test_result =
   | RSkip of path * string
   | RTodo of path * string
 
-(** Events which occur during a test run *)   
+(** Events which occur during a test run *)
 type test_event =
-    EStart of path 
+    EStart of path
   | EEnd of path
   | EResult of test_result
 
@@ -196,7 +196,7 @@ val perform_test : (test_event -> 'a) -> test -> test_result list
     during the test. *)
 val run_test_tt : ?verbose:bool -> test -> test_result list
 
-(** Main version of the text based test runner. It reads the supplied command 
+(** Main version of the text based test runner. It reads the supplied command
     line arguments to set the verbose level and limit the number of test to run
   *)
 val run_test_tt_main : test -> test_result list

--- a/commons/ocaml.ml
+++ b/commons/ocaml.ml
@@ -1,11 +1,11 @@
-(* 
- * Yoann Padioleau 
+(*
+ * Yoann Padioleau
  *
  * Copyright (C) 2009-2012 Facebook
- * 
+ *
  * Most of the code in this file was inspired by code by Gazagnaire.
  * Here is the original copyright:
- * 
+ *
  * Copyright (c) 2009 Thomas Gazagnaire <thomas@gazagnaire.com>
  *
  * Permission to use, copy, modify, and distribute this software for any
@@ -25,9 +25,9 @@ open Common
 (*****************************************************************************)
 (* Purpose *)
 (*****************************************************************************)
-(* 
+(*
  * OCaml hacks to support reflection.
- * 
+ *
  * OCaml does not support reflection, and it's a good thing: we love
  * strong type-checking that forbids too clever hacks like 'eval', or
  * run-time reflection; it's too much power for you, you will misuse
@@ -39,39 +39,39 @@ open Common
  * source code files. It's a little bit a poor's man reflection mechanism,
  * because it's more manual, but it's for the best. Metaprogramming had
  * to be painful, because it is dangerous!
- * 
- * Example: 
- *  
+ *
+ * Example:
+ *
  *      TODO
- * 
+ *
  * In some sense we reimplement what is in the OCaml compiler, which
  * contains the full AST of OCaml source code. But the OCaml compiler
  * and its AST are too big, too scary for many tasks that would be satisfied
  * by a restricted but simpler AST.
- * 
+ *
  * Camlp4 is obviously also a solution to this problem, but it has a
  * learning curve, and it's a slightly different world than the pure
  * regular OCaml world. So this module, and ocamltarzan together can
  * reduce the problem by taking the best of camlp4, while still
  * avoiding it.
- * 
- * 
- * 
+ *
+ *
+ *
  * The support is partial. We support only the OCaml constructions
  * we found the most useful for programming stuff like
- * stub generators. 
- * 
+ * stub generators.
+ *
  * less? not all OCaml so call it miniml.ml  ? or reflection.ml ?
- * 
- * 
- * Notes: 2 worlds 
+ *
+ *
+ * Notes: 2 worlds
  *   - the type level world,
  *   - the data level world
- * 
+ *
  * Then there is whether the code is generated on the fly, or output somewhere
  * to be compiled and linked again (so 2 steps process, more manual, but
  * arguably less complicated magic)
- * 
+ *
  * different level of (meta)programming:
  *
  *  - programming in OCaml on OCaml values (classic)
@@ -79,24 +79,24 @@ open Common
  *  - programming in OCaml on Sexp.t value of type description
  *  - programming in OCaml on OCaml.v value of value
  *  - programming in OCaml on OCaml.t value of type description
- * 
+ *
  * Depending on what you have to do, some levels are more suited than other.
  * For instance to do a show, to pretty print value, then sexp is good,
- * because really you just want to write code that handle 2 cases, 
+ * because really you just want to write code that handle 2 cases,
  * atoms and list. That's really what pretty printing is all about. You
  * could write a pretty printer for Ocaml.v, but it will need to handle
  * 10 cases. Now if you want to write a code generator for python, or an ORM,
  * then Ocaml.v is better than sexp, because in sexp you lost some valuable
- * information (that you may have to reverse engineer, like whether 
+ * information (that you may have to reverse engineer, like whether
  * a Sexp.List corresponds to a field, or a sum, or wether something is
  * null or an empty list, or wether it's an int or float, etc).
- * 
+ *
  * Another way to do (meta)programming is:
  *  - programming in Camlp4 on OCaml ast
  *  - writing camlmix code to generate code.
- * 
+ *
  * notes:
- *  - sexp value or sexp of type description, not as precise, but easier to 
+ *  - sexp value or sexp of type description, not as precise, but easier to
  *    write really generic code that do not need to have more information
  *    about the sexp nodes (such as wether it's a field, a constuctor, etc)
  *  - miniml value or type, not as precise that the regular type,
@@ -104,35 +104,35 @@ open Common
  *  - ocaml value (not type as you cant program at type level),
  *    precise type checking, but can be tedious to write generic
  *    code like generic visitors or pickler/unpicklers
- * 
+ *
  * This file is working with ocamltarzan/pa/pa_type.ml (and so indirectly
  * it is working with camlp4).
- * 
+ *
  * Note that can even generate sexp_of_x for miniML :) really
  * reflexive tower here
- * 
- * Note that even if this module helps a programmer to avoid
- * using directly camlp4 to auto generate some code, it can 
- * not solve all the tasks. 
  *
- * history: 
+ * Note that even if this module helps a programmer to avoid
+ * using directly camlp4 to auto generate some code, it can
+ * not solve all the tasks.
+ *
+ * history:
  *  - Thought about it when wanting to do the ast_php.ml to be
  *    transformed into a .adsl declaration to be able to generate
  *    corresponding python classes using astgen.py.
  *  - Thought about a miniMLType and miniMLValue, and then realize
  *    that that was maybe what code in the ocaml-orm-sqlite
- *    was doing (type-of et value-of), except I wanted the 
+ *    was doing (type-of et value-of), except I wanted the
  *    ocamltarzan style of meta-programming instead of the camlp4 one.
- * 
- * 
+ *
+ *
  * Alternatives:
  *  - camlp4
- *    obviously camlp4 has access to the full AST of OCaml, but 
- *    that is one pb, that's too much. We often want only to do 
+ *    obviously camlp4 has access to the full AST of OCaml, but
+ *    that is one pb, that's too much. We often want only to do
  *    analysis on the type
  *  - type-conv
  *    good, but force to use camlp4. Can use the generic sexplib
- *    and then work on the generated sexp, but as explained below, 
+ *    and then work on the generated sexp, but as explained below,
  *    is will be on the value.
  *  - use lib-sexp (just the sexp library part, not the camlp4 support part)
  *    but not enough info. Even if usually
@@ -141,35 +141,35 @@ open Common
  *    is the sexp representation of the type! not a value of this type.
  *    Also lib-sexp autogenerated code can be hard to understand, especially
  *    if the type definition is complex. A good side effect of ocaml.ml
- *    is that it provides an intermediate step :) So even if you 
+ *    is that it provides an intermediate step :) So even if you
  *    could pretty print value from your def to sexp directly, you could
- *    also use transform your value into a Ocaml.v, then use 
+ *    also use transform your value into a Ocaml.v, then use
  *    the somehow more readable function that translate a v into a sexp,
  *    and same when wanting to read a value from a sexp, by using
  *    again Ocaml.v as an intermediate. It's nevertheless obviously
  *    less efficient.
- * 
+ *
  *  - zephyr, or thrift ?
  *  - F# ?
  *  - Lisp/Scheme ?
  *  - .Net interoperability
- * 
+ *
  *)
 
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
 
-(* src: 
+(* src:
  *  - orm-sqlite/value/value.ml
  *  (itself a fork of http://xenbits.xen.org/xapi/xen-api-libs.hg?file/7a17b2ab5cfc/rpc-light/rpc.ml)
  *  - orm-sqlite/type-of/type.ml
- * 
+ *
  * update: Gazagnaire made a paper about that.
- * 
- * modifications: 
- *  - slightly renamed the types and rearrange order of constructors.  Could 
- *    have use nested modules to allow to reuse Int in different contexts,  
+ *
+ * modifications:
+ *  - slightly renamed the types and rearrange order of constructors.  Could
+ *    have use nested modules to allow to reuse Int in different contexts,
  *    but I actually prefer to prefix the values with the V, so when debugging
  *    stuff, it's clearer that what you are looking are values, not types
  *    (even if the ocaml toplevel would prefix the value with a V. or T.,
@@ -181,7 +181,7 @@ open Common
 
 (* OCaml type definitions *)
 type t =
-  | Unit 
+  | Unit
   | Bool | Float | Char | String | Int
 
   | Tuple of t list
@@ -194,16 +194,16 @@ type t =
 
   | Apply of string * t
 
-  (* special cases of Apply *) 
+  (* special cases of Apply *)
   | Option of t
-  | List of t 
+  | List of t
 
-  (* todo? split in another type, because here it's the left part, 
+  (* todo? split in another type, because here it's the left part,
    * whereas before is the right part of a type definition. Also
    * have not the polymorphic args to some defs like ('a, 'b) Hashbtbl
-   * | Rec of string * t 
+   * | Rec of string * t
    * | Ext of string * t
-   * 
+   *
    * | Enum of t (* ??? *)
    *)
 
@@ -211,8 +211,8 @@ type t =
   (* with tarzan *)
 
 (* OCaml values (a restricted form of expressions) *)
-type v = 
-  | VUnit 
+type v =
+  | VUnit
   | VBool of bool | VFloat of float | VInt of int (* was int64 *)
   | VChar of char | VString of string
 
@@ -223,7 +223,7 @@ type v =
   | VVar of (string * int64)
   | VArrow of string
 
-  (* special cases *) 
+  (* special cases *)
   | VNone | VSome of v
   | VList of v list
   | VRef of v
@@ -242,27 +242,27 @@ type v =
 (*****************************************************************************)
 
 (* the generated code can use that if he wants *)
-let (_htype: (string, t) Hashtbl.t) = 
+let (_htype: (string, t) Hashtbl.t) =
   Hashtbl.create 101
 let (add_new_type: string -> t -> unit) = fun s t ->
   Hashtbl.add _htype s t
 let (get_type: string -> t) = fun s ->
   Hashtbl.find _htype s
- 
+
 
 
 (* for generated code that want to transform and in and out of a v or t *)
-let vof_unit () = 
+let vof_unit () =
   VUnit
-let vof_int x = 
+let vof_int x =
   VInt ((*Int64.of_int*) x)
-let vof_float x = 
+let vof_float x =
   VFloat ((*Int64.of_int*) x)
-let vof_string x = 
+let vof_string x =
   VString x
-let vof_bool b = 
+let vof_bool b =
   VBool b
-let vof_list ofa x = 
+let vof_list ofa x =
   VList (List.map ofa x)
 let vof_option ofa x =
   match x with
@@ -311,34 +311,34 @@ let option_ofv a__of_sexp sexp = match sexp with
 (*****************************************************************************)
 (* Format pretty printers *)
 (*****************************************************************************)
-let add_sep xs = 
+let add_sep xs =
   xs +> List.map (fun x -> Right x) +> Common2.join_gen (Left ())
 
-(* 
+(*
  * OCaml value pretty printer. A similar functionnality is provided by
- * the OCaml toplevel interpreter ('/usr/bin/ocaml') but 
- * sometimes it is useful to print values from a regular command 
- * line program. You don't always want to run the ocaml interpreter (or 
+ * the OCaml toplevel interpreter ('/usr/bin/ocaml') but
+ * sometimes it is useful to print values from a regular command
+ * line program. You don't always want to run the ocaml interpreter (or
  * customized interpreter built by ocamlmktop), and type an expression
  * in to get the printed value.
- * 
- * The v_of_xxx generated code by ocamltarzan is 
+ *
+ * The v_of_xxx generated code by ocamltarzan is
  * the first part to make this possible. The function below
  * is the second part.
- * 
+ *
  * The '@[', '@,', etc are Format printf tags. See the doc of the Format
- * module in the OCaml manual to understand their meaning. Mainly, 
- * @[ and @] open and close a pretty print box, and '@ ' and '@,' 
+ * module in the OCaml manual to understand their meaning. Mainly,
+ * @[ and @] open and close a pretty print box, and '@ ' and '@,'
  * are to give breaking hints to the pretty printer.
- * 
- * The output can be copy pasted in ML code directly, which can be 
+ *
+ * The output can be copy pasted in ML code directly, which can be
  * useful when you want to pattern match over complex ocaml value.
  *)
 
-let string_of_v v = 
+let string_of_v v =
   Common2.format_to_string (fun () ->
     let ppf = Format.printf in
-    let rec aux v = 
+    let rec aux v =
       match v with
       | VUnit -> ppf "()"
       | VBool v1 ->
@@ -365,7 +365,7 @@ let string_of_v v =
             ppf ";@ ";
           );
           ppf "@]}";
-          
+
       | VSum ((s, xs)) ->
           (match xs with
           | [] -> ppf "%s" s
@@ -377,7 +377,7 @@ let string_of_v v =
               );
               ppf "@])";
           )
-          
+
       | VVar (s, i64) -> ppf "%s_%d" s (Int64.to_int i64)
       | VArrow v1 -> failwith "Arrow TODO"
       | VNone -> ppf "None";
@@ -406,11 +406,11 @@ let map_of_char x = x
 let map_of_string (s:string) = s
 
 let map_of_ref aref x = x (* dont go into ref *)
-let map_of_option v_of_a v = 
+let map_of_option v_of_a v =
   match v with
   | None -> None
   | Some x -> Some (v_of_a x)
-let map_of_list of_a xs = 
+let map_of_list of_a xs =
   List.map of_a xs
 let map_of_int x = x
 let map_of_int64 x = x
@@ -431,9 +431,9 @@ let map_of_either3 _of_a _of_b _of_c =
 let rec (map_v: f:( k:(v -> v) -> v -> v) -> v -> v) =
   fun ~f x ->
 
- let rec map_v v = 
+ let rec map_v v =
   (* generated by ocamltarzan with: camlp4o -o /tmp/yyy.ml -I pa/ pa_type_conv.cmo pa_map.cmo  pr_o.cmo /tmp/xxx.ml  *)
-  let rec k x = 
+  let rec k x =
     match x with
     | VUnit -> VUnit
     | VBool v1 -> let v1 = map_of_bool v1 in VBool ((v1))
@@ -479,19 +479,19 @@ let v_bool x = ()
 let v_int x = ()
 let v_string (s:string) = ()
 let v_ref aref x = () (* dont go into ref *)
-let v_option v_of_a v = 
+let v_option v_of_a v =
   match v with
   | None -> ()
   | Some x -> v_of_a x
-let v_list of_a xs = 
+let v_list of_a xs =
   List.iter of_a xs
 
-let v_either of_a of_b x = 
+let v_either of_a of_b x =
   match x with
   | Left a -> of_a a
   | Right b -> of_b b
 
-let v_either3 of_a of_b of_c x = 
+let v_either3 of_a of_b of_c x =
   match x with
   | Left3 a -> of_a a
   | Middle3 b -> of_b b

--- a/commons/ocaml.mli
+++ b/commons/ocaml.mli
@@ -1,5 +1,5 @@
 
-(* 
+(*
  * OCaml hacks to support reflection (works with ocamltarzan).
  *
  * See also sexp.ml, json.ml, and xml.ml for other "reflective" techniques.
@@ -7,7 +7,7 @@
 
 (* OCaml core type definitions (no objects, no modules) *)
 type t =
-  | Unit 
+  | Unit
   | Bool | Float | Char | String | Int
 
   | Tuple of t list
@@ -20,9 +20,9 @@ type t =
 
   | Apply of string * t
 
-  (* special cases of Apply *) 
+  (* special cases of Apply *)
   | Option of t
-  | List of t 
+  | List of t
 
   | TTODO of string
 
@@ -30,8 +30,8 @@ val add_new_type: string -> t -> unit
 val get_type: string -> t
 
 (* OCaml values (a restricted form of expressions) *)
-type v = 
-  | VUnit 
+type v =
+  | VUnit
   | VBool of bool | VFloat of float | VInt of int
   | VChar of char | VString of string
 
@@ -42,7 +42,7 @@ type v =
   | VVar of (string * int64)
   | VArrow of string
 
-  (* special cases *) 
+  (* special cases *)
   | VNone | VSome of v
   | VList of v list
   | VRef of v
@@ -59,7 +59,7 @@ val vof_list   : ('a -> v) -> 'a list -> v
 val vof_option : ('a -> v) -> 'a option -> v
 val vof_ref    : ('a -> v) -> 'a ref -> v
 val vof_either    : ('a -> v) -> ('b -> v) -> ('a, 'b) Common.either -> v
-val vof_either3    : ('a -> v) -> ('b -> v) -> ('c -> v) -> 
+val vof_either3    : ('a -> v) -> ('b -> v) -> ('c -> v) ->
   ('a, 'b, 'c) Common.either3 -> v
 
 val int_ofv:    v -> int
@@ -93,9 +93,9 @@ val load_json: Common.filename -> Json_type.json_type
 *)
 
 (* mapper/visitor *)
-val map_v: 
-  f:( k:(v -> v) -> v -> v) -> 
-  v -> 
+val map_v:
+  f:( k:(v -> v) -> v -> v) ->
+  v ->
   v
 
 (* other building blocks, used by code generated using ocamltarzan *)
@@ -108,10 +108,10 @@ val map_of_string: string -> string
 val map_of_ref: 'a -> 'b -> 'b
 val map_of_option: ('a -> 'b) -> 'a option -> 'b option
 val map_of_list: ('a -> 'a) -> 'a list -> 'a list
-val map_of_either: 
+val map_of_either:
   ('a -> 'b) -> ('c -> 'd) -> ('a, 'c) Common.either -> ('b, 'd) Common.either
-val map_of_either3: 
-  ('a -> 'b) -> ('c -> 'd) -> ('e -> 'f) -> 
+val map_of_either3:
+  ('a -> 'b) -> ('c -> 'd) -> ('e -> 'f) ->
   ('a, 'c, 'e) Common.either3 -> ('b, 'd, 'f) Common.either3
 
 (* pure visitor building blocks, used by code generated using ocamltarzan *)
@@ -122,9 +122,9 @@ val v_string: string -> unit
 val v_option: ('a -> unit) -> 'a option -> unit
 val v_list: ('a -> unit) -> 'a list -> unit
 val v_ref: ('a -> unit) -> 'a ref -> unit
-val v_either: 
-  ('a -> unit) -> ('b -> unit) -> 
+val v_either:
+  ('a -> unit) -> ('b -> unit) ->
   ('a, 'b) Common.either -> unit
-val v_either3: 
+val v_either3:
   ('a -> unit) -> ('b -> unit) -> ('c -> unit) ->
   ('a, 'b, 'c) Common.either3 -> unit

--- a/commons/readme.txt
+++ b/commons/readme.txt
@@ -14,16 +14,16 @@ wants to, he can also leverage the other commons_xxx libraries by
 explicitely building them after he has installed the necessary
 external files.
 
-For many configurable things we can use some flags in ml files, 
+For many configurable things we can use some flags in ml files,
 and have some -xxx command line argument to set them or not,
 but for other things flags are not enough as they will not remove
 the header and linker dependencies in Makefiles. A solution is
 to use cpp and pre-process many files that have such configuration
 issue. Another solution is to centralize all the cpp issue in one
 file, features.ml.in, that acts as a generic wrapper for other
-librairies and depending on the configuration actually call 
+librairies and depending on the configuration actually call
 the external library or provide a fake empty services indicating
-that the service is not present. 
+that the service is not present.
 So you should have a ../configure that call cpp on features.ml.in
 to set those linking-related configuration settings.
 

--- a/commons/set_.mli
+++ b/commons/set_.mli
@@ -22,10 +22,10 @@
    are purely applicative (no side-effects).
    The implementation uses balanced binary trees, and is therefore
    reasonably efficient: insertion and membership take time
-   logarithmic in the size of the set, for instance. 
+   logarithmic in the size of the set, for instance.
 *)
 (* pad:
-module type OrderedType = 
+module type OrderedType =
   sig
     type t
       (** The type of the set elements. *)
@@ -107,7 +107,7 @@ module type S =
     val exists: ('elt -> bool) -> 'elt t -> bool
     (** [exists p s] checks if at least one element of
        the set satisfies the predicate [p]. *)
-        
+
     val filter: ('elt -> bool) -> 'elt t -> 'elt t
     (** [filter p s] returns the set of all elements in [s]
        that satisfy predicate [p]. *)

--- a/commons_ocollection/oarray.ml
+++ b/commons_ocollection/oarray.ml
@@ -2,28 +2,28 @@ open Common
 
 open Osequence
 
-(* growing array ? initialise with None, 
- * and generate exception when not defined or have an arraydefault 
+(* growing array ? initialise with None,
+ * and generate exception when not defined or have an arraydefault
  * update: can use dynArray ?
  *)
 
 (* !!take care!!, this is not a pure data structure *)
-class ['a] oarray n el = 
+class ['a] oarray n el =
 object(o: 'o)
   inherit ['a] osequence
 
   val data = Array.make n el
 
   method empty = raise Todo
-  method add (i,v)  = 
-    Array.set data i v; 
+  method add (i,v)  =
+    Array.set data i v;
     o
 
-  method iter f = 
+  method iter f =
     Array.iteri (Common2.curry f) data
   method view = raise Todo
 
-  method assoc i = 
+  method assoc i =
     Array.get data i
 
   method null = raise Todo
@@ -33,14 +33,14 @@ object(o: 'o)
   method first = raise Todo
   method delkey = raise Todo
 
-  method keys = raise Todo 
+  method keys = raise Todo
 
   method del = raise Todo
   method fromlist = raise Todo
-  method length = 
+  method length =
     Array.length data
 
-  (* method create: int -> 'a -> 'o = 
+  (* method create: int -> 'a -> 'o =
     raise Todo
   *)
   (* method put: make more explicit the fact that array do side effect *)

--- a/commons_ocollection/oassoc.ml
+++ b/commons_ocollection/oassoc.ml
@@ -3,54 +3,54 @@ open Common
 open Ocollection
 
 (* assoc, also called map or dictionnary *)
-class virtual ['a,'b] oassoc = 
+class virtual ['a,'b] oassoc =
 object(o: 'o)
   inherit ['a * 'b] ocollection
-  
+
   method virtual assoc: 'a -> 'b
   method virtual delkey: 'a -> 'o
- 
+
   (* pre: must be in *)
-  method replkey: ('a * 'b) -> 'o = 
-    fun (k,v) -> o#add (k,v) 
+  method replkey: ('a * 'b) -> 'o =
+    fun (k,v) -> o#add (k,v)
 
   (* pre: must not be in *)
   (* method add: ('a * 'b) -> 'o = *)
 
   (*
-    method keys = 
+    method keys =
     List.map fst (o#tolist)
   *)
   method virtual keys: 'a list (* or 'a oset ? *)
 
-  method find: 'a -> 'b = fun k -> 
+  method find: 'a -> 'b = fun k ->
     o#assoc k
 
-  method find_opt: 'a -> 'b option = fun k -> 
-    try 
+  method find_opt: 'a -> 'b option = fun k ->
+    try
       let res = o#assoc k in
       Some res
     with Not_found -> None
 
-  method haskey: 'a -> bool = fun k -> 
-    try (ignore(o#assoc k); true) 
+  method haskey: 'a -> bool = fun k ->
+    try (ignore(o#assoc k); true)
     with Not_found -> false
- 
-  method apply: 'a -> ('b -> 'b) -> 'o = fun k f -> 
-    let old = o#assoc k in 
+
+  method apply: 'a -> ('b -> 'b) -> 'o = fun k f ->
+    let old = o#assoc k in
     o#replkey (k, f old)
 
   (* apply default, assoc_default, take in class parameters a default value *)
-  method apply_with_default: 'a -> ('b -> 'b) -> (unit -> 'b) -> 'o = 
-    fun k f default -> 
-      let old = 
+  method apply_with_default: 'a -> ('b -> 'b) -> (unit -> 'b) -> 'o =
+    fun k f default ->
+      let old =
         try o#assoc k
         with Not_found -> default ()
       in
       o#replkey (k, f old)
 
-  method apply_with_default2 = fun k f default -> 
+  method apply_with_default2 = fun k f default ->
     o#apply_with_default k f default +> ignore
-    
+
 
 end

--- a/commons_ocollection/oassoc_buffer.ml
+++ b/commons_ocollection/oassoc_buffer.ml
@@ -6,45 +6,45 @@ open Oassocb
 open Osetb
 
 (* Take care that must often redefine all function in the original
- * oassoc.ml because if some methods are not redefined, for instance 
+ * oassoc.ml because if some methods are not redefined, for instance
  * #clear, then if do wrapper over a oassocdbm, then even if oassocdbm
  * redefine #clear, it will not be called, but instead the default
  * method will be called that internally will call another method.
  * So better delegate all the methods and override even the method
  * with a default definition.
- * 
+ *
  * In the same way sometimes an exn can occur at weird time. When
  * we add an element, sometimes this may raise an exn such as Out_of_memory,
  * but as we dont add directly but only at flush time, the exn
  * may happen far later the user added something in this oassoc.
- * Also in the case of Out_of_memory, even if the entry is not 
+ * Also in the case of Out_of_memory, even if the entry is not
  * added in the wrapped, it will still be present in the cache
  * and so the next flush will still generate an exn that again
  * may not be cached. So for the moment if Out_of_memory then
  * do something special and erase the entry in the cache.
- * 
+ *
  * Cf also oassoc_cache.ml which can be even more efficient.
  *)
 
 (* !!take care!!: this class has side effect, not a pure oassoc *)
 (* can not make it pure, cos the assoc have side effect on the cache *)
-class ['a,'b] oassoc_buffer   max cached = 
+class ['a,'b] oassoc_buffer   max cached =
 object(o)
   inherit ['a,'b] oassoc
 
   val counter = ref 0
-  val cache = ref (new oassocb []) 
+  val cache = ref (new oassocb [])
   val dirty = ref (new osetb Set_.empty)
   val wrapped = ref cached
 
-  method private myflush = 
+  method private myflush =
 
-    let has_a_raised = ref false in 
+    let has_a_raised = ref false in
 
-    !dirty#iter (fun k -> 
-      try 
+    !dirty#iter (fun k ->
+      try
         wrapped := !wrapped#add (k, !cache#assoc k)
-      with Out_of_memory -> 
+      with Out_of_memory ->
         pr2 "PBBBBBB: Out_of_memory in oassoc_buffer, but still empty cache";
         has_a_raised := true;
     );
@@ -53,59 +53,59 @@ object(o)
     counter := 0;
     if !has_a_raised then raise Out_of_memory
 
-      
+
   method misc_op_hook2 = o#myflush
-        
-  method empty = 
+
+  method empty =
     raise Todo
-      
+
   (* what happens in k is already present ? or if add multiple times
    * the same k ? cache is a oassocb and so the previous binding is
-   * still there, but dirty is a set, and in myflush we iter based 
+   * still there, but dirty is a set, and in myflush we iter based
    * on dirty so we will flush only the last 'k' in the cache.
    *)
-  method add (k,v) = 
+  method add (k,v) =
     cache := !cache#add (k,v);
     dirty := !dirty#add k;
     incr counter;
     if !counter > max then o#myflush;
     o
 
-  method iter f = 
+  method iter f =
     o#myflush; (* bugfix: have to flush !!! *)
     !wrapped#iter f
 
 
-  method keys = 
+  method keys =
     o#myflush; (* bugfix: have to flush !!! *)
     !wrapped#keys
 
-  method clear = 
+  method clear =
     o#myflush; (* bugfix: have to flush !!! *)
     !wrapped#clear
 
 
-  method length = 
+  method length =
     o#myflush;
     !wrapped#length
 
-  method view = 
+  method view =
     raise Todo
 
-  method del (k,v) = 
-    cache := !cache#del (k,v); 
+  method del (k,v) =
+    cache := !cache#del (k,v);
     (* TODO as for delkey, do a try over wrapped *)
-    wrapped := !wrapped#del (k,v); 
+    wrapped := !wrapped#del (k,v);
     dirty := !dirty#del k;
     o
   method mem e = raise Todo
   method null = raise Todo
 
-  method assoc k = 
-    try !cache#assoc k 
-    with Not_found -> 
+  method assoc k =
+    try !cache#assoc k
+    with Not_found ->
       (* may launch Not_found, but this time, dont catch it *)
-      let v = !wrapped#assoc k in 
+      let v = !wrapped#assoc k in
       begin
         cache := !cache#add (k,v);
         (* otherwise can use too much mem *)
@@ -113,22 +113,22 @@ object(o)
         if !counter > max then o#myflush;
         v
       end
-          
-  method delkey k = 
-    cache := !cache#delkey k; 
+
+  method delkey k =
+    cache := !cache#delkey k;
     (* sometimes have not yet flushed, so may not be yet in, (could
      * also flush in place of doing try).
-     * 
+     *
      * TODO would be better to see if was in cache (in case mean that
      * perhaps not flushed and do try and in other case just cos del
      * (without try) cos forcement flushed ou was an error *)
-    begin 
-      try wrapped := !wrapped#delkey k 
+    begin
+      try wrapped := !wrapped#delkey k
       with Not_found -> ()
     end;
     dirty := !dirty#del k;
     o
 
-end     
+end
 
 

--- a/commons_ocollection/oassoc_buffer.mli
+++ b/commons_ocollection/oassoc_buffer.mli
@@ -2,7 +2,7 @@
 class ['a, 'b] oassoc_buffer :
   int ->
   (< add : 'a * 'b -> 'd; assoc : 'a -> 'b; del : 'a * 'b -> 'd;
-   delkey : 'a -> 'd; iter : ('a * 'b -> unit) -> unit; length : int; 
+   delkey : 'a -> 'd; iter : ('a * 'b -> unit) -> unit; length : int;
    keys: 'a list; clear: unit;
    .. >
      as 'd) ->

--- a/commons_ocollection/oassoc_cache.ml
+++ b/commons_ocollection/oassoc_cache.ml
@@ -8,27 +8,27 @@ open Osetb
 (* todo: gather stat of use per key, so when flush, try keep
  * entries that are used above a certain threshold, and if after
  * this step, there is still too much, then erase also those keys.
- * 
- * todo: limit number of entries, and erase all (then better do a ltu) 
- * 
- * todo: another cache that behave as in lfs1, 
- * every 100 operation do a flush 
- * 
- * todo: choose between oassocb and oassoch ? 
- * 
+ *
+ * todo: limit number of entries, and erase all (then better do a ltu)
+ *
+ * todo: another cache that behave as in lfs1,
+ * every 100 operation do a flush
+ *
+ * todo: choose between oassocb and oassoch ?
+ *
  * Also take care that must often redefine all function in the original
- * oassoc.ml because if some methods are not redefined, for instance 
+ * oassoc.ml because if some methods are not redefined, for instance
  * #clear, then if do wrapper over a oassocdbm, then even if oassocdbm
  * redefine #clear, it will not be called, but instead the default
  * method will be called that internally will call another method.
  * So better delegate all the methods and override even the method
  * with a default definition.
- * 
+ *
  * In the same way sometimes an exn can occur at weird time. When
  * we add an element, sometimes this may raise an exn such as Out_of_memory,
  * but as we dont add directly but only at flush time, the exn
  * may happen far later the user added something in this oassoc.
- * Also in the case of Out_of_memory, even if the entry is not 
+ * Also in the case of Out_of_memory, even if the entry is not
  * added in the wrapped, it will still be present in the cache
  * and so the next flush will still generate an exn that again
  * may not be cached. So for the moment if Out_of_memory then
@@ -37,23 +37,23 @@ open Osetb
 
 (* !!take care!!: this class has side effect, not a pure oassoc *)
 (* can not make it pure, cos the assoc have side effect on the cache *)
-class ['a,'b] oassoc_buffer   max cached = 
+class ['a,'b] oassoc_buffer   max cached =
 object(o)
   inherit ['a,'b] oassoc
 
   val counter = ref 0
-  val cache = ref (new oassocb []) 
+  val cache = ref (new oassocb [])
   val dirty = ref (new osetb Set_poly.empty)
   val wrapped = ref cached
 
-  method private myflush = 
+  method private myflush =
 
-    let has_a_raised = ref false in 
+    let has_a_raised = ref false in
 
-    !dirty#iter (fun k -> 
-      try 
+    !dirty#iter (fun k ->
+      try
         wrapped := !wrapped#add (k, !cache#assoc k)
-      with Out_of_memory -> 
+      with Out_of_memory ->
         pr2 "PBBBBBB: Out_of_memory in oassoc_buffer, but still empty cache";
         has_a_raised := true;
     );
@@ -62,59 +62,59 @@ object(o)
     counter := 0;
     if !has_a_raised then raise Out_of_memory
 
-      
+
   method misc_op_hook2 = o#myflush
-        
-  method empty = 
+
+  method empty =
     raise Todo
-      
+
   (* what happens in k is already present ? or if add multiple times
    * the same k ? cache is a oassocb and so the previous binding is
-   * still there, but dirty is a set, and in myflush we iter based 
+   * still there, but dirty is a set, and in myflush we iter based
    * on dirty so we will flush only the last 'k' in the cache.
    *)
-  method add (k,v) = 
+  method add (k,v) =
     cache := !cache#add (k,v);
     dirty := !dirty#add k;
     incr counter;
     if !counter > max then o#myflush;
     o
 
-  method iter f = 
+  method iter f =
     o#myflush; (* bugfix: have to flush !!! *)
     !wrapped#iter f
 
 
-  method keys = 
+  method keys =
     o#myflush; (* bugfix: have to flush !!! *)
     !wrapped#keys
 
-  method clear = 
+  method clear =
     o#myflush; (* bugfix: have to flush !!! *)
     !wrapped#clear
 
 
-  method length = 
+  method length =
     o#myflush;
     !wrapped#length
 
-  method view = 
+  method view =
     raise Todo
 
-  method del (k,v) = 
-    cache := !cache#del (k,v); 
+  method del (k,v) =
+    cache := !cache#del (k,v);
     (* TODO as for delkey, do a try over wrapped *)
-    wrapped := !wrapped#del (k,v); 
+    wrapped := !wrapped#del (k,v);
     dirty := !dirty#del k;
     o
   method mem e = raise Todo
   method null = raise Todo
 
-  method assoc k = 
-    try !cache#assoc k 
-    with Not_found -> 
+  method assoc k =
+    try !cache#assoc k
+    with Not_found ->
       (* may launch Not_found, but this time, dont catch it *)
-      let v = !wrapped#assoc k in 
+      let v = !wrapped#assoc k in
       begin
         cache := !cache#add (k,v);
         (* otherwise can use too much mem *)
@@ -122,50 +122,50 @@ object(o)
         if !counter > max then o#myflush;
         v
       end
-          
-  method delkey k = 
-    cache := !cache#delkey k; 
+
+  method delkey k =
+    cache := !cache#delkey k;
     (* sometimes have not yet flushed, so may not be yet in, (could
      * also flush in place of doing try).
-     * 
+     *
      * TODO would be better to see if was in cache (in case mean that
      * perhaps not flushed and do try and in other case just cos del
      * (without try) cos forcement flushed ou was an error *)
-    begin 
-      try wrapped := !wrapped#delkey k 
+    begin
+      try wrapped := !wrapped#delkey k
       with Not_found -> ()
     end;
     dirty := !dirty#del k;
     o
 
-end     
+end
 
 
 (*
-class ['a,'b] oassoc_cache cache cached max =  
-  object(o) 
-    inherit ['a,'b] oassoc 
- 
-    val full = ref 0 
-    val max = max 
-    val cache = cache 
-    val cached = cached 
-    val lru = TODO 
-       
-    val data = Hashtbl.create 100 
- 
-    method empty = raise Todo 
-    method add (k,v) = (Hashtbl.add data k v; o) 
-    method iter f = cached#iter f 
-    method view = raise Todo 
- 
-    method del (k,v) = (cache#del (k,v); cached#del (k,v); o) 
-    method mem e = raise Todo 
-    method null = raise Todo 
- 
-    method assoc k = Hashtbl.find data k 
-    method delkey k = (cache#delkey (k,v); cached#del (k,v); o) 
-end    
+class ['a,'b] oassoc_cache cache cached max =
+  object(o)
+    inherit ['a,'b] oassoc
+
+    val full = ref 0
+    val max = max
+    val cache = cache
+    val cached = cached
+    val lru = TODO
+
+    val data = Hashtbl.create 100
+
+    method empty = raise Todo
+    method add (k,v) = (Hashtbl.add data k v; o)
+    method iter f = cached#iter f
+    method view = raise Todo
+
+    method del (k,v) = (cache#del (k,v); cached#del (k,v); o)
+    method mem e = raise Todo
+    method null = raise Todo
+
+    method assoc k = Hashtbl.find data k
+    method delkey k = (cache#delkey (k,v); cached#del (k,v); o)
+end
 *)
 
 

--- a/commons_ocollection/oassoc_cache.mli
+++ b/commons_ocollection/oassoc_cache.mli
@@ -2,7 +2,7 @@
 class ['a, 'b] oassoc_buffer :
   int ->
   (< add : 'a * 'b -> 'd; assoc : 'a -> 'b; del : 'a * 'b -> 'd;
-   delkey : 'a -> 'd; iter : ('a * 'b -> unit) -> unit; length : int; 
+   delkey : 'a -> 'd; iter : ('a * 'b -> unit) -> unit; length : int;
    keys: 'a list; clear: unit;
    .. >
      as 'd) ->

--- a/commons_ocollection/oassocb.ml
+++ b/commons_ocollection/oassocb.ml
@@ -2,7 +2,7 @@ open Common
 
 open Oassoc
 
-class ['a,'b] oassocb xs = 
+class ['a,'b] oassocb xs =
   object(o)
     inherit ['a,'b] oassoc
 
@@ -21,7 +21,7 @@ class ['a,'b] oassocb xs =
     method assoc k = Map_.find k data
     method delkey k = {< data = Map_.remove k data >}
 
-    method keys = 
+    method keys =
       List.map fst (o#tolist)
-end     
+end
 

--- a/commons_ocollection/oassoch.ml
+++ b/commons_ocollection/oassoch.ml
@@ -3,7 +3,7 @@ open Common
 open Oassoc
 
 (* !!take care!!: this class does side effect, not a pure oassoc *)
-class ['a,'b] oassoch xs = 
+class ['a,'b] oassoch xs =
   let h = Common.hash_of_list xs in
   object(o)
     inherit ['a,'b] oassoc
@@ -24,15 +24,15 @@ class ['a,'b] oassoch xs =
     method mem e = raise Todo
     method null = (try (Hashtbl.iter (fun k v -> raise Common2.ReturnExn) data; false) with Common2.ReturnExn -> true)
 
-    method assoc k = 
-      try 
+    method assoc k =
+      try
         Hashtbl.find data k
-      with Not_found -> (Common2.log3 ("pb assoc with k = " ^ (Dumper.dump k)); raise Not_found) 
-        
+      with Not_found -> (Common2.log3 ("pb assoc with k = " ^ (Dumper.dump k)); raise Not_found)
+
     method delkey k = (Hashtbl.remove data k; o)
 
-    method keys = 
+    method keys =
       List.map fst (o#tolist)
 
-end     
+end
 

--- a/commons_ocollection/oassocid.ml
+++ b/commons_ocollection/oassocid.ml
@@ -2,7 +2,7 @@ open Common
 open Oassoc
 
 (* just a class that behave as fun x -> x *)
-class ['a] oassoc_id xs = 
+class ['a] oassoc_id xs =
   object(o)
     inherit ['a,'a] oassoc
 
@@ -18,7 +18,7 @@ class ['a] oassoc_id xs =
     method assoc k = k
     method delkey k = {<  >}
 
-    method keys = 
+    method keys =
       List.map fst (o#tolist)
 
-end     
+end

--- a/commons_ocollection/objet.ml
+++ b/commons_ocollection/objet.ml
@@ -1,29 +1,29 @@
 open Common
 
 (* Type classes via objects. See also now interfaces.ml
- * 
+ *
  * todo? get more inspiration from Java to put fundamental interfaces
  * here ? such as cloneable, equaable, showable, debugable, etc
  *)
 
 class virtual objet =
 object(o:'o)
-  method invariant: unit -> unit = fun () -> 
+  method invariant: unit -> unit = fun () ->
     raise Todo
-  (* method check: unit -> unit = fun () -> 
+  (* method check: unit -> unit = fun () ->
     assert(o#invariant());
   *)
 
-  method of_string: string -> unit = 
+  method of_string: string -> unit =
     raise Todo
-  method to_string: unit -> string = 
+  method to_string: unit -> string =
     raise Todo
-  method debug: unit -> unit = 
-    raise Todo
-
-  method misc_op_hook: unit -> 'o = 
+  method debug: unit -> unit =
     raise Todo
 
-  method misc_op_hook2: unit = 
+  method misc_op_hook: unit -> 'o =
+    raise Todo
+
+  method misc_op_hook2: unit =
     ()
 end

--- a/commons_ocollection/ocollection.ml
+++ b/commons_ocollection/ocollection.ml
@@ -7,7 +7,7 @@ open Common
 (*---------------------------------------------------------------------------*)
 type ('a, 'b) view = Empty | Cons of 'a * 'b
 
-class virtual ['a] ocollection = 
+class virtual ['a] ocollection =
 object(o: 'o)
   inherit Objet.objet
 
@@ -23,36 +23,36 @@ object(o: 'o)
   method virtual null: bool      (* can do default with: lenght(tolist)= 0 *)
 
 
-  method add2: 'a -> unit = fun a -> 
+  method add2: 'a -> unit = fun a ->
     o#add a +> ignore;
     ()
-  method del2: 'a -> unit = fun a -> 
+  method del2: 'a -> unit = fun a ->
     o#del a +> ignore;
     ()
-  method clear: unit = 
+  method clear: unit =
     o#iter (fun e -> o#del2 e);
-    
 
 
 
-  method fold: 'b. ('b -> 'a -> 'b) -> 'b -> 'b = fun f a -> 
-    let a = ref a in 
+
+  method fold: 'b. ('b -> 'a -> 'b) -> 'b -> 'b = fun f a ->
+    let a = ref a in
     o#iter (fun e -> a := f !a e);
     !a
 
-  method tolist: 'a list = 
+  method tolist: 'a list =
     List.rev (o#fold (fun acc e -> e::acc) [])
-  method fromlist: 'a list -> 'o = 
+  method fromlist: 'a list -> 'o =
     fun xs -> xs +> List.fold_left (fun o e -> o#add e) o#empty
 
-  method length: int = 
+  method length: int =
     (* oldsimple: o#tolist +> List.length *)
     (* opti: *)
     let count = ref 0 in
     o#iter (fun e -> incr count);
     !count
 
-  method exists: ('a -> bool) -> bool = fun f -> 
+  method exists: ('a -> bool) -> bool = fun f ->
     o#tolist +> List.exists f
 
   method filter: ('a -> bool) -> 'o = fun f ->
@@ -61,9 +61,9 @@ object(o: 'o)
 
   (* forall, fold, map *)
 
-  method getone: 'a = 
+  method getone: 'a =
     match o#view with Cons (e,tl) -> e  | Empty -> failwith "no head"
-  method others: 'o = 
+  method others: 'o =
     match o#view with Cons (e,tl) -> tl | Empty -> failwith "no tail"
 
 end

--- a/commons_ocollection/ocollection.mli
+++ b/commons_ocollection/ocollection.mli
@@ -1,6 +1,6 @@
 (*s: ocollection.mli *)
-type ('a, 'b) view = 
-  | Empty 
+type ('a, 'b) view =
+  | Empty
   | Cons of 'a * 'b
 
 class virtual ['a] ocollection :

--- a/commons_ocollection/ofullcommon.ml
+++ b/commons_ocollection/ofullcommon.ml
@@ -1,11 +1,11 @@
 (* Do a 'open Fullcommon' to access most of the functions in commons/
  * without needing to qualify them.
- * 
+ *
  * update: Jane Street use a similar trick, to have a more complete
  * Pervasives, but for far more. They can define a module Std that
  * correspond to old std lib and a module Std_internal that instead
  * include all their extensions over the standard lib (a more complete
- * List module, Arg, etc) 
+ * List module, Arg, etc)
 *)
 include Common2
 

--- a/commons_ocollection/ograph.ml
+++ b/commons_ocollection/ograph.ml
@@ -1,6 +1,6 @@
 open Common
 
-(* todo: 
+(* todo:
  *  invariant succesors/predecessors
  *)
 
@@ -23,6 +23,6 @@ object(o: 'o)
   method virtual children: 'a Oset.oset -> 'a Oset.oset
   method virtual brothers: 'a -> 'a Oset.oset
 
-  method mydebug: ('a * 'a list) list = 
+  method mydebug: ('a * 'a list) list =
     (o#nodes)#tolist +> List.map (fun a -> (a, (o#successors a)#tolist))
 end

--- a/commons_ocollection/ograph2way.ml
+++ b/commons_ocollection/ograph2way.ml
@@ -7,20 +7,20 @@ open Ograph
 open Osetb
 
 (* graph2way  prend en parametre le type de finitemap et set a prendre
- * todo? add_arc doit ramer, car del la key, puis add => 
- * better to have a ref to a set 
- * todo: efficient graph: with pointers and a tag: visited 
+ * todo? add_arc doit ramer, car del la key, puis add =>
+ * better to have a ref to a set
+ * todo: efficient graph: with pointers and a tag: visited
  * => need keep global value visited_counter
  * check(that node is in, ...), display
- * 
- * pourrait remettre val nods, a la place de les calculer. mais bon 
+ *
+ * pourrait remettre val nods, a la place de les calculer. mais bon
  * s'en sert pas vraiment car y'a pas de notion d'identifiant de noeud
  * et de label.
- * 
+ *
  * invariant: key in pred is also in succ (completness) and value in
  * either table is a key also
  *)
-class ['a] ograph2way   asucc apred (*f1*) f2 = 
+class ['a] ograph2way   asucc apred (*f1*) f2 =
 object(o)
   inherit ['a] ograph
 
@@ -41,11 +41,11 @@ object(o)
     pred = pred#delkey e;
     succ = succ#delkey e;
   >}
-  method add_arc (a,b) = {< 
+  method add_arc (a,b) = {<
     succ = succ#replkey (a, (succ#find a)#add b);
     pred = pred#replkey (b, (pred#find b)#add a);
   >}
-  method del_arc (a,b) = {< 
+  method del_arc (a,b) = {<
     succ = succ#replkey (a, (succ#find a)#del b);
     pred = pred#replkey (b, (pred#find b)#del a);
   >}
@@ -58,29 +58,29 @@ object(o)
     succ#iter (fun (k,v) -> a := !a#add k);
     !a
 
-        
 
-  method ancestors xs = 
-    let rec aux xs acc = 
+
+  method ancestors xs =
+    let rec aux xs acc =
       match xs#view with (* could be done with an iter *)
       | Empty -> acc
-      | Cons(x, xs) -> (acc#add x) 
+      | Cons(x, xs) -> (acc#add x)
           +> (fun newacc -> aux (o#predecessors x) newacc)
           +> (fun newacc -> aux xs newacc)
     in aux xs (f2()) (* (new osetb []) *)
 
-  method children  xs = 
-    let rec aux xs acc = 
+  method children  xs =
+    let rec aux xs acc =
       match xs#view with (* could be done with an iter *)
       | Empty -> acc
-      | Cons(x, xs) -> (acc#add x) 
+      | Cons(x, xs) -> (acc#add x)
           +> (fun newacc -> aux (o#successors x) newacc)
           +> (fun newacc -> aux xs newacc)
     in aux xs (f2()) (* (new osetb []) *)
 
 
-  method brothers  x = 
+  method brothers  x =
     let parents = o#predecessors x in
     (parents#fold (fun acc e -> acc $++$ o#successors e) (f2()))#del x
-      
-end   
+
+end

--- a/commons_ocollection/ograph_extended.ml
+++ b/commons_ocollection/ograph_extended.ml
@@ -11,17 +11,17 @@ open Osetb
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* 
+(*
  * An imperative directed polymorphic graph.
- * 
+ *
  * todo?: prendre en parametre le type de finitemap et set?
- * todo?: add_arc doit ramer, car del la key, puis add. Better to 
+ * todo?: add_arc doit ramer, car del la key, puis add. Better to
  *  have a ref to a set?
- * 
- * opti: graph with pointers and a tag visited => need keep global value 
+ *
+ * opti: graph with pointers and a tag visited => need keep global value
  *  visited_counter.  check(that node is in, ...), display.
- * opti: when the graph structure is stable, have a method compact,  that 
- *  transforms that in a matrix (assert that all number between 0 and 
+ * opti: when the graph structure is stable, have a method compact,  that
+ *  transforms that in a matrix (assert that all number between 0 and
  *  free_index are used,  or do some defrag-like-move/renaming).
  *)
 
@@ -40,57 +40,57 @@ class ['a,'b] ograph_extended =
 
   object(o)
     (* inherit ['a] ograph *)
-      
+
     val free_index = 0
 
     val succ = build_assoc()
     val pred = build_assoc()
     val nods = build_assoc()
 
-    method add_node (e: 'a) = 
+    method add_node (e: 'a) =
       let i = free_index in
-      ({< 
-        nods = nods#add (i, e); 
+      ({<
+        nods = nods#add (i, e);
         pred = pred#add (i, build_set() );
         succ = succ#add (i, build_set() );
         free_index = i + 1;
        >}, i)
 
-    method add_nodei i (e: 'a) = 
-      ({< 
-        nods = nods#add (i, e); 
+    method add_nodei i (e: 'a) =
+      ({<
+        nods = nods#add (i, e);
         pred = pred#add (i, build_set() );
         succ = succ#add (i, build_set() );
         free_index = (max free_index i) + 1;
        >}, i)
 
 
-    method del_node (i) = 
+    method del_node (i) =
       {<
-        (* check: e is effectively the index associated with e, 
+        (* check: e is effectively the index associated with e,
            and check that already in *)
 
         (* todo: assert that have no pred and succ, otherwise
-         * will have some dangling pointers 
+         * will have some dangling pointers
          *)
-        nods = nods#delkey i; 
+        nods = nods#delkey i;
         pred = pred#delkey i;
         succ = succ#delkey i;
         >}
 
-    method replace_node (i, (e: 'a)) = 
+    method replace_node (i, (e: 'a)) =
       assert (nods#haskey i);
       {<
         nods = nods#replkey (i, e);
        >}
 
-    method add_arc ((a,b),(v: 'b)) = 
-      {< 
+    method add_arc ((a,b),(v: 'b)) =
+      {<
         succ = succ#replkey (a, (succ#find a)#add (b, v));
         pred = pred#replkey (b, (pred#find b)#add (a, v));
         >}
     method del_arc ((a,b),v) =
-      {< 
+      {<
         succ = succ#replkey (a, (succ#find a)#del (b,v));
         pred = pred#replkey (b, (pred#find b)#del (a,v));
         >}
@@ -102,31 +102,31 @@ class ['a,'b] ograph_extended =
     method allsuccessors = succ
 
 (*
-    method ancestors xs = 
-      let rec aux xs acc = 
+    method ancestors xs =
+      let rec aux xs acc =
         match xs#view with (* could be done with an iter *)
         | Empty -> acc
-        | Cons(x, xs) -> (acc#add x) 
+        | Cons(x, xs) -> (acc#add x)
               +> (fun newacc -> aux (o#predecessors x) newacc)
               +> (fun newacc -> aux xs newacc)
       in aux xs (f2()) (* (new osetb []) *)
 
-    method children  xs = 
-      let rec aux xs acc = 
+    method children  xs =
+      let rec aux xs acc =
         match xs#view with (* could be done with an iter *)
         | Empty -> acc
-        | Cons(x, xs) -> (acc#add x) 
+        | Cons(x, xs) -> (acc#add x)
               +> (fun newacc -> aux (o#successors x) newacc)
               +> (fun newacc -> aux xs newacc)
       in aux xs (f2()) (* (new osetb []) *)
 
-    method brothers  x = 
+    method brothers  x =
       let parents = o#predecessors x in
       (parents#fold (fun acc e -> acc $++$ o#successors e) (f2()))#del x
 
 *)
 
-  end   
+  end
 
 (*****************************************************************************)
 (* Mutable version *)
@@ -137,44 +137,44 @@ class ['a,'b] ograph_mutable =
   let build_set ()   = new osetb Set_.empty in
 
   object(o)
-      
+
     val mutable free_index = 0
 
     val mutable succ = build_assoc()
     val mutable pred = build_assoc()
     val mutable nods = build_assoc()
 
-    method add_node (e: 'a) = 
+    method add_node (e: 'a) =
       let i = free_index in
-      nods <- nods#add (i, e); 
+      nods <- nods#add (i, e);
       pred <- pred#add (i, build_set() );
       succ <- succ#add (i, build_set() );
       free_index <- i + 1;
       i
 
-    method add_nodei i (e: 'a) = 
-      nods <- nods#add (i, e); 
+    method add_nodei i (e: 'a) =
+      nods <- nods#add (i, e);
       pred <- pred#add (i, build_set() );
       succ <- succ#add (i, build_set() );
       free_index <- (max free_index i) + 1;
 
 
-    method del_node (i) = 
-        (* check: e is effectively the index associated with e, 
+    method del_node (i) =
+        (* check: e is effectively the index associated with e,
            and check that already in *)
 
         (* todo: assert that have no pred and succ, otherwise
-         * will have some dangling pointers 
+         * will have some dangling pointers
          *)
-        nods <- nods#delkey i; 
+        nods <- nods#delkey i;
         pred <- pred#delkey i;
         succ <- succ#delkey i;
 
-    method replace_node (i, (e: 'a)) = 
+    method replace_node (i, (e: 'a)) =
       assert (nods#haskey i);
       nods <- nods#replkey (i, e);
-        
-    method add_arc ((a,b),(v: 'b)) = 
+
+    method add_arc ((a,b),(v: 'b)) =
       succ <- succ#replkey (a, (succ#find a)#add (b, v));
       pred <- pred#replkey (b, (pred#find b)#add (a, v));
     method del_arc ((a,b),v) =
@@ -187,16 +187,16 @@ class ['a,'b] ograph_mutable =
     method nodes = nods
     method allsuccessors = succ
 
-    method nb_nodes = 
+    method nb_nodes =
       nods#length
 
-    method nb_edges = 
-      nods#fold (fun acc (i, e) -> 
+    method nb_edges =
+      nods#fold (fun acc (i, e) ->
         let children = o#successors i in
         acc + children#cardinal
       ) 0
 
-  end   
+  end
 
 (*****************************************************************************)
 (* API *)
@@ -205,8 +205,8 @@ class ['a,'b] ograph_mutable =
 (* depth first search *)
 let dfs_iter xi f g =
   let already = Hashtbl.create 101 in
-  let rec aux_dfs xs = 
-    xs +> List.iter (fun xi -> 
+  let rec aux_dfs xs =
+    xs +> List.iter (fun xi ->
       if Hashtbl.mem already xi then ()
       else begin
         Hashtbl.add already xi true;
@@ -218,23 +218,23 @@ let dfs_iter xi f g =
   aux_dfs [xi]
 
 
-let dfs_iter_with_path xi f g = 
+let dfs_iter_with_path xi f g =
   let already = Hashtbl.create 101 in
-  let rec aux_dfs path xi = 
+  let rec aux_dfs path xi =
     if Hashtbl.mem already xi then ()
     else begin
       Hashtbl.add already xi true;
       f xi path;
       let succ = g#successors xi in
       let succ' = succ#tolist +> List.map fst in
-      succ' +> List.iter (fun yi -> 
+      succ' +> List.iter (fun yi ->
           aux_dfs (xi::path) yi
       );
       end
   in
   aux_dfs [] xi
-  
-    
+
+
 
 let generate_ograph_generic g label fnode filename =
   Common.with_open_outfile filename (fun (pr,_) ->
@@ -245,7 +245,7 @@ let generate_ograph_generic g label fnode filename =
     | Some x -> pr (Printf.sprintf "label = \"%s\";\n" x));
 
     let nodes = g#nodes in
-    nodes#iter (fun (k,node) -> 
+    nodes#iter (fun (k,node) ->
       let (str,border_color,inner_color) = fnode (k, node) in
       let color =
 	match inner_color with
@@ -255,13 +255,13 @@ let generate_ograph_generic g label fnode filename =
 	    | Some x -> Printf.sprintf ", style=\"setlinewidth(3)\", color = %s" x)
 	| Some x ->
 	    (match border_color with
-	      None -> Printf.sprintf ", style=\"setlinewidth(3),filled\", fillcolor = %s" x 
+	      None -> Printf.sprintf ", style=\"setlinewidth(3),filled\", fillcolor = %s" x
 	    | Some x' -> Printf.sprintf ", style=\"setlinewidth(3),filled\", fillcolor = %s, color = %s" x x') in
-     (* so can see if nodes without arcs were created *) 
+     (* so can see if nodes without arcs were created *)
       pr (spf "%d [label=\"%s   [%d]\"%s];\n" k str k color)
     );
 
-    nodes#iter (fun (k,node) -> 
+    nodes#iter (fun (k,node) ->
       let succ = g#successors k in
       succ#iter (fun (j,edge) ->
         pr (spf "%d -> %d;\n" k j);
@@ -278,12 +278,12 @@ let generate_ograph_xxx g filename =
     pr "size = \"10,10\";\n" ;
 
     let nodes = g#nodes in
-    nodes#iter (fun (k,(node, s)) -> 
-     (* so can see if nodes without arcs were created *) 
+    nodes#iter (fun (k,(node, s)) ->
+     (* so can see if nodes without arcs were created *)
       pr (spf "%d [label=\"%s   [%d]\"];\n" k s k)
     );
 
-    nodes#iter (fun (k,node) -> 
+    nodes#iter (fun (k,node) ->
       let succ = g#successors k in
       succ#iter (fun (j,edge) ->
         pr (spf "%d -> %d;\n" k j);
@@ -295,30 +295,30 @@ let generate_ograph_xxx g filename =
 
 
 let launch_gv_cmd filename =
-  let _status = 
+  let _status =
     Unix.system ("dot " ^ filename ^ " -Tps  -o " ^ filename ^ ".ps;") in
-  let _status = 
+  let _status =
     Unix.system ("gv " ^ filename ^ ".ps")
   in
-  (* zarb: I needed this when I launch the program with '&' via eshell, 
-   * otherwise gv did not get the chance to be launched 
-   * Unix.sleep 1; 
+  (* zarb: I needed this when I launch the program with '&' via eshell,
+   * otherwise gv did not get the chance to be launched
+   * Unix.sleep 1;
    *)
   ()
 
-let print_ograph_extended g filename launchgv = 
+let print_ograph_extended g filename launchgv =
   generate_ograph_xxx g filename;
   if launchgv then launch_gv_cmd filename
 
-let print_ograph_mutable g filename launchgv = 
+let print_ograph_mutable g filename launchgv =
   generate_ograph_xxx g filename;
   if launchgv then launch_gv_cmd filename
 
-let print_ograph_mutable_generic 
-    ?(title=None) 
+let print_ograph_mutable_generic
+    ?(title=None)
     ?(launch_gv = true)
     ?(output_file = "/tmp/ograph.dot")
     ~s_of_node
-    g = 
+    g =
   generate_ograph_generic g title s_of_node output_file;
   if launch_gv then launch_gv_cmd output_file

--- a/commons_ocollection/ograph_extended.mli
+++ b/commons_ocollection/ograph_extended.mli
@@ -3,17 +3,17 @@ open Common
 
 type nodei = int
 
-(* graph structure: 
- *  - node: index -> nodevalue 
+(* graph structure:
+ *  - node: index -> nodevalue
  *  - arc: (index * index) * edgevalue
- * 
+ *
  * How ? matrix ? but no growing array :(
- * 
+ *
  * When need index ? Must have an index when can't just use the nodevalue
  * as a key, cos sometimes may have 2 times the same key, but it must
  * be 2 different nodes. For instance in a C program 'f(); f();' we want 2
  * nodes, one per 'f();' hence the index. If each node is different, then
- * no problem, can omit index. 
+ * no problem, can omit index.
  *)
 
 class ['node, 'edge] ograph_extended :
@@ -55,33 +55,33 @@ object ('o)
 end
 
 
-val dfs_iter : 
+val dfs_iter :
   nodei -> (nodei -> unit) -> ('node, 'edge) ograph_mutable -> unit
 
-val dfs_iter_with_path : 
-  nodei -> (nodei -> nodei list -> unit) -> ('node, 'edge) ograph_mutable -> 
+val dfs_iter_with_path :
+  nodei -> (nodei -> nodei list -> unit) -> ('node, 'edge) ograph_mutable ->
   unit
 
-val print_ograph_mutable_generic : 
+val print_ograph_mutable_generic :
   ?title:string option -> (* label for the entire graph *)
-  ?launch_gv:bool -> 
-  ?output_file:filename -> 
+  ?launch_gv:bool ->
+  ?output_file:filename ->
   (* what string to print for a node and how to color it *)
   s_of_node:((nodei * 'node) -> (string * string option * string option)) ->
-  ('node, 'edge) ograph_mutable -> 
+  ('node, 'edge) ograph_mutable ->
   unit
 
 
-val print_ograph_extended : 
-  ('node * string, 'edge) ograph_extended -> 
-  filename (* output file *) -> 
-  bool (* launch gv ? *) -> 
+val print_ograph_extended :
+  ('node * string, 'edge) ograph_extended ->
+  filename (* output file *) ->
+  bool (* launch gv ? *) ->
   unit
 
-val print_ograph_mutable : 
-  ('node * string, 'edge) ograph_mutable -> 
-  filename (* output file *) -> 
-  bool (* launch gv ? *) -> 
+val print_ograph_mutable :
+  ('node * string, 'edge) ograph_mutable ->
+  filename (* output file *) ->
+  bool (* launch gv ? *) ->
   unit
 
 val launch_gv_cmd : Common.filename -> unit

--- a/commons_ocollection/ograph_simple.ml
+++ b/commons_ocollection/ograph_simple.ml
@@ -12,7 +12,7 @@ open Osetb
 (* Prelude *)
 (*****************************************************************************)
 (* An imperative directed polymorphic graph.
- * 
+ *
  * What is the difference with ograph_extended? With ograph_extended we
  * dont force the user to have a key; we generate those keys as he
  * adds nodes. Here we assume the user already has an idea of what kind
@@ -30,58 +30,58 @@ class ['key, 'a,'b] ograph_mutable =
   let build_set ()   = new osetb Set_.empty in
 
 object(o)
-  
+
   val mutable succ = build_assoc()
   val mutable pred = build_assoc()
   val mutable nods = (build_assoc() : ('key, 'a) Oassocb.oassocb)
 
-  method add_node i (e: 'a) = 
-    nods <- nods#add (i, e); 
+  method add_node i (e: 'a) =
+    nods <- nods#add (i, e);
     pred <- pred#add (i, build_set() );
     succ <- succ#add (i, build_set() );
 
-  method del_node (i) = 
-    (* check: e is effectively the index associated with e, 
+  method del_node (i) =
+    (* check: e is effectively the index associated with e,
        and check that already in *)
 
     (* todo: assert that have no pred and succ, otherwise
-     * will have some dangling pointers 
+     * will have some dangling pointers
      *)
-    nods <- nods#delkey i; 
+    nods <- nods#delkey i;
     pred <- pred#delkey i;
     succ <- succ#delkey i;
 
-  method del_leaf_node_and_its_edges (i) = 
+  method del_leaf_node_and_its_edges (i) =
     let succ = o#successors i in
     if not (succ#null)
     then failwith "del_leaf_node_and_its_edges: have some successors"
     else begin
       let pred = o#predecessors i in
-      pred#tolist +> List.iter (fun (k, edge) -> 
+      pred#tolist +> List.iter (fun (k, edge) ->
         o#del_arc (k,i) edge;
       );
       o#del_node i
     end
-      
-  method leaf_nodes () = 
+
+  method leaf_nodes () =
     let (set : 'key Oset.oset)  = build_set () in
-    o#nodes#tolist +> List.fold_left (fun acc (k,v) -> 
+    o#nodes#tolist +> List.fold_left (fun acc (k,v) ->
       if (o#successors k)#null
       then acc#add k
       else acc
     ) set
-    
 
-  method replace_node i (e: 'a) = 
+
+  method replace_node i (e: 'a) =
     assert (nods#haskey i);
     nods <- nods#replkey (i, e);
 
-  method add_node_if_not_present i (e: 'a) = 
+  method add_node_if_not_present i (e: 'a) =
     if nods#haskey i
     then ()
     else o#add_node i e
-    
-  method add_arc (a,b) (v: 'b) = 
+
+  method add_arc (a,b) (v: 'b) =
     succ <- succ#replkey (a, (succ#find a)#add (b, v));
     pred <- pred#replkey (b, (pred#find b)#add (a, v));
   method del_arc (a,b) v =
@@ -95,14 +95,14 @@ object(o)
   method allsuccessors = succ
 
   (* detect if no loop ? *)
-  method ancestors k = 
+  method ancestors k =
     let empty_set = build_set() in
 
-    
-    let rec aux acc x = 
+
+    let rec aux acc x =
       if acc#mem x
-      then 
-        (* bugfix: have_loop := true; ? not, not necessarally. 
+      then
+        (* bugfix: have_loop := true; ? not, not necessarally.
          * if you got a diamon, seeing a second time the same
          * x does not mean we are in a loop
          *)
@@ -117,7 +117,7 @@ object(o)
     let set = set#del k in
     set
 
-end   
+end
 
 (*****************************************************************************)
 (* Debugging *)
@@ -129,10 +129,10 @@ let print_ograph_generic ~str_of_key ~str_of_node filename g =
     pr "size = \"10,10\";\n" ;
 
     let nodes = g#nodes in
-    nodes#iter (fun (k,node) -> 
+    nodes#iter (fun (k,node) ->
       pr (spf "%s [label=\"%s\"];\n" (str_of_key k) (str_of_node k node))
     );
-    nodes#iter (fun (k,node) -> 
+    nodes#iter (fun (k,node) ->
       let succ = g#successors k in
       succ#iter (fun (j,edge) ->
         pr (spf "%s -> %s;\n" (str_of_key k) (str_of_key j));

--- a/commons_ocollection/ograph_simple.mli
+++ b/commons_ocollection/ograph_simple.mli
@@ -27,11 +27,11 @@ object ('o)
 
 end
 
-val print_ograph_generic: 
+val print_ograph_generic:
   str_of_key:('key -> string) ->
   str_of_node:('key -> 'node -> string) ->
-  Common.filename -> 
-  ('key, 'node,'edge) ograph_mutable -> 
+  Common.filename ->
+  ('key, 'node,'edge) ograph_mutable ->
   unit
 
 (*e: ograph_simple.mli *)

--- a/commons_ocollection/oset.ml
+++ b/commons_ocollection/oset.ml
@@ -10,7 +10,7 @@ object(o: 'o)
   method virtual union: 'o -> 'o
   method virtual inter: 'o -> 'o
   method virtual minus: 'o -> 'o
-    
+
   (* allow binary methods tricks, generate exception when not good type *)
   method  tosetb: 'a Set_.t = raise Impossible
   method  tosetpt: SetPt.t = raise Impossible
@@ -18,21 +18,21 @@ object(o: 'o)
   method virtual toset: 'b. 'b (* generic (not safe) tricks *)
 
   (* is_intersect, equal, subset *)
-  method is_subset_of: 'o -> bool = fun o2 -> 
+  method is_subset_of: 'o -> bool = fun o2 ->
     ((o2#minus o)#cardinal >= 0) && ((o#minus o2)#cardinal =|= 0)
 
-  method is_equal: 'o -> bool = fun o2 -> 
+  method is_equal: 'o -> bool = fun o2 ->
     ((o2#minus o)#cardinal =|= 0) && ((o#minus o2)#cardinal =|= 0)
-      
+
 
   method is_singleton: bool = (* can be short circuited *)
     o#length =|= 1
   method cardinal: int = (* just to keep naming conventions *)
-    o#length 
-      (* dont work: 
-         method big_union: 'b. ('a -> 'b oset) -> 'b oset = fun f -> todo() 
+    o#length
+      (* dont work:
+         method big_union: 'b. ('a -> 'b oset) -> 'b oset = fun f -> todo()
       *)
-      
+
 end
 
 let ($??$) e xs = xs#mem e
@@ -42,9 +42,9 @@ let ($--$) xs ys = xs#minus ys
 let ($<<=$) xs ys = xs#is_subset_of ys
 let ($==$) xs ys = xs#is_equal ys
 
-(* todo: pas beau le seed.  I dont put the type otherwise have to 
- * put explicit :> 
+(* todo: pas beau le seed.  I dont put the type otherwise have to
+ * put explicit :>
  *)
-let (mapo: ('a -> 'b) -> 'b oset -> 'a oset -> 'b oset) = fun f seed xs -> 
+let (mapo: ('a -> 'b) -> 'b oset -> 'a oset -> 'b oset) = fun f seed xs ->
   xs#fold (fun acc x -> acc#add (f x)) seed
 

--- a/commons_ocollection/oset.mli
+++ b/commons_ocollection/oset.mli
@@ -4,15 +4,15 @@ object ('o)
   inherit ['a] Ocollection.ocollection
 
   method cardinal : int
-    
+
   method virtual inter : 'o -> 'o
   method virtual minus : 'o -> 'o
   method virtual union : 'o -> 'o
-    
+
   method is_singleton : bool
   method is_subset_of : 'o -> bool
   method is_equal : 'o -> bool
-    
+
   method virtual toset : 'd
   method tosetb : 'a Set_.t
   method toseti : Seti.seti

--- a/commons_ocollection/osetb.ml
+++ b/commons_ocollection/osetb.ml
@@ -3,7 +3,7 @@ open Oset
 
 let empty = Set_.empty
 
-class ['a] osetb xs   = 
+class ['a] osetb xs   =
   object(o)
     inherit ['a] oset
 
@@ -11,14 +11,14 @@ class ['a] osetb xs   =
     method tosetb = data
 
     (* if put [] then no segfault, if [11] then segfault *)
-    method toset = Obj.magic data 
+    method toset = Obj.magic data
 
     method empty = {< data = Set_.empty >}
     method add e = {< data = Set_.add e data >}
     method iter f = Set_.iter f   data
-    method view = 
-      if Set_.is_empty data 
-      then Empty 
+    method view =
+      if Set_.is_empty data
+      then Empty
       else let el = Set_.choose data in Cons (el, o#del el)
 
     method del e = {< data = Set_.remove e data >}
@@ -32,5 +32,5 @@ class ['a] osetb xs   =
     method inter s = {< data = Set_.inter data s#tosetb >}
     method minus s = {< data = Set_.diff  data s#tosetb >}
     (* todo: include, ... *)
-        
+
   end

--- a/commons_ocollection/oseth.ml
+++ b/commons_ocollection/oseth.ml
@@ -3,60 +3,60 @@ open Common
 open Oset
 
 (* !!take care!!: this class does side effect, not a pure oassoc *)
-class ['a] oseth xs   = 
+class ['a] oseth xs   =
 object(o)
   inherit ['a] oset
 
   val data = Hashtbl.create 100
-    
+
   (* if put [] then no segfault, if [11] then segfault *)
-  method toset = Obj.magic data 
+  method toset = Obj.magic data
 
   method empty = {< data = Hashtbl.create 100 >}
-  method add k = 
-    Hashtbl.add data k true; 
+  method add k =
+    Hashtbl.add data k true;
     o
-      
+
   method iter f = Hashtbl.iter (fun k v -> f k) data
   method view = raise Todo
-    
-  method del k = 
-    Hashtbl.remove data k; 
+
+  method del k =
+    Hashtbl.remove data k;
     o
-  method mem k = 
-    try (ignore(Hashtbl.find data k); true) 
+  method mem k =
+    try (ignore(Hashtbl.find data k); true)
     with Not_found -> false
 
-  method null = 
-    try (Hashtbl.iter (fun k v -> raise Common2.ReturnExn) data; false) 
+  method null =
+    try (Hashtbl.iter (fun k v -> raise Common2.ReturnExn) data; false)
     with Common2.ReturnExn -> true
 
 (* TODO    method length *)
 
-  method union s = 
-    let v = Hashtbl.create 100 in 
+  method union s =
+    let v = Hashtbl.create 100 in
     o#iter (fun k -> Hashtbl.add v k true);
     s#iter (fun k -> Hashtbl.add v k true);
     {< data = v >}
-  method inter s = 
-    let v = Hashtbl.create 100 in 
+  method inter s =
+    let v = Hashtbl.create 100 in
     o#iter (fun k -> if s#mem k then Hashtbl.add v k true);
     {< data = v >}
-  method minus s = 
-    let v = Hashtbl.create 100 in 
+  method minus s =
+    let v = Hashtbl.create 100 in
     o#iter (fun k -> if not(s#mem k) then Hashtbl.add v k true);
     {< data = v >}
 
   (* override default  *)
-  method getone = 
+  method getone =
     let x = ref None in
     try (
-      Hashtbl.iter (fun k _ -> x := Some k; raise Common2.ReturnExn) data; 
+      Hashtbl.iter (fun k _ -> x := Some k; raise Common2.ReturnExn) data;
       raise Not_found
-    ) 
+    )
     with Common2.ReturnExn -> Common2.some !x
-      
-      
+
+
 end
 
 

--- a/commons_ocollection/oseti.ml
+++ b/commons_ocollection/oseti.ml
@@ -1,7 +1,7 @@
 open Ocollection
 open Oset
 
-class ['a] oseti xs   = 
+class ['a] oseti xs   =
   object(o)
     inherit [int] oset
 
@@ -12,9 +12,9 @@ class ['a] oseti xs   =
     method empty = {< data = Seti.empty >}
     method add e = {< data = Seti.add e data >}
     method iter f = Seti.iter f   data
-    method view = 
-      if Seti.is_empty data 
-      then Empty 
+    method view =
+      if Seti.is_empty data
+      then Empty
       else let el = Seti.choose data in Cons (el, o#del el)
 
     method del e = {< data = Seti.remove e data >}
@@ -27,7 +27,7 @@ class ['a] oseti xs   =
     method union s = {< data = Seti.union data s#toseti >}
     method inter s = {< data = Seti.inter data s#toseti >}
     method minus s = {< data = Seti.diff  data s#toseti >}
-        
+
     method invariant () = Seti.invariant data
     method to_string () = Seti.string_of_seti data
 

--- a/commons_ocollection/osetpt.ml
+++ b/commons_ocollection/osetpt.ml
@@ -2,21 +2,21 @@ open Ocollection
 open Oset
 
 
-class ['a] osetpt xs   = 
+class ['a] osetpt xs   =
   object(o)
     inherit [int] oset
 
     val data = SetPt.empty
     method tosetpt = data
     (* if put [] then no segfault, if [11] then segfault *)
-    method toset = Obj.magic data 
+    method toset = Obj.magic data
 
     method empty = {< data = SetPt.empty >}
     method add e = {< data = SetPt.add e data >}
     method iter f = SetPt.iter f   data
-    method view = 
-      if SetPt.is_empty data 
-      then Empty 
+    method view =
+      if SetPt.is_empty data
+      then Empty
       else let el = SetPt.choose data in Cons (el, o#del el)
 
     method del e = {< data = SetPt.remove e data >}
@@ -29,5 +29,5 @@ class ['a] osetpt xs   =
     method union s = {< data = SetPt.union data s#tosetpt >}
     method inter s = {< data = SetPt.inter data s#tosetpt >}
     method minus s = {< data = SetPt.diff  data s#tosetpt >}
-        
+
   end

--- a/commons_ocollection/setPt.ml
+++ b/commons_ocollection/setPt.ml
@@ -1,15 +1,15 @@
 (*
  * Ptset: Sets of integers implemented as Patricia trees.
  * Copyright (C) 2000 Jean-Christophe FILLIATRE
- * 
+ *
  * This software is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
  * License version 2, as published by the Free Software Foundation.
- * 
+ *
  * This software is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * 
+ *
  * See the GNU Library General Public License version 2 for more details
  * (enclosed in the file LGPL).
  *)
@@ -50,7 +50,7 @@ type t =
     $$\mathtt{Branch~(0,~1,~Leaf~4,~Branch~(1,~4,~Leaf~1,~Leaf~5))}$$
     The first branching bit is the bit 0 (and the corresponding prefix
     is [0b0], not of use here), with $\{4\}$ on the left and $\{1,5\}$ on the
-    right. Then the right subtree branches on bit 2 (and so has a branching 
+    right. Then the right subtree branches on bit 2 (and so has a branching
     value of $2^2 = 4$), with prefix [0b01 = 1]. *)
 
 (*s Empty set and singletons. *)
@@ -90,9 +90,9 @@ let mask p m = p land (m-1)
 
 let join (p0,t0,p1,t1) =
   let m = branching_bit p0 p1 in
-  if zero_bit p0 m then 
+  if zero_bit p0 m then
     Branch (mask p0 m, m, t0, t1)
-  else 
+  else
     Branch (mask p0 m, m, t1, t0)
 
 (*s Then the insertion of value [k] in set [t] is easily implemented
@@ -108,11 +108,11 @@ let match_prefix k p m = (mask k m) == p
 let add k t =
   let rec ins = function
     | Empty -> Leaf k
-    | Leaf j as t -> 
+    | Leaf j as t ->
         if j == k then t else join (k, Leaf k, j, t)
     | Branch (p,m,t0,t1) as t ->
         if match_prefix k p m then
-          if zero_bit k m then 
+          if zero_bit k m then
             Branch (p, m, ins t0, t1)
           else
             Branch (p, m, t0, ins t1)
@@ -123,7 +123,7 @@ let add k t =
 
 (*s The code to remove an element is basically similar to the code of
     insertion. But since we have to maintain the invariant that both
-    subtrees of a [Branch] node are non-empty, we use here the 
+    subtrees of a [Branch] node are non-empty, we use here the
     ``smart constructor'' [branch] instead of [Branch]. *)
 
 let branch = function
@@ -135,7 +135,7 @@ let remove k t =
   let rec rmv = function
     | Empty -> Empty
     | Leaf j as t -> if k == j then Empty else t
-    | Branch (p,m,t0,t1) as t -> 
+    | Branch (p,m,t0,t1) as t ->
         if match_prefix k p m then
           if zero_bit k m then
             branch (p, m, rmv t0, t1)
@@ -166,9 +166,9 @@ let rec merge = function
         Branch (p, m, merge (s0,t0), merge (s1,t1))
       else if m < n && match_prefix q p m then
         (* [q] contains [p]. Merge [t] with a subtree of [s]. *)
-        if zero_bit q m then 
+        if zero_bit q m then
           Branch (p, m, merge (s0,t), s1)
-        else 
+        else
           Branch (p, m, s0, merge (s1,t))
       else if m > n && match_prefix p q n then
         (* [p] contains [q]. Merge [s] with a subtree of [t]. *)
@@ -196,9 +196,9 @@ let rec subset s1 s2 = match (s1,s2) with
       if m1 == m2 && p1 == p2 then
         subset l1 l2 && subset r1 r2
       else if m1 > m2 && match_prefix p1 p2 m2 then
-        if zero_bit p1 m2 then 
+        if zero_bit p1 m2 then
           subset l1 l2 && subset r1 l2
-        else 
+        else
           subset l1 r2 && subset r1 r2
       else
         false
@@ -213,7 +213,7 @@ let rec inter s1 s2 = match (s1,s2) with
   | Leaf k1, _ -> if mem k1 s2 then s1 else Empty
   | _, Leaf k2 -> if mem k2 s1 then s2 else Empty
   | Branch (p1,m1,l1,r1), Branch (p2,m2,l2,r2) ->
-      if m1 == m2 && p1 == p2 then 
+      if m1 == m2 && p1 == p2 then
         merge (inter l1 l2, inter r1 r2)
       else if m1 < m2 && match_prefix p2 p1 m1 then
         inter (if zero_bit p2 m1 then l1 else r1) s2
@@ -231,9 +231,9 @@ let rec diff s1 s2 = match (s1,s2) with
       if m1 == m2 && p1 == p2 then
         merge (diff l1 l2, diff r1 r2)
       else if m1 < m2 && match_prefix p2 p1 m1 then
-        if zero_bit p2 m1 then 
-          merge (diff l1 s2, r1) 
-        else 
+        if zero_bit p2 m1 then
+          merge (diff l1 s2, r1)
+        else
           merge (l1, diff r1 s2)
       else if m1 > m2 && match_prefix p1 p2 m2 then
         if zero_bit p1 m2 then diff s1 l2 else diff s1 r2
@@ -253,7 +253,7 @@ let rec iter f = function
   | Empty -> ()
   | Leaf k -> f k
   | Branch (_,_,t0,t1) -> iter f t0; iter f t1
-      
+
 let rec fold f s accu = match s with
   | Empty -> accu
   | Leaf k -> f k accu
@@ -269,7 +269,7 @@ let rec exists p = function
   | Leaf k -> p k
   | Branch (_,_,t0,t1) -> exists p t0 || exists p t1
 
-let filter p s = 
+let filter p s =
   let rec filt acc = function
     | Empty -> acc
     | Leaf k -> if p k then add k acc else acc

--- a/commons_ocollection/seti.ml
+++ b/commons_ocollection/seti.ml
@@ -6,38 +6,38 @@ open Common
 
 (* todo: could take an incr/decr func in param, to make it generic
  * opti: remember the min/max (optimisation to have intersect biggest x -> x)
- * opti: avoid all those rev, and avoid the intervise 
+ * opti: avoid all those rev, and avoid the intervise
  * (but yes the algo are then more complex :)
- * opti: balanced set intervalle 
+ * opti: balanced set intervalle
 *)
 
 (*****************************************************************************)
 type seti = elt list (* last elements is in first pos, ordered reverse *)
   and elt = Exact of int | Interv of int * int
 
-(* invariant= ordered list, no incoherent interv (one elem or zero elem), 
+(* invariant= ordered list, no incoherent interv (one elem or zero elem),
  * merged (intervalle are separated) *)
-let invariant xs = 
-  let rec aux min xs = 
-    xs +> List.fold_left (fun min e -> 
-      match e with 
-      | Exact i -> 
+let invariant xs =
+  let rec aux min xs =
+    xs +> List.fold_left (fun min e ->
+      match e with
+      | Exact i ->
           if i <= min then pr2 (spf "i = %d, min = %d" i min);
           (* todo: should be even stronger, shoud be i > min+1 *)
           assert (i > min);
           i
-      | Interv (i,j) -> 
+      | Interv (i,j) ->
           assert (i > min);
           assert (j > i);
           j
     ) min
   in
-  ignore(aux min_int (List.rev xs)); 
+  ignore(aux min_int (List.rev xs));
   ()
 
-let string_of_seti xs = 
-  "[" ^  
-    join "," (xs +> List.rev +> List.map (function 
+let string_of_seti xs =
+  "[" ^
+    join "," (xs +> List.rev +> List.map (function
     | (Exact i) -> string_of_int i
     | (Interv (i,j)) -> Printf.sprintf "%d - %d" i j)) ^
     "]"
@@ -47,42 +47,42 @@ let empty = []
 
 let pack newi j = function
   | [] -> [Interv (newi,j)]
-  | (Exact z)::xs -> 
+  | (Exact z)::xs ->
       (Interv (newi, j))::(if newi =|= z then xs else (Exact z)::xs)
-  | (Interv (i', j'))::xs -> 
-      if newi =|= j' 
+  | (Interv (i', j'))::xs ->
+      if newi =|= j'
       then (Interv (i', j))::xs  (* merge *)
       else (Interv (newi, j))::(Interv (i', j'))::xs
-        
+
 
 (* the only possible merges are when x = i-1, otherwise, the job is done before *)
-let rec (add2: int -> seti -> seti) = fun x -> function 
+let rec (add2: int -> seti -> seti) = fun x -> function
   | [] -> [Exact x]
   | (Exact i)::xs when x > i+1 -> (Exact x)::(Exact i)::xs
   | (Interv (i,j)::xs) when x > j+1 -> (Exact x)::(Interv (i,j))::xs
   | (Interv (i,j)::xs) when x =|= j+1 -> (Interv (i,x))::xs
   | (Exact i)::xs when x =|= i+1 -> (Interv (i,x))::xs
-      
+
   | (Exact i)::xs when i =|= x   -> (Exact i)::xs
   | (Interv (i,j)::xs) when x <= j && x >= i -> (Interv (i,j))::xs
-  | other -> 
+  | other ->
 (*         let _ = log "Cache miss" in *)
       let _ = Common2.count2 () in
       (match other with
-      |       (Exact i)::xs when x =|= i-1 -> pack x i xs 
+      |       (Exact i)::xs when x =|= i-1 -> pack x i xs
       |       (Exact i)::xs when x < i-1 -> (Exact i)::add x xs
-                
+
       |       (Interv (i,j)::xs) when x =|= i-1 -> pack x j xs
       |       (Interv (i,j)::xs) when x < i-1 -> (Interv (i,j))::add x xs
       |       _ -> raise Impossible
       )
-and add x y = let _ = Common2.count5 () in add2 x y                                                         
+and add x y = let _ = Common2.count5 () in add2 x y
 
-            
+
 let rec tolist2 = function
   | [] -> []
   | (Exact i)::xs -> i::tolist2 xs
-  | (Interv (i,j))::xs -> Common2.enum i j @ tolist2 xs 
+  | (Interv (i,j))::xs -> Common2.enum i j @ tolist2 xs
 let rec tolist xs = List.rev (tolist2 xs)
 
 let rec fromlist = function xs -> List.fold_left (fun a e -> add e a) empty xs
@@ -96,18 +96,18 @@ let exactize = function
 let exactize2 x y = if x =|= y then Exact x else Interv (x,y)
 
 
-let rec (remove: int -> seti -> seti) = fun x xs -> 
+let rec (remove: int -> seti -> seti) = fun x xs ->
   match xs with
   | [] -> [] (*  pb, not in  *)
-  | (Exact z)::zs -> 
+  | (Exact z)::zs ->
       (match x <=> z with
       | Equal -> zs
       | Sup -> xs  (*  pb, not in *)
       | Inf -> (Exact z)::remove x zs
-      ) 
-  | (Interv (i,j)::zs) -> 
+      )
+  | (Interv (i,j)::zs) ->
       if x > j then xs (*  pb not in *)
-      else 
+      else
         if x >= i && x <= j then
           (
             let _ = assert (j > i) in (* otherwise can lead to construct seti such as [7,6] when removing 6 from [6,6] *)
@@ -127,51 +127,51 @@ let _ = assert_equal (remove 3 [Interv (1, 7)])  [Interv (4,7); Interv (1,2)]
 let _ = assert_equal (remove 4 [Interv (3, 4)])  [Exact (3);]
 (* let _ = example (try (ignore(remove 6 [Interv (6, 6)] = []); false) with _ -> true)   *)
 
-    
+
 let rec mem e = function
-  | [] -> false 
-  | (Exact x)::xs -> 
+  | [] -> false
+  | (Exact x)::xs ->
       (match e <=> x with
       | Equal -> true
       | Sup -> false
       | Inf -> mem e xs
-      ) 
-  | (Interv (i,j)::xs) -> 
+      )
+  | (Interv (i,j)::xs) ->
       if e > j then false
-      else 
+      else
         if e >= i && e <= j then true
       else mem e xs
 
-let iter f xs = xs +> List.iter 
+let iter f xs = xs +> List.iter
   (function
   | Exact i -> f i
   | Interv (i, j) -> for k = i to j do f k done
   )
-        
+
 let is_empty xs = xs =*= []
 let choose = function
   | [] -> failwith "not supposed to be called with empty set"
   | (Exact i)::xs -> i
   | (Interv (i,j))::xs -> i
-      
+
 let elements xs = tolist xs
 let rec cardinal = function
   | [] -> 0
   | (Exact _)::xs -> 1+cardinal xs
   | (Interv (i,j)::xs) -> (j-i) +1 + cardinal xs
-      
+
 (*****************************************************************************)
 (*  TODO: could return corresponding osetb ? *)
-let rec inter xs ys = 
-  let rec aux = fun xs ys -> 
+let rec inter xs ys =
+  let rec aux = fun xs ys ->
     match (xs, ys) with
     | (_, []) -> []
     | ([],_)  -> []
-    | (x::xs, y::ys) -> 
+    | (x::xs, y::ys) ->
         (match (x, y) with
-        | (Interv (i1, j1), Interv (i2, j2)) -> 
+        | (Interv (i1, j1), Interv (i2, j2)) ->
             (match i1 <=> i2 with
-            | Equal -> 
+            | Equal ->
                 (match j1 <=> j2 with
                 | Equal -> (Interv (i1,j1))::aux xs ys
                     (*  [  ] *)
@@ -183,11 +183,11 @@ let rec inter xs ys =
                     (*  [    ] *)
                     (*  [ ] [       same *)
                 )
-            | Inf -> 
+            | Inf ->
                 if j1 < i2 then aux xs (y::ys) (* need order ? *)
                   (*  [    ] *)
                   (*         [ ] *)
-                else 
+                else
                   (match j1 <=> j2 with
                   | Equal -> (Interv (i2, j1))::aux xs ys
                       (*  [    ] *)
@@ -206,17 +206,17 @@ let rec inter xs ys =
   in
   (* TODO avoid the rev rev, but aux good ? need order ?  *)
   List.rev_map exactize (aux (List.rev_map intervise xs) (List.rev_map intervise ys))
-      
-let union xs ys = 
-  let rec aux = fun xs ys -> 
+
+let union xs ys =
+  let rec aux = fun xs ys ->
     match (xs, ys) with
     | (vs, []) -> vs
     | ([],vs)  -> vs
-    | (x::xs, y::ys) -> 
+    | (x::xs, y::ys) ->
         (match (x, y) with
-        | (Interv (i1, j1), Interv (i2, j2)) -> 
+        | (Interv (i1, j1), Interv (i2, j2)) ->
             (match i1 <=> i2 with
-            | Equal -> 
+            | Equal ->
                 (match j1 <=> j2 with
                 | Equal -> (Interv (i1,j1))::aux xs ys
                     (*  [  ] *)
@@ -228,11 +228,11 @@ let union xs ys =
                     (*  [    ] *)
                     (*  [ ] [       same *)
                 )
-            | Inf -> 
+            | Inf ->
                 if j1 < i2 then Interv (i1, j1):: aux xs (y::ys)
                   (*  [    ] *)
                   (*         [ ] *)
-                else 
+                else
                   (match j1 <=> j2 with
                   | Equal -> (Interv (i1, j1))::aux xs ys
                       (*  [    ] *)
@@ -256,16 +256,16 @@ let union xs ys =
  * not very strong, should return (Interv (1,4)) *)
 (* let _ = Example (union [Interv (1, 4)] [Interv (1, 3)] = ([Exact 4; Interv (1,3)])) *)
 
-let diff xs ys = 
-  let rec aux = fun xs ys -> 
+let diff xs ys =
+  let rec aux = fun xs ys ->
     match (xs, ys) with
     | (vs, []) -> vs
     | ([],vs)  -> []
-    | (x::xs, y::ys) -> 
+    | (x::xs, y::ys) ->
         (match (x, y) with
-        | (Interv (i1, j1), Interv (i2, j2)) -> 
+        | (Interv (i1, j1), Interv (i2, j2)) ->
             (match i1 <=> i2 with
-            | Equal -> 
+            | Equal ->
                 (match j1 <=> j2 with
                 | Equal -> aux xs ys
                     (*  [  ] *)
@@ -277,11 +277,11 @@ let diff xs ys =
                     (*  [    ] *)
                     (*  [ ]  *)
                 )
-            | Inf -> 
+            | Inf ->
                 if j1 < i2 then Interv (i1, j1):: aux xs (y::ys)
                   (*  [    ] *)
                   (*         [ ] *)
-                else 
+                else
                   (match j1 <=> j2 with
                   | Equal -> (Interv (i1, i2-1))::aux xs ys (* -1 cos exlude [ *)
                       (*  [    ] *)
@@ -293,11 +293,11 @@ let diff xs ys =
                       (*  [       ] *)
                       (*     [ ]  *)
                   )
-            | Sup -> 
+            | Sup ->
                 if j2 < i1 then aux (x::xs) ys
                   (*       [    ] *)
                   (*  [ ] *)
-                else 
+                else
                   (match j1 <=> j2 with
                   | Equal -> aux xs ys
                       (*         [    ] *)
@@ -318,7 +318,7 @@ let diff xs ys =
 
 
 (*     let _ = Example (diff [Interv (3,7)] [Interv (4,5)] = [Interv (6, 7); Exact 3]) *)
- 
+
 (*****************************************************************************)
 let rec debug = function
   | [] -> ""
@@ -328,22 +328,22 @@ let rec debug = function
 (*****************************************************************************)
 (* if operation return wrong result, then may later have to patch them *)
 let patch1 xs = List.map exactize xs
-let patch2 xs = xs +> List.map (fun e -> 
+let patch2 xs = xs +> List.map (fun e ->
   match e with
-  | Interv (i,j) when i > j && i =|= j+1 -> 
+  | Interv (i,j) when i > j && i =|= j+1 ->
       let _ = pr2 (spf "i = %d, j = %d" i j) in
       Exact i
   | e -> e
 )
-let patch3 xs = 
-  let rec aux min xs = 
-    xs +> List.fold_left (fun (min,acc) e -> 
-      match e with 
-      | Exact i -> 
-          if i =|= min 
+let patch3 xs =
+  let rec aux min xs =
+    xs +> List.fold_left (fun (min,acc) e ->
+      match e with
+      | Exact i ->
+          if i =|= min
           then (min, acc)
           else (i, (Exact i)::acc)
-      | Interv (i,j) -> 
+      | Interv (i,j) ->
           (j, (Interv (i,j)::acc))
     ) (min, [])
   in

--- a/config/envos/environment_splint.h
+++ b/config/envos/environment_splint.h
@@ -27,7 +27,7 @@
 
 # ifdef STRICT
 /*@checkedstrict@*/ int errno;
-# else 
+# else
 ///*@unchecked@*/ int errno;
 # endif
 
@@ -43,10 +43,10 @@
 /*@constant int __bool_true_false_are_defined = 1@*/
 
 /*
-** types 
+** types
 */
 
-//typedef /*@integraltype@*/ ptrdiff_t;    
+//typedef /*@integraltype@*/ ptrdiff_t;
 //typedef /*@unsignedintegraltype@*/ size_t;
 //typedef /*@signedintegraltype@*/ ssize_t;
 //typedef /*@integraltype@*/ wchar_t;
@@ -67,10 +67,10 @@
 /*@constant _Bool NDEBUG;@*/
 
 # ifdef STRICT
-/*@falseexit@*/ void assert (/*@sef@*/ /*pad:_Bool*/ int e) 
+/*@falseexit@*/ void assert (/*@sef@*/ /*pad:_Bool*/ int e)
   /*@*/ ;
 # else
-///*@falseexit@*/ void assert (/*@sef@*/ _Bool /*@alt int@*/ e) 
+///*@falseexit@*/ void assert (/*@sef@*/ _Bool /*@alt int@*/ e)
   /*@*/ ;
 # endif
 
@@ -146,7 +146,7 @@ struct lconv
 /*@constant int LC_NUMERIC;@*/
 /*@constant int LC_TIME;@*/
 
-/*@observer@*/ /*@null@*/ char *setlocale (int category, /*@null@*/ char *locale) 
+/*@observer@*/ /*@null@*/ char *setlocale (int category, /*@null@*/ char *locale)
    /*@modifies internalState, errno@*/ ;
 
 struct lconv *localeconv (void) /*@*/ ;
@@ -342,7 +342,7 @@ float floorf (float x) /*@*/ ;
 long double floorl (long double x) /*@*/ ;
 
 double nearbyint (double x) /*@*/ ;
-float nearbyintf (float x) /*@*/ ; 
+float nearbyintf (float x) /*@*/ ;
 long double nearbyintl (long double x) /*@*/ ;
 
 double rint (double x) /*@*/;
@@ -359,7 +359,7 @@ double round (double x) /*@*/ ;
 long int lround (double x) /*@modifies errno@*/ ;
 long long llround (double x) /*@modifies errno@*/ ;
 
-double trunc (double x) /*@*/ ; 
+double trunc (double x) /*@*/ ;
 double fmod (double x, double y) /*@*/ ;
 double remainder (double x, double y) /*@*/ ;
 double remquo (double x, double y, /*@out@*/ int *quo) /*@modifies *quo@*/ ;
@@ -466,7 +466,7 @@ int setjmp (/*@out@*/ jmp_buf env) /*@modifies env;@*/ ;
 ** returns the function (or NULL if unsuccessful).
 */
 
-/*@null@*/ void (*signal (int sig, /*@null@*/ void (*func)(int))) (int) 
+/*@null@*/ void (*signal (int sig, /*@null@*/ void (*func)(int))) (int)
    /*@modifies internalState, errno;@*/ ;
 
 /*@mayexit@*/ int raise (int sig) ;
@@ -532,53 +532,53 @@ int rename (char *old, char *new) /*@modifies fileSystem, errno@*/ ;
    /*@modifies fileSystem, errno@*/ ;
 
 /*@observer@*/ char *
-  tmpnam (/*@out@*/ /*@null@*/ /*@returned@*/ char *s) 
+  tmpnam (/*@out@*/ /*@null@*/ /*@returned@*/ char *s)
   /*@modifies *s, internalState@*/ ;
 
-int fclose (FILE *stream) 
+int fclose (FILE *stream)
    /*@modifies *stream, errno, fileSystem;@*/ ;
 
-int fflush (/*@null@*/ FILE *stream) 
+int fflush (/*@null@*/ FILE *stream)
    /*@modifies *stream, errno, fileSystem;@*/ ;
 
-/*@null@*/ /*@dependent@*/ FILE *fopen (char *filename, char *mode) 
-   /*@modifies fileSystem@*/ ;         
+/*@null@*/ /*@dependent@*/ FILE *fopen (char *filename, char *mode)
+   /*@modifies fileSystem@*/ ;
 
-/*@dependent@*/ /*@null@*/ FILE *freopen (char *filename, char *mode, FILE *stream) 
+/*@dependent@*/ /*@null@*/ FILE *freopen (char *filename, char *mode, FILE *stream)
   /*@modifies *stream, fileSystem, errno@*/ ;
 
-void setbuf (FILE *stream, /*@null@*/ /*@exposed@*/ /*@out@*/ char *buf) 
-     /*@modifies fileSystem, *stream, *buf@*/ 
+void setbuf (FILE *stream, /*@null@*/ /*@exposed@*/ /*@out@*/ char *buf)
+     /*@modifies fileSystem, *stream, *buf@*/
      /*:errorcode != 0*/ ;
      /*:requires maxSet(buf) >= (BUFSIZ - 1):*/ ;
 
-int setvbuf (FILE *stream, /*@null@*/ /*@exposed@*/ /*@out@*/ char *buf, 
+int setvbuf (FILE *stream, /*@null@*/ /*@exposed@*/ /*@out@*/ char *buf,
 	     int mode, size_t size)
       /*@modifies fileSystem, *stream, *buf@*/
      /*@requires maxSet(buf) >= (size - 1) @*/ ;
 
 # ifdef STRICT
-/*@printflike@*/ 
+/*@printflike@*/
 int fprintf (FILE *stream, char *format, ...)
    /*@modifies fileSystem, *stream@*/ ;
 # else
-///*@printflike@*/ 
+///*@printflike@*/
 //int /*@alt void@*/ fprintf (FILE *stream, char *format, ...)
 //   /*@modifies fileSystem, *stream@*/ ;
 # endif
 
-/*@scanflike@*/ 
+/*@scanflike@*/
 int fscanf (FILE *stream, char *format, ...)
    /*@modifies fileSystem, *stream, errno@*/ ;
 
 # ifdef STRICT
-/*@printflike@*/ 
-int printf (char *format, ...) 
+/*@printflike@*/
+int printf (char *format, ...)
    /*@globals stdout@*/
    /*@modifies fileSystem, *stdout@*/ ;
 # else
-///*@printflike@*/ 
-//int /*@alt void@*/ printf (char *format, ...) 
+///*@printflike@*/
+//int /*@alt void@*/ printf (char *format, ...)
 //   /*@globals stdout@*/
 //   /*@modifies fileSystem, *stdout@*/ ;
 # endif
@@ -590,13 +590,13 @@ int scanf(char *format, ...)
    /*drl added errno 09-19-2001 */ ;
 
 # ifdef STRICT
-/*@printflike@*/ 
-int sprintf (/*@out@*/ char *s, char *format, ...) 
+/*@printflike@*/
+int sprintf (/*@out@*/ char *s, char *format, ...)
    /*@warn bufferoverflowhigh "Buffer overflow possible with sprintf.  Recommend using snprintf instead"@*/
    /*@modifies *s@*/ ;
 # else
-///*@printflike@*/ 
-//int /*@alt void@*/ sprintf (/*@out@*/ char *s, char *format, ...) 
+///*@printflike@*/
+//int /*@alt void@*/ sprintf (/*@out@*/ char *s, char *format, ...)
 //   /*@warn bufferoverflowhigh "Buffer overflow possible with sprintf.  Recommend using snprintf instead"@*/
 //   /*@modifies *s@*/ ;
 # endif
@@ -607,7 +607,7 @@ int snprintf (/*@out@*/ char * /*pad:restrict*/ s, size_t n, const char * /*pad:
    /*@modifies s@*/
    /*@requires maxSet(s) >= (n - 1)@*/ ;
 
-/*@scanflike@*/ 
+/*@scanflike@*/
 int sscanf (/*@out@*/ char *s, char *format, ...) /*@modifies errno@*/ ;
    /* modifies extra arguments */
 
@@ -626,7 +626,7 @@ int vsnprintf (/*@out@*/ char *str, size_t size, const char *format, va_list ap)
      /*@requires maxSet(str) >= (size - 1)@*/ /* drl - this was size, size-1 in stdio.h */
      /*@modifies str@*/ ;
 
-int fgetc (FILE *stream) 
+int fgetc (FILE *stream)
    /*@modifies fileSystem, *stream, errno@*/ ;
 
 /*@null@*/ char *
@@ -649,7 +649,7 @@ int getc (/*@sef@*/ FILE *stream)
 
 int getchar (void) /*@globals stdin@*/ /*@modifies fileSystem, *stdin, errno@*/ ;
 
-/*@null@*/ char *gets (/*@out@*/ char *s) 
+/*@null@*/ char *gets (/*@out@*/ char *s)
    /*@warn bufferoverflowhigh
            "Use of gets leads to a buffer overflow vulnerability.  Use fgets instead"@*/
    /*@globals stdin@*/ /*@modifies fileSystem, *s, *stdin, errno@*/ ;
@@ -660,26 +660,26 @@ int putc (int /*@alt char@*/ c, /*@sef@*/ FILE *stream)
 
 int putchar (int /*@alt char@*/ c)
    /*:errorcode EOF:*/
-   /*@globals stdout@*/ 
-   /*@modifies fileSystem, *stdout, errno@*/ ; 
+   /*@globals stdout@*/
+   /*@modifies fileSystem, *stdout, errno@*/ ;
 
 int puts (const char *s)
    /*:errorcode EOF:*/
    /*@globals stdout@*/
-   /*@modifies fileSystem, *stdout, errno@*/ ; 
+   /*@modifies fileSystem, *stdout, errno@*/ ;
 
 int ungetc (int /*@alt char@*/ c, FILE *stream)
   /*@modifies fileSystem, *stream@*/ ;
       /*drl REMOVED errno 09-19-2001*/
 
-size_t 
+size_t
   fread (/*@out@*/ void *ptr, size_t size, size_t nobj, FILE *stream)
-  /*@modifies fileSystem, *ptr, *stream, errno@*/ 
+  /*@modifies fileSystem, *ptr, *stream, errno@*/
   /*requires maxSet(ptr) >= (size - 1) @*/
   /*@ensures maxRead(ptr) == (size - 1) @*/ ;
 
 size_t fwrite (void *ptr, size_t size, size_t nobj, FILE *stream)
-  /*@modifies fileSystem, *stream, errno@*/ 
+  /*@modifies fileSystem, *stream, errno@*/
   /*@requires maxRead(ptr) >= size @*/ ;
 
 int fgetpos (FILE *stream, /*@out@*/ fpos_t *pos)
@@ -694,7 +694,7 @@ int fseek (FILE *stream, long int offset, int whence)
 int fsetpos (FILE *stream, fpos_t *pos)
    /*@modifies fileSystem, *stream, errno@*/ ;
 
-long int ftell(FILE *stream) 
+long int ftell(FILE *stream)
    /*:errorcode -1:*/ /*@modifies errno*/ ;
 
 void rewind (FILE *stream) /*@modifies *stream@*/ ;
@@ -704,8 +704,8 @@ int feof (FILE *stream) /*@modifies errno@*/ ;
 
 int ferror (FILE *stream) /*@modifies errno@*/ ;
 
-void perror (/*@null@*/ char *s) 
-   /*@globals errno, stderr@*/ /*@modifies fileSystem, *stderr@*/ ; 
+void perror (/*@null@*/ char *s)
+   /*@globals errno, stderr@*/ /*@modifies fileSystem, *stderr@*/ ;
 
 /*
 ** stdlib.h
@@ -721,7 +721,7 @@ double strtod (char *s, /*@null@*/ /*@out@*/ char **endp)
 long strtol (char *s, /*@null@*/ /*@out@*/ char **endp, int base)
   /*@modifies *endp, errno@*/ ;
 
-unsigned long 
+unsigned long
   strtoul (char *s, /*@null@*/ /*@out@*/ char **endp, int base)
   /*@modifies *endp, errno@*/ ;
 
@@ -740,7 +740,7 @@ void srand (unsigned int seed) /*@modifies internalState@*/ ;
      /*@ensures maxSet(result) == (size - 1); @*/ ;
 
 /*end drl changed */
-     
+
 /* 11 June 1997: removed out on return value */
 
 /*
@@ -753,13 +753,13 @@ void srand (unsigned int seed) /*@modifies internalState@*/ ;
 */
 
 /*@null@*/ /*@only@*/ void *
-   realloc (/*@null@*/ /*@only@*/ /*@out@*/ /*@returned@*/ void *p, size_t size) 
+   realloc (/*@null@*/ /*@only@*/ /*@out@*/ /*@returned@*/ void *p, size_t size)
      /*@modifies *p@*/ /*@ensures maxSet(result) >= (size - 1) @*/;
 
 void free (/*@null@*/ /*@out@*/ /*@only@*/ void *p) /*@modifies p@*/ ;
 
-/*@constant int EXIT_FAILURE; @*/ 
-/*@constant int EXIT_SUCCESS; @*/ 
+/*@constant int EXIT_FAILURE; @*/
+/*@constant int EXIT_SUCCESS; @*/
 
 /*@exits@*/ void abort (void) /*@*/ ;
 /*@exits@*/ void exit (int status) /*@*/ ;
@@ -770,17 +770,17 @@ int atexit (void (*func)(void)) /*@modifies internalState@*/ ;
 int system (/*@null@*/ char *s) /*@modifies fileSystem@*/ ;
 
 /*@null@*/ /*@dependent@*/ void *
-  bsearch (void *key, void *base, 
-	   size_t n, size_t size, 
+  bsearch (void *key, void *base,
+	   size_t n, size_t size,
 	   int (*compar)(void *, void *)) /*@*/ ;
 
-void qsort (void *base, size_t n, size_t size, 
+void qsort (void *base, size_t n, size_t size,
 		   int (*compar)(void *, void *))
    /*@modifies *base, errno@*/ ;
 
 int abs (int n) /*@*/ ;
 
-typedef /*@concrete@*/ struct 
+typedef /*@concrete@*/ struct
 {
   int quot;
   int rem;
@@ -788,9 +788,9 @@ typedef /*@concrete@*/ struct
 
 div_t div (int num, int denom) /*@*/ ;
 
-long int labs (long int n) /*@*/ ; 
+long int labs (long int n) /*@*/ ;
 
-typedef /*@concrete@*/ struct 
+typedef /*@concrete@*/ struct
 {
   long int quot;
   long int rem;
@@ -821,7 +821,7 @@ wint_t fputwc (wchar_t c, FILE *stream)
 int fputws (const wchar_t *s, FILE *stream)
    /*@modifies fileSystem, *stream@*/ ;
 
-int fwide (FILE *stream, int mode) /*@*/ ; 
+int fwide (FILE *stream, int mode) /*@*/ ;
    /* does not modify the stream */
 
 /*@printflike@*/ int fwprintf (FILE *stream, const wchar_t *format, ...)
@@ -838,13 +838,13 @@ wint_t getwchar (void) /*@modifies fileSystem, *stdin@*/;
 size_t mbrlen (const char *s, size_t n, /*@null@*/ mbstate_t *ps) /*@*/ ;
 
 size_t mbrtowc (/*@null@*/ wchar_t *pwc, const char *s, size_t n,
-		       /*@null@*/ mbstate_t *ps) 
+		       /*@null@*/ mbstate_t *ps)
    /*@modifies *pwc@*/ ;
 
 int mbsinit (/*@null@*/ const mbstate_t *ps) /*@*/ ;
 
 size_t mbsrtowcs (/*@null@*/ wchar_t *dst, const char **src, size_t len,
-			 /*@null@*/ mbstate_t *ps) 
+			 /*@null@*/ mbstate_t *ps)
    /*@modifies *dst@*/ ;
 
 /* note use of sef --- stream may be evaluated more than once */
@@ -884,28 +884,28 @@ int wcscmp (const wchar_t *s1, const wchar_t *s2) /*@*/ ;
 
 int wcscoll (const wchar_t *s1, const wchar_t *s2) /*@*/ ;
 
-void /*@alt wchar_t *@*/ 
+void /*@alt wchar_t *@*/
   wcscpy (/*@unique@*/ /*@out@*/ /*@returned@*/ wchar_t *s1, const wchar_t *s2)
   /*@modifies *s1@*/ ;
 
 size_t wcscspn (const wchar_t *s1, const wchar_t *s2) /*@*/ ;
 
 size_t wcsftime (/*@out@*/ wchar_t *s, size_t maxsize, const wchar_t *format,
-			const struct tm *timeptr) 
+			const struct tm *timeptr)
    /*@modifies *s@*/ ;
 
 size_t wcslen (const wchar_t *s) /*@*/ ;
 
 void /*@alt wchar_t *@*/
   wcsncat (/*@unique@*/ /*@returned@*/ /*@out@*/ wchar_t *s1, const wchar_t *s2,
-	   size_t n) 
+	   size_t n)
   /*@modifies *s1@*/ ;
 
 int wcsncmp (const wchar_t *s1, const wchar_t *s2, size_t n) /*@*/ ;
 
 void /*@alt wchar_t *@*/
   wcsncpy (/*@unique@*/ /*@returned@*/ /*@out@*/ wchar_t *s1, const wchar_t *s2,
-	   size_t n) 
+	   size_t n)
    /*@modifies *s1@*/ ;
 
 /*@null@*/ wchar_t *
@@ -918,7 +918,7 @@ void /*@alt wchar_t *@*/
 
 size_t
   wcsrtombs (/*@null@*/ char *dst, const wchar_t **src, size_t len,
-	     /*@null@*/ mbstate_t *ps) 
+	     /*@null@*/ mbstate_t *ps)
   /*@modifies *src@*/ ;
 
 size_t wcsspn (const wchar_t *s1, const wchar_t *s2) /*@*/ ;
@@ -1013,9 +1013,9 @@ wctrans_t wctrans (const char *property)	/*@*/ ;
 wctype_t wctype (const char *property) /*@*/ ;
 
 int mblen (char *s, size_t n) /*@*/ ;
-int mbtowc (/*@null@*/ wchar_t *pwc, /*@null@*/ char *s, size_t n) 
+int mbtowc (/*@null@*/ wchar_t *pwc, /*@null@*/ char *s, size_t n)
    /*@modifies *pwc@*/ ;
-int wctomb (/*@out@*/ /*@null@*/ char *s, wchar_t wchar) 
+int wctomb (/*@out@*/ /*@null@*/ char *s, wchar_t wchar)
    /*@modifies *s@*/ ;
 size_t mbstowcs (/*@out@*/ wchar_t *pwcs, char *s, size_t n)
   /*@modifies *pwcs@*/ ;
@@ -1025,9 +1025,9 @@ size_t wcstombs (/*@out@*/ char *s, wchar_t *pwcs, size_t n)
 /*
 ** string.h
 */
-     
+
 void /*@alt void * @*/
-  memcpy (/*@unique@*/ /*@returned@*/ /*@out@*/ void *s1, void *s2, size_t n) 
+  memcpy (/*@unique@*/ /*@returned@*/ /*@out@*/ void *s1, void *s2, size_t n)
   /*@modifies *s1@*/
      /*@requires maxRead(s2) >= (n - 1) /\ maxSet(s1) >= (n - 1); @*/
      ;
@@ -1038,42 +1038,42 @@ void /*@alt void * @*/
   /*@requires maxRead(s2) >= (n - 1) /\ maxSet(s1) >= (n - 1); @*/
    ;
 
-  
+
   /* drl
      modifed  12/29/2000
   */
 
-void /*@alt char * @*/ 
-  strcpy (/*@unique@*/ /*@out@*/ /*@returned@*/ char *s1, char *s2) 
-     /*@modifies *s1@*/ 
+void /*@alt char * @*/
+  strcpy (/*@unique@*/ /*@out@*/ /*@returned@*/ char *s1, char *s2)
+     /*@modifies *s1@*/
      /*@requires maxSet(s1) >= maxRead(s2) @*/
      /*@ensures maxRead(s1) == maxRead (s2) /\ maxRead(result) == maxRead(s2) /\ maxSet(result) == maxSet(s1); @*/;
 
 void /*@alt char * @*/
-  strncpy (/*@unique@*/ /*@out@*/ /*@returned@*/ char *s1, char *s2, size_t n) 
-     /*@modifies *s1@*/ 
+  strncpy (/*@unique@*/ /*@out@*/ /*@returned@*/ char *s1, char *s2, size_t n)
+     /*@modifies *s1@*/
      /*@requires maxSet(s1) >= ( n - 1 ); @*/
-     /*@ensures maxRead (s2) >= maxRead(s1) /\ maxRead (s1) <= n; @*/ ; 
+     /*@ensures maxRead (s2) >= maxRead(s1) /\ maxRead (s1) <= n; @*/ ;
 
 void /*@alt char * @*/
-  strcat (/*@unique@*/ /*@returned@*/ char *s1, char *s2) 
+  strcat (/*@unique@*/ /*@returned@*/ char *s1, char *s2)
      /*@modifies *s1@*/ /*@requires maxSet(s1) >= (maxRead(s1) + maxRead(s2) );@*/
      /*@ensures maxRead(result) == (maxRead(s1) + maxRead(s2) );@*/;
 
 void /*@alt char * @*/
   strncat (/*@unique@*/ /*@returned@*/ char *s1, char *s2, size_t n)
-     /*@modifies *s1@*/ 
+     /*@modifies *s1@*/
      /*@requires maxSet(s1) >= ( maxRead(s1) + n); @*/
       /*@ensures maxRead(s1) >= (maxRead(s1) + n); @*/;
 
      /*drl end*/
-     
+
 int memcmp (void *s1, void *s2, size_t n) /*@*/ ;
 int strcmp (char *s1, char *s2) /*@*/ ;
 int strcoll (char *s1, char *s2) /*@*/ ;
 int strncmp (char *s1, char *s2, size_t n) /*@*/ ;
-size_t strxfrm (/*@out@*/ /*@null@*/ char *s1, char *s2, size_t n) 
-  /*@modifies *s1@*/ ;  /* s1 may be null only if n == 0 */ 
+size_t strxfrm (/*@out@*/ /*@null@*/ char *s1, char *s2, size_t n)
+  /*@modifies *s1@*/ ;  /* s1 may be null only if n == 0 */
 
 /*@null@*/ void *memchr (void *s, int c, size_t n) /*@*/ ;
 
@@ -1107,14 +1107,14 @@ size_t strspn (char *s, char *t) /*@*/ ;
   strtok (/*@returned@*/ /*@null@*/ char *s, char *t)
   /*@modifies *s, internalState, errno@*/ ;
 
-void /*@alt void *@*/ memset (/*@out@*/ /*@returned@*/ void *s, 
+void /*@alt void *@*/ memset (/*@out@*/ /*@returned@*/ void *s,
 				     int c, size_t n)
      /*@modifies *s@*/ /*@requires maxSet(s) >= (n - 1) @*/ /*@ensures maxRead(s) >= (n - 1) @*/ ;
 
 /*@observer@*/ char *strerror (int errnum) /*@*/ ;
 
 /*drl */
-size_t strlen (char *s) /*@*/ /*@ensures result == maxRead(s); @*/; 
+size_t strlen (char *s) /*@*/ /*@ensures result == maxRead(s); @*/;
 
 /*
 ** time.h
@@ -1145,7 +1145,7 @@ time_t mktime (struct tm *timeptr) /*@*/ ;
 time_t time (/*@null@*/ /*@out@*/ time_t *tp)
   /*@modifies *tp@*/ ;
 
-/*@observer@*/ char *asctime (struct tm *timeptr) 
+/*@observer@*/ char *asctime (struct tm *timeptr)
   /*@modifies errno*/ /*@ensures maxSet(result) == 25 /\  maxRead(result) == 25; @*/ ;
 
 /*@observer@*/ char *ctime (time_t *tp) /*@*/
@@ -1154,7 +1154,7 @@ time_t time (/*@null@*/ /*@out@*/ time_t *tp)
 /* 2003-11-01: remove null annotation: gmtima and localtime cannot return null */
 /*@observer@*/ struct tm *gmtime (time_t *tp) /*@*/ ;
 
-/*@observer@*/ struct tm *localtime (time_t *tp) 
+/*@observer@*/ struct tm *localtime (time_t *tp)
   /*@modifies errno@*/ ;
 
 size_t strftime (/*@out@*/ char *s, size_t smax,
@@ -1225,7 +1225,7 @@ size_t strftime (/*@out@*/ char *s, size_t smax,
 //typedef /*@unsignedintegraltype@*/ uintmax_t;
 
 /*
-** What should the types be here? 
+** What should the types be here?
 */ /*#*/
 
 /*@constant int INT8_MIN@*/
@@ -1377,7 +1377,7 @@ extern int closedir (DIR *dirp)
 
    /*drl 1/4/2001 added the dependent annotation as suggested by
      Ralf Wildenhues */
-   
+
 extern /*@null@*/ /*@dependent@*/ DIR *opendir (const char *dirname)
    /*@modifies errno, fileSystem@*/;
 
@@ -1488,7 +1488,7 @@ extern void rewinddir (DIR *dirp)
 /*@constant int O_NONBLOCK@*/
 
 /*@constant int O_RDONLY@*/
-#define O_RDONLY 2 
+#define O_RDONLY 2
 /*@constant int O_RDWR@*/
 #define O_RDWR 2
 /*@constant int O_TRUNC@*/
@@ -1729,7 +1729,7 @@ typedef struct {
 
 typedef union {
   int    sival_int;
-  void  *sival_ptr;    
+  void  *sival_ptr;
 } sigval;
 
 struct sigaction {
@@ -1738,7 +1738,7 @@ struct sigaction {
   int sa_flags;
   void (*sa_sigaction)(int, siginfo_t *, void *); /* Added 2003-06-13: Noticed by Jerry James */
 } ;
- 
+
 	extern /*@mayexit@*/ int
 kill (pid_t pid, int sig)
 	/*@modifies errno@*/;
@@ -1810,12 +1810,12 @@ struct stat {
 } ;
 /*
 ** evans 2004-05-19: dependent annotations atted for time_t fields.  Could not find
-** any clear documetation on this, but it seems to be correct. 
+** any clear documetation on this, but it seems to be correct.
 */
 
 /*
 ** POSIX does not require that the S_I* be functions. They're
-** macros virtually everywhere. 
+** macros virtually everywhere.
 */
 
 # ifdef STRICT
@@ -1823,7 +1823,7 @@ struct stat {
 //# define SBOOLINT _Bool /*@alt int@*/
 # else
 /*@notfunction@*/
-//# define SBOOLINT _Bool           
+//# define SBOOLINT _Bool
 # endif
 
 //extern SBOOLINT S_ISBLK (/*@sef@*/ mode_t m) /*@*/ ;
@@ -1838,13 +1838,13 @@ struct stat {
 
 int chmod (const char *path, mode_t mode)
      /*@modifies fileSystem, errno@*/ ;
-     
+
 int fstat (int fd, /*@out@*/ struct stat *buf)
      /*@modifies errno, *buf@*/ ;
-     
+
 int mkdir (const char *path, mode_t mode)
      /*@modifies fileSystem, errno@*/;
-     
+
 int mkfifo (const char *path, mode_t mode)
      /*@modifies fileSystem, errno@*/;
 
@@ -2289,11 +2289,11 @@ typedef struct
 } regmatch_t;
 
 int regcomp (/*@out@*/ regex_t *preg, /*@nullterminated@*/ const char *regex, int cflags)
-   /*:statusreturn@*/ 
+   /*:statusreturn@*/
    /*@modifies preg@*/ ;
 
 int regexec (const regex_t *preg, /*@nullterminated@*/ const char *string, size_t nmatch, /*@out@*/ regmatch_t pmatch[], int eflags)
-   /*@requires maxSet(pmatch) >= nmatch@*/ 
+   /*@requires maxSet(pmatch) >= nmatch@*/
    /*@modifies pmatch@*/ ;
 
 size_t regerror (int errcode, const regex_t *preg, /*@out@*/ char *errbuf, size_t errbuf_size)
@@ -2407,7 +2407,7 @@ extern /*@unchecked@*/ int signgam;
 //typedef /*@integraltype@*/ clockid_t;
 /*@=redef@*/
 
-extern void bcopy (char *b1, /*@out@*/ char *b2, int length) 
+extern void bcopy (char *b1, /*@out@*/ char *b2, int length)
    /*@modifies *b2@*/ ;  /* Yes, the second parameter is the out param! */
 
 extern int /*@alt _Bool@*/ bcmp (char *b1, char *b2, int length) /*@*/ ;
@@ -2417,12 +2417,12 @@ extern void bzero (/*@out@*/ char *b1, int length) /*@modifies *b1@*/ ;
 extern int ffs (int i) /*@*/ ;
 extern int symlink (char *name1, char *name2) /*@modifies fileSystem@*/ ;
 
-extern int 
-  setvbuf_unlocked (FILE *stream, /*@null@*/ /*@exposed@*/ char *buf, 
+extern int
+  setvbuf_unlocked (FILE *stream, /*@null@*/ /*@exposed@*/ char *buf,
 		    int mode, size_t size)
   /*@modifies internalState@*/ ;
 
-extern void 
+extern void
   setbuffer (FILE *stream, /*@null@*/ /*@exposed@*/ char *buf, int size)
   /*@modifies internalState@*/ ;
 
@@ -2431,18 +2431,18 @@ extern void setlinebuf (FILE *stream) /*@modifies internalState@*/ ;
 extern int strerror_r (int errnum, /*@out@*/ char *strerrbuf, int buflen)
   /*@modifies strerrbuf@*/ ;
 
-extern size_t 
-  fread_unlocked (/*@out@*/ void *ptr, size_t size, size_t nitems, 
-		  FILE *stream) 
+extern size_t
+  fread_unlocked (/*@out@*/ void *ptr, size_t size, size_t nitems,
+		  FILE *stream)
   /*@modifies *stream, *ptr;@*/ ;
 
-extern size_t 
+extern size_t
   fwrite_unlocked (void *pointer, size_t size, size_t num_items, FILE *stream)
   /*@modifies *stream;@*/ ;
 
-extern void /*@alt void * @*/ 
-  memccpy (/*@returned@*/ /*@out@*/ void *s1, 
-	   /*@unique@*/ void *s2, int c, size_t n) 
+extern void /*@alt void * @*/
+  memccpy (/*@returned@*/ /*@out@*/ void *s1,
+	   /*@unique@*/ void *s2, int c, size_t n)
   /*@modifies *s1@*/ ;
 
 extern int strcasecmp (char *s1, char *s2) /*@*/ ;
@@ -2459,7 +2459,7 @@ extern /*@null@*/ /*@dependent@*/ char *
 //These are in ISO C99.  Moved to standard.h:
 //   extern double cbrt (double x) /*@modifies errno@*/ ;
 //   extern double rint (double x) /*@*/ ;
-//   extern double trunc (double x) /*@*/ ; 
+//   extern double trunc (double x) /*@*/ ;
 //# endif
 
 
@@ -2572,11 +2572,11 @@ extern /*@null@*/ /*@dependent@*/ char *
 /*@constant double M_2_PI@*/
 /*@constant double M_2_SQRTPI@*/
 /*@constant double M_SQRT2@*/
-/*@constant double M_SQRT1_2@*/ 
+/*@constant double M_SQRT1_2@*/
 
 /*@constant double MAXFLOAT@*/
 /*@constant double HUGE@*/
- 
+
 /*@constant int DOMAIN@*/
 /*@constant int SING@*/
 /*@constant int OVERFLOW@*/
@@ -2608,17 +2608,17 @@ typedef volatile unsigned long vulong_t;
 typedef long label_t;
 typedef int level_t;
 //typedef	/*@integraltype@*/ daddr_t;
-typedef	char *caddr_t;	
-typedef long *qaddr_t; 
+typedef	char *caddr_t;
+typedef long *qaddr_t;
 typedef char *addr_t;
 typedef long physadr_t;
 typedef short cnt_t;
-typedef	int chan_t;	
+typedef	int chan_t;
 typedef	int paddr_t;
 typedef	void *mid_t;
-typedef char slab_t[12];	
-typedef ulong_t	shmatt_t;	
-typedef ulong_t	msgqnum_t;	
+typedef char slab_t[12];
+typedef ulong_t	shmatt_t;
+typedef ulong_t	msgqnum_t;
 typedef ulong_t	msglen_t;
 typedef	uchar_t uchar;
 typedef	ushort_t ushort;
@@ -2637,7 +2637,7 @@ typedef u_long fixpt_t;
 typedef long segsz_t;
 //typedef /*@abstract@*/ fd_set;
 
-int ioctl (int d, int /*@alt long@*/ request, /*@out@*/ void *arg) 
+int ioctl (int d, int /*@alt long@*/ request, /*@out@*/ void *arg)
    /*@modifies *arg, errno@*/ ;  /* depends on request! */
 
 pid_t vfork (void) /*@modifies fileSystem@*/ ;
@@ -2820,7 +2820,7 @@ struct sockaddr_storage {
 } ;
 
 struct msghdr {
-  /*@dependent@*/ void *msg_name;		
+  /*@dependent@*/ void *msg_name;
   socklen_t msg_namelen;	/*: maxSet (msg_name) >= msg_namelen */
   /*@dependent@*/ struct iovec *msg_iov;	/* scatter/gather array */
   int msg_iovlen;		/* # elements in msg_iov */ /*: maxSet (msg_iov) >= msg_iovlen */
@@ -2842,8 +2842,8 @@ struct cmsghdr {
 /*@null@*/ /*@exposed@*/ struct cmsghdr *CMSG_FIRSTHDR (struct msghdr *) /*@*/ ;
 
 struct linger {
-  int l_onoff;	
-  int l_linger;	
+  int l_onoff;
+  int l_linger;
 };
 
 /*@constant int SOCK_DGRAM@*/
@@ -2916,20 +2916,20 @@ int connect (int s, const struct sockaddr *name, int namelen)
 int getpeername (int s, /*@out@*/ struct sockaddr */*restrict*/ name, socklen_t */*restrict*/ namelen)
   /*drl splint doesn't handle restrict yet*/
    /*@modifies *name, *namelen, errno@*/;
-	
+
 #ifdef STRICT
 
 int getsockname (int s, /*@out@*/ struct sockaddr *address, socklen_t *address_len)
-     /*@i556@*/  /*: can't do this? requires maxSet(address) >= (*address_len) @*/ 
+     /*@i556@*/  /*: can't do this? requires maxSet(address) >= (*address_len) @*/
   /*@modifies *address, *address_len, errno@*/;
 
-#else  
+#else
 //int getsockname (int s, /*@out@*/ struct sockaddr *address, socklen_t  /*@alt size_t@*/ *address_len)
-  /*@i556@*/  /*: can't do this? requires maxSet(address) >= (*address_len) @*/ 
+  /*@i556@*/  /*: can't do this? requires maxSet(address) >= (*address_len) @*/
   /*@modifies *address, *address_len, errno@*/;
 
 #endif
-  
+
 int getsockopt (int s, int level, int optname, /*@out@*/ void *optval, size_t *optlen)
 	/*@modifies *optval, *optlen, errno@*/;
 
@@ -3157,7 +3157,7 @@ mprotect (caddr_t addr, int len, int prot)
 	extern int
 	munmap (/*@only@*/ caddr_t addr, size_t len)
      /*@modifies fileSystem, *addr, errno @*/;
-    
+
 	extern int
 msync (caddr_t addr, int len, int flags)
 	/*@*/;
@@ -3262,7 +3262,7 @@ extern int fsync (int fd) /*@modifies errno, fileSystem@*/;
 
 extern int ftruncate (int fd, off_t length) /*@modifies errno, fileSystem@*/;
 
-int gethostname (/*@out@*/ char *address, size_t address_len) 
+int gethostname (/*@out@*/ char *address, size_t address_len)
    /*:errorstatus@*/
    /*@modifies address@*/ ;
 
@@ -3271,8 +3271,8 @@ int initgroups (const char *name, int basegid)
 
 int lchown (const char *path, uid_t owner, gid_t group)
      /*@modifies errno, fileSystem@*/;
-     
-int select (int mfd, fd_set /*@null@*/ *r, fd_set /*@null@*/ *w, 
+
+int select (int mfd, fd_set /*@null@*/ *r, fd_set /*@null@*/ *w,
 	    fd_set /*@null@*/ *e, /*@null@*/ struct timeval *t)
   /*@modifies *r, *w, *e, *t, errno@*/;
   /* evans - 2002-05-26: added null for t, bug reported by Enrico Scholz */
@@ -3282,25 +3282,25 @@ int setegid (gid_t egid)
 
 int seteuid (uid_t euid)
    /*@modifies errno, internalState@*/;
-     
+
 int setgroups (int ngroups, const gid_t *gidset)
    /*@modifies errno, internalState@*/;
-     
+
 int setregid (gid_t rgid, gid_t egid)
    /*@modifies errno, internalState@*/;
-     
+
 int setreuid (gid_t ruid, gid_t euid)
    /*@modifies errno, internalState@*/;
-     
+
 void sync (void)
    /*@modifies fileSystem@*/;
-     
+
 //int symlink (const char *path, const char *path2)
 //   /*@modifies fileSystem@*/;
-     
+
 int truncate (const char *name, off_t length)
    /*@modifies errno, fileSystem@*/;
-     
+
 /*@constant int EBADRPC@*/
 /*@constant int ERPCMISMATCH@*/
 /*@constant int EPROGUNAVAIL@*/
@@ -3505,7 +3505,7 @@ semop (int id, struct sembuf *semoparray, size_t nops)
 
 void * shmat (int id, /*@null@*/ void *addr, int flag)
      /*@modifies errno@*/ ;
-     
+
 extern int shmctl (int id, int cmd, /*@out@*/ struct shmid_ds *buf)
      /*@modifies errno, *buf@*/ ;
 
@@ -3563,22 +3563,22 @@ extern int shmget (key_t key, int size, int flag)
 
 int LOG_MASK (int pri)
      /*@*/;
-     
+
 int LOG_UPTO (int pri)
      /*@*/;
-     
+
 void closelog (void)
      /*@modifies fileSystem@*/;
-     
+
 void openlog (const char *ident, int logopt, int facility)
      /*@modifies fileSystem@*/;
-     
+
 int setlogmask (int maskpri)
      /*@modifies internalState@*/;
-     
+
 void /*@printflike@*/ syslog (int priority, const char *message, ...)
      /*@modifies fileSystem@*/;
-     
+
 void vsyslog (int priority, const char *message, va_list args)
      /*@modifies fileSystem@*/;
 
@@ -3707,7 +3707,7 @@ int /*@alt _Bool@*/ S_TYPEISSHM  (/*@sef@*/ struct stat *buf) /*@*/ ;
 int lstat(const char *, /*@out@*/ struct stat *)
      /*:errorcode -1:*/
      /*@modifies errno@*/ ;
-     
+
 int mknod (const char *, mode_t, dev_t)
   /*@warn portability "The only portable use of mknod is to create FIFO-special file. If mode is not S_IFIFO or dev is not 0, the behaviour of mknod() is unspecified."@*/
   /*:errorcode -1:*/
@@ -3722,9 +3722,9 @@ int fchflags (int fd, u_long flags)
   /*@modifies fileSystem, errno@*/;
 
 /* evans 2002-03-17: this was missing, reported by Ralf Wildenhues */
-int fchmod(int fildes, mode_t mode) 
-   /*@modifies fileSystem, errno@*/ ; 
-  
+int fchmod(int fildes, mode_t mode)
+   /*@modifies fileSystem, errno@*/ ;
+
 /*
 ** sys/statvfs.h
 ** from http://www.opengroup.org/onlinepubs/007908799/xsh/sysstatvfs.h.html
@@ -3738,20 +3738,20 @@ struct statvfs {
    fsblkcnt_t    f_bavail;
    fsfilcnt_t    f_files;
    fsfilcnt_t    f_ffree;
-   fsfilcnt_t    f_favail;                       
+   fsfilcnt_t    f_favail;
    unsigned long f_fsid;
    unsigned long f_flag;
-   unsigned long f_namemax; 
+   unsigned long f_namemax;
 } ;
 
 /*@constant unsigned long ST_RDONLY; @*/
 /*@constant unsigned long ST_NOSUID; @*/
 
-int fstatvfs (int fildes, /*@out@*/ struct statvfs *buf) 
+int fstatvfs (int fildes, /*@out@*/ struct statvfs *buf)
    /*@modifies buf@*/ ;
 
 int statvfs (const char *path, /*@out@*/ struct statvfs *buf)
-    /*@modifies buf@*/ ; 
+    /*@modifies buf@*/ ;
 
 
 /*________________________________________________________________________
@@ -3870,10 +3870,10 @@ struct servent
   /*@observer@*/ char *s_proto;		        /* Protocol to use.  */
 } ;
 
-/*@observer@*/ /*@dependent@*/ /*@null@*/ struct servent *getservbyname (const char *name, /*@null@*/ const char *proto) 
+/*@observer@*/ /*@dependent@*/ /*@null@*/ struct servent *getservbyname (const char *name, /*@null@*/ const char *proto)
      /*@warn multithreaded "Unsafe in multithreaded applications, use getsrvbyname_r instead"@*/ ;
 
-struct servent *getservbyname_r (const char *name, /*@null@*/ const char *proto, /*@out@*/ /*@returned@*/ struct servent *result, /*@out@*/ char *buffer, int buflen) 
+struct servent *getservbyname_r (const char *name, /*@null@*/ const char *proto, /*@out@*/ /*@returned@*/ struct servent *result, /*@out@*/ char *buffer, int buflen)
      /*@requires maxSet (buffer) >= buflen@*/ ;
 
 
@@ -3893,19 +3893,19 @@ int endservent (void);
 extern int h_errno;
 
 /*@null@*/ /*@observer@*/ struct hostent *gethostbyname (/*@nullterminated@*/ /*@notnull@*/ const char *name)
-     /*@warn multithreaded "Unsafe in multithreaded applications, use gethostbyname_r instead"@*/ 
+     /*@warn multithreaded "Unsafe in multithreaded applications, use gethostbyname_r instead"@*/
      /*@modifies h_errno@*/ ;
 
 struct hostent *gethostbyname_r (/*@nullterminated@*/ const char *name, /*@notnull@*/ /*@returned@*/ struct hostent *hent, /*@out@*/ /*@exposed@*/ char *buffer, int bufsize, /*@out@*/ int *h_errnop)
      /*@requires maxSet(buffer) >= bufsize@*/ ;
 
-/*@null@*/ /*@observer@*/ struct hostent *gethostbyaddr (/*@notnull@*/ const void *addr, size_t addrlen, int type) 
+/*@null@*/ /*@observer@*/ struct hostent *gethostbyaddr (/*@notnull@*/ const void *addr, size_t addrlen, int type)
      /*@requires maxRead(addr) == addrlen@*/ /*:i534 ??? is this right? */
-     /*@warn multithreaded "Unsafe in multithreaded applications, use gethostbyaddr_r instead"@*/ 
+     /*@warn multithreaded "Unsafe in multithreaded applications, use gethostbyaddr_r instead"@*/
      /*@modifies h_errno@*/ ;
 
-struct hostent *gethostbyaddr_r (/*@notnull@*/ const void *addr, size_t addrlen, int type, 
-				 /*@returned@*/ /*@out@*/ struct hostent *hent, 
+struct hostent *gethostbyaddr_r (/*@notnull@*/ const void *addr, size_t addrlen, int type,
+				 /*@returned@*/ /*@out@*/ struct hostent *hent,
 				 /*@exposed@*/ /*@out@*/ char *buffer, int bufsize, /*@out@*/ int *h_errnop)
      /*@requires maxRead(addr) == addrlen /\ maxSet(buffer) >= bufsize@*/
      /*:i534 ??? is this right? */ ;
@@ -4265,9 +4265,9 @@ int nice(int)
 ssize_t pread(int, /*@out@*/ void *buf, size_t nbyte, off_t offset)
      /*@modifies errno, fileSystem@*/
      /*@requires maxSet(buf) >= (nbyte - 1) @*/
-     /*@ensures maxRead(buf) >= nbyte @*/ 
+     /*@ensures maxRead(buf) >= nbyte @*/
      /*:errorcode -1:*/ ;
-     
+
 int pthread_atfork(void (*)(void), void (*)(void), void(*)(void))
      /*@modifies errno, fileSystem@*/
      /*:errorcode !0:*/ ;
@@ -4357,7 +4357,7 @@ useconds_t ualarm(useconds_t, useconds_t)
 //int unlink(const char *)
 //     /*@modifies fileSystem, errno@*/
 //     /*:errorcode -1:*/ ;
-//     
+//
 //int usleep(useconds_t)
 //     /*@modifies fileSystem, errno@*/
 //     /*:errorcode -1:*/ ;
@@ -4371,7 +4371,7 @@ useconds_t ualarm(useconds_t, useconds_t)
 //
 //int chroot (/*@notnull@*/ /*@nullterminated@*/ const char *path)
 //     /*@modifies internalState, errno@*/
-//     /*:errorcode -1:*/ 
+//     /*:errorcode -1:*/
 //     /*@warn superuser "Only super-user processes may call chroot."@*/ ;
 //
 //int fchroot (int fildes)
@@ -4380,7 +4380,7 @@ useconds_t ualarm(useconds_t, useconds_t)
 
 
 /*
-** ctype.h 
+** ctype.h
 **
 ** evans 2001-08-26 - added from http://www.opengroup.org/onlinepubs/007908799/xsh/ctype.h.html
 */
@@ -4405,11 +4405,11 @@ char  _tolower(/*@sef@*/ int) /*@*/ ;
 ** evans 2001-08-27 - added from http://www.opengroup.org/onlinepubs/007908799/xsh/drand48.html
 */
 
-double drand48 (void) /*@modifies internalState@*/ ; 
-double erand48 (unsigned short int /*@-fixedformalarray@*/ xsubi[3] /*@=fixedformalarray@*/ ) 
-   /*@modifies internalState@*/ ; 
+double drand48 (void) /*@modifies internalState@*/ ;
+double erand48 (unsigned short int /*@-fixedformalarray@*/ xsubi[3] /*@=fixedformalarray@*/ )
+   /*@modifies internalState@*/ ;
 
-void srand48 (long int seedval) /*@modifies internalState@*/ ; 
+void srand48 (long int seedval) /*@modifies internalState@*/ ;
 
 /*
 ** netinet/in.h
@@ -4434,8 +4434,8 @@ struct sockaddr_in {
 } ;
 
 
-/* The <netinet/in.h> header defines the following macros for use as values of the level argument of 
-   getsockopt() and setsockopt(): 
+/* The <netinet/in.h> header defines the following macros for use as values of the level argument of
+   getsockopt() and setsockopt():
  */
 
 /*@constant int IPPROTO_IP@*/
@@ -4443,7 +4443,7 @@ struct sockaddr_in {
 /*@constant int IPPROTO_TCP@*/
 /*@constant int IPPROTO_UDP@*/
 
-/* The <netinet/in.h> header defines the following macros for use as destination addresses for connect(), sendmsg() and sendto(): 
+/* The <netinet/in.h> header defines the following macros for use as destination addresses for connect(), sendmsg() and sendto():
  */
 
 /*@constant in_addr_t INADDR_ANY@*/
@@ -4469,7 +4469,7 @@ in_port_t ntohs (in_port_t netshort) /*@*/ ;
 struct dirent
 {
   ino_t  d_ino;
-  char   d_name[];    
+  char   d_name[];
 } ;
 
 /*@=redef@*/ /*@=matchfields@*/
@@ -4478,7 +4478,7 @@ struct dirent
 
 /*:i32 need to check annotations on these */
 
-//int closedir (DIR *) /*:errorcode -1*/ ; 
+//int closedir (DIR *) /*:errorcode -1*/ ;
 ///*@null@*/ /*@dependent@*/ DIR *opendir(const char *)  /*@modifies errno, fileSystem@*/ ;
 //
 ///* in posix.h: struct dirent *readdir(DIR *); */
@@ -4511,16 +4511,16 @@ extern char * stpncpy(/*@out@*/ /*@returned@*/ char * dest,
 		      const char * src, size_t n)
            /*@modifies *dest @*/
    /*@requires MaxSet(dest) >= ( n - 1 ); @*/ /*@ensures MaxRead (src) >= MaxRead(dest) /\ MaxRead (dest) <= n; @*/
-  ; 
+  ;
 
   /* drl added 09-25-001
-     Alexander Ma pointed out these were missing 
+     Alexander Ma pointed out these were missing
   */
-  
+
 int usleep (useconds_t useconds) /*@modifies systemState, errno@*/
      /*error -1 sucess 0 */
      /* warn opengroup unix specification recommends using setitimer(), timer_create(), timer_delete(), timer_getoverrun(), timer_gettime() or
-     timer_settime() instead of this interface. 
+     timer_settime() instead of this interface.
      */
      ;
 
@@ -4531,7 +4531,7 @@ int usleep (useconds_t useconds) /*@modifies systemState, errno@*/
       */
      /*I'm going to assume that the address had the format:
        "###.###.###.###" which is 16 bytes*/
-     
+
        /*@kept@*/ char *inet_ntoa(struct in_addr in)
      /*@ensures maxSet(result) <= 15 /\ maxRead(result) <= 15 @*/
      ;
@@ -4550,20 +4550,20 @@ int usleep (useconds_t useconds) /*@modifies systemState, errno@*/
 
 //     extern       double acosh(double x)  /*@modifies errno @*/ /*error errno and implementation-dependent(NaN if present) */ /*error NaN and may errno*/;
 //     extern       double asinh(double x) /*@modifies errno @*/  /*error NaN and may errno */;
-//     
+//
 //  extern        double atanh(double x) /*@modifies errno @*/ /*error errno and implementation-dependent(NaN if present) */ /*error NaN and may errno */ ;
 
 //     extern         double lgamma(double x)  /*@modifies errno @*/  /*error NaN or HUGE_VAL may set errno */;
-//     
+//
 //     extern int signgam ;
-//     
+//
 //      extern      double erf(double x)  /*@modifies errno @*/  /*error NaN or 0 may set errno */;
 //
 //   extern      double erfc (double x) /*@modifies errno @*/  /*error NaN or 0
 //					may set errno */;
 
-     
 
-     
-     
+
+
+
 

--- a/config/macros/common_macros.h
+++ b/config/macros/common_macros.h
@@ -8,16 +8,16 @@
  * be considered as a declaration with XX being a typedef, so would
  * Have ambiguity. So at least by adding this special case, we can
  * catch more correct string-macro, no more a XX YY but now a good
- * "XX" YY 
- * 
+ * "XX" YY
+ *
  * cf include/linux/kernel.h
  *
- * For stringification I need to have at least a witness, a string, 
+ * For stringification I need to have at least a witness, a string,
  * and sometimes have just printk(KERN_WARNING MYSTR) and it could
  * be transformed in a typedef later, so better to at least
  * transform in string already the string-macro we know.
- * 
- * Perhaps better to apply also as soon as possible the 
+ *
+ * Perhaps better to apply also as soon as possible the
  * correct macro-annotation tagging (__init & co) to be able to
  * filter them as soon as possible so that they will not polluate
  * our pattern-matching that come later.
@@ -26,15 +26,15 @@
 //#define  KERN_DEBUG "KERN_DEBUG"
 
 
-/* EX_TABLE & co. 
+/* EX_TABLE & co.
  *
  * Replaced by a string. We can't put everything as comment
  * because it can be part of an expression where we wait for
- * something, where we wait for a string. So at least we 
+ * something, where we wait for a string. So at least we
  * must keep the EX_TABLE token and transform it as a string.
  *
- * normally not needed if have good stringification of macro 
- * but those macros are sometimes used multiple times 
+ * normally not needed if have good stringification of macro
+ * but those macros are sometimes used multiple times
  * as in EX_TABLE(0b) EX_TABLE(1b)  and we don't detect
  * it well yet.
  */
@@ -52,7 +52,7 @@
 
 // also static DECLARATOR(x);
 
-// also LIST_HEAD stuff 
+// also LIST_HEAD stuff
 // used in qemu, freebsd
 
 // ****************************************************************************
@@ -88,7 +88,7 @@
 // const, often defined via macro for backward compatibility with old compiler
 // I guess.
 
-// 
+//
 
 // private/public
 
@@ -111,7 +111,7 @@
  */
 
 // #define uninitialized_var(x) x = x
-// as in u16 uninitialized_var(ioboard_type);	/* GCC be quiet */ 
+// as in u16 uninitialized_var(ioboard_type);	/* GCC be quiet */
 
 
 // ****************************************************************************
@@ -123,7 +123,7 @@
 // GENTEST, GENHEADER
 
 // structure
-// MACHINE_START 
+// MACHINE_START
 
 // iterator defined two times
 

--- a/config/macros/common_windows.h
+++ b/config/macros/common_windows.h
@@ -1,2 +1,2 @@
 
-//WINAPI, etc 
+//WINAPI, etc

--- a/config/macros/macros_apache.h
+++ b/config/macros/macros_apache.h
@@ -1,5 +1,5 @@
 // ****************************************************************************
-// Httpd (apache) macros 
+// Httpd (apache) macros
 // ****************************************************************************
 
 #define AP_DECLARE(x) x
@@ -30,7 +30,7 @@
 #define EXPORT static
 #define REGISTER register
 
-#define MODSSL_D2I_SSL_SESSION_CONST const 
+#define MODSSL_D2I_SSL_SESSION_CONST const
 #define MODSSL_D2I_X509_CONST const
 #define MODSSL_D2I_PrivateKey_CONST const
 #define MODSSL_D2I_SSL_SESSION_CONST const

--- a/config/macros/macros_emacs.h
+++ b/config/macros/macros_emacs.h
@@ -1,9 +1,9 @@
-// time: 
+// time:
 //  start 18h07 62%
 //        18h35 84.42%
 //               95% (fix old C decl typedef pb)
-//        + 30min 96.1 
-/* remaining main pbs: 
+//        + 30min 96.1
+/* remaining main pbs:
  *  'xxx' unicode character
  *  foo(void) { },    function with no return type and often old C decl style
  */
@@ -114,7 +114,7 @@
 //bad: {
 
 //BAD:!!!!! extern int regcomp _RE_ARGS ((regex_t *__restrict __preg,
-//#define __restrict 
+//#define __restrict
 
 //BAD:!!!!! extern int getopt_long (int ___argc, char *__getopt_argv_const *___argv,
 //bad: 			const char *__shortopts,

--- a/config/macros/macros_gcc.h
+++ b/config/macros/macros_gcc.h
@@ -1,10 +1,10 @@
-// time: ? 
+// time: ?
 //   10min + 20min + 10min: 96.72%
 
 // ****************************************************************************
-// Gcc (as in the source of gcc code) macros 
+// Gcc (as in the source of gcc code) macros
 // ****************************************************************************
-//BAD:!!!!! java_gimplify_self_mod_expr (tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED, 
+//BAD:!!!!! java_gimplify_self_mod_expr (tree *expr_p, gimple_seq *pre_p ATTRIBUTE_UNUSED,
 #define ATTRIBUTE_UNUSED
 
 //BAD:!!!!! static void help (void) ATTRIBUTE_NORETURN;
@@ -43,13 +43,13 @@
 //BAD:!!!!!   void (*p_msg) (const char *, ...) ATTRIBUTE_GCC_CXXDIAG(1,2);
 //BAD:!!!!! typedef void (*diagnostic_fn_t) (const char *, ...) ATTRIBUTE_GCC_CXXDIAG(1,2);
 //BAD:!!!!!   void (*p_msg) (const char *, ...) ATTRIBUTE_GCC_CXXDIAG(1,2);
-#define ATTRIBUTE_GCC_CXXDIAG(a,b) 
+#define ATTRIBUTE_GCC_CXXDIAG(a,b)
 
 //BAD:!!!!!      ATTRIBUTE_GCC_PPDIAG(2,3);
-#define ATTRIBUTE_GCC_PPDIAG(a,b) 
+#define ATTRIBUTE_GCC_PPDIAG(a,b)
 
 //BAD:!!!!! extern void error (const char *, ...) ATTRIBUTE_GCC_DIAG(1,2);
-#define ATTRIBUTE_GCC_DIAG(a,b) 
+#define ATTRIBUTE_GCC_DIAG(a,b)
 
 //BAD:!!!!! extern void pedwarn_c99 (int opt, const char *, ...) ATTRIBUTE_GCC_CDIAG(2,3);
 #define ATTRIBUTE_GCC_CDIAG(a,b)
@@ -57,7 +57,7 @@
 //bad: typedef struct gfc_symtree
 //bad: {
 //BAD:!!!!!   BBT_HEADER (gfc_symtree);
-#define BBT_HEADER(a) 
+#define BBT_HEADER(a)
 
 
 //BAD:!!!!! HAIFA_INLINE static rtx
@@ -74,7 +74,7 @@
 
 //BAD:!!!!! void gfc_warning (const char *, ...) ATTRIBUTE_GCC_GFC(1,2);
 //BAD:!!!!! void gfc_error (const char *, ...) ATTRIBUTE_GCC_GFC(1,2);
-#define ATTRIBUTE_GCC_GFC(a,b) 
+#define ATTRIBUTE_GCC_GFC(a,b)
 
 //bad: 	  EXECUTE_IF_SET_IN_BITMAP (gimple_call_clobbered_vars (cfun), 0, i, bi)
 //bad:     {
@@ -145,7 +145,7 @@
 
 
 //BAD:!!!!! typedef unsigned _Fract UDAtype __attribute__ ((mode (UDA)));
-#define _Fract 
+#define _Fract
 
 //BAD:!!!!! typedef _Complex float XCtype	__attribute__ ((mode (XC)));
 #define _Complex
@@ -165,7 +165,7 @@
 //BAD:!!!!! STATIC void
 #define STATIC static
 
-//PB false positif: 
+//PB false positif:
 //BAD:!!!!! char __gnat_shared_libgnat_default = STATIC;
 //ERROR-RECOV: found sync col 0 at line 108
 
@@ -197,11 +197,11 @@ BAD:!!!!! extern CONST_MODE_IBIT unsigned char mode_ibit[NUM_MACHINE_MODES];
 
 pad: why pb ?
  = File "/home/pad/software-src/devel/gcc-svn/gcc/hard-reg-set.h", line 432, column 0,  charpos = 14162
-    around = '', whole content = 
+    around = '', whole content =
 ERROR-RECOV: found sync end of #define 431
 badcount: 6
 bad:        *scan_tp_++ |= *scan_fp_++; } while (0)
-bad: 
+bad:
 bad: #define IOR_COMPL_HARD_REG_SET(TO, FROM)  \
 bad: do { HARD_REG_ELT_TYPE *scan_tp_ = (TO), *scan_fp_ = (FROM); 	\
 bad:      int i;							\

--- a/config/macros/macros_glibc.h
+++ b/config/macros/macros_glibc.h
@@ -1,5 +1,5 @@
-// time start 
-//      01h10  77.3% 
+// time start
+//      01h10  77.3%
 //      01h40  84%
 //      - +10 min
 //      17h02 86%
@@ -8,10 +8,10 @@
 //      19h13 90% (also added restrict C99 in lexer and grammar)
 //      20h23 92% (also added ifdef cplusplus handling in lexer)
 
-/* main pbs: 
-*    done: restrict typedef inference 
+/* main pbs:
+*    done: restrict typedef inference
 *    complex extension
-*/   
+*/
 
 //bad: char *
 //BAD:!!!!! internal_function
@@ -165,7 +165,7 @@
 //BAD:!!!!! __libc_lock_define_initialized_recursive (static, lock);
 #define __libc_lock_define_initialized_recursive(a,b) int foo;
 
-//BAD:!!!!!     __libc_lock_define (, lock) 
+//BAD:!!!!!     __libc_lock_define (, lock)
 #define __libc_lock_define (a,b) int foo;
 
 
@@ -179,7 +179,7 @@
 //bad: {
 //bad: static bool __libc_freeres_fn_section
 //BAD:!!!!! free_slotinfo (struct dtv_slotinfo_list **elemp)
-#define __libc_freeres_fn_section 
+#define __libc_freeres_fn_section
 
 //BAD:!!!!!   static __thread void *data attribute_tls_model_ie;
 //bad: void ** __attribute__ ((const))
@@ -191,7 +191,7 @@
 
 
 //BAD:!!!!!   char name __flexarr;
-#define __flexarr 
+#define __flexarr
 //
 //BAD:!!!!!   void *__unbounded result;
 #define __unbounded
@@ -223,7 +223,7 @@
 #define libc_hidden_proto(a)
 
 //bad: libc_hidden_def (__libc_dlclose)
-#define libc_hidden_def(a) 
+#define libc_hidden_def(a)
 
 
 //BAD:!!!!! LINKAGE int
@@ -268,7 +268,7 @@
 
 //BAD:!!!!! __MATH_INLINE float __NTH (fdimf (float __x, float __y));
 //BAD:!!!!! __MATH_INLINE int
-#define __MATH_INLINE 
+#define __MATH_INLINE
 
 //
 //BAD:!!!!! symbol_version (__novmx_longjmp,_longjmp,GLIBC_2.3);
@@ -312,15 +312,15 @@
 
 //BAD:!!!!! _HURD_THREADVAR_H_EXTERN_INLINE unsigned long int *
 //bad: __hurd_threadvar_location (enum __hurd_threadvar_index __index)
-#define _HURD_THREADVAR_H_EXTERN_INLINE 
+#define _HURD_THREADVAR_H_EXTERN_INLINE
 
 //BAD:!!!!! _HURD_SIGNAL_H_EXTERN_INLINE void
 //bad: _hurd_critical_section_unlock (void *our_lock)
-#define _HURD_SIGNAL_H_EXTERN_INLINE 
+#define _HURD_SIGNAL_H_EXTERN_INLINE
 
 //BAD:!!!!! _HURD_FD_H_EXTERN_INLINE int
 //bad: _hurd_fd_error_signal (error_t err)
-#define _HURD_FD_H_EXTERN_INLINE 
+#define _HURD_FD_H_EXTERN_INLINE
 //
 //BAD:!!!!! _HURD_H_EXTERN_INLINE int
 //bad: __hurd_fail (error_t err)
@@ -328,7 +328,7 @@
 
 //BAD:!!!!!   __malloc_ptr_t (*hook) __MALLOC_PMT ((size_t, size_t,
 //bad: 					__const __malloc_ptr_t)) =
-#define __MALLOC_PMT(a) a 
+#define __MALLOC_PMT(a) a
 
 //BAD:!!!!! static Void_t* memalign_hook_ini __MALLOC_P ((size_t alignment, size_t sz,
 //bad: 					      const __malloc_ptr_t caller));
@@ -336,13 +336,13 @@
 
 //BAD:!!!!! void weak_variable (*__free_hook) (__malloc_ptr_t __ptr,
 //bad: 				   const __malloc_ptr_t) = NULL;
-#define weak_variable 
+#define weak_variable
 
 
 //
 //BAD:!!!!! __complex__ double
 //bad: __clog10 (__complex__ double x)
-#define __complex__ 
+#define __complex__
 
 //bad: int
 //bad: __strcasecmp (s1, s2 LOCALE_PARAM)
@@ -374,15 +374,15 @@ bad: }
 
 //BAD:!!!!! _HURD_THREADVAR_H_EXTERN_INLINE unsigned long int *
 //bad: __hurd_threadvar_location (enum __hurd_threadvar_index __index)
-#define _HURD_THREADVAR_H_EXTERN_INLINE 
+#define _HURD_THREADVAR_H_EXTERN_INLINE
 
 //BAD:!!!!! _HURD_SIGNAL_H_EXTERN_INLINE void
 //bad: _hurd_critical_section_unlock (void *our_lock)
-#define _HURD_SIGNAL_H_EXTERN_INLINE 
+#define _HURD_SIGNAL_H_EXTERN_INLINE
 
 //BAD:!!!!! _HURD_FD_H_EXTERN_INLINE int
 //bad: _hurd_fd_error_signal (error_t err)
-#define _HURD_FD_H_EXTERN_INLINE 
+#define _HURD_FD_H_EXTERN_INLINE
 //
 //BAD:!!!!! _HURD_H_EXTERN_INLINE int
 //bad: __hurd_fail (error_t err)
@@ -390,7 +390,7 @@ bad: }
 
 //BAD:!!!!!   __malloc_ptr_t (*hook) __MALLOC_PMT ((size_t, size_t,
 //bad: 					__const __malloc_ptr_t)) =
-#define __MALLOC_PMT(a) a 
+#define __MALLOC_PMT(a) a
 
 //BAD:!!!!! static Void_t* memalign_hook_ini __MALLOC_P ((size_t alignment, size_t sz,
 //bad: 					      const __malloc_ptr_t caller));
@@ -398,13 +398,13 @@ bad: }
 
 //BAD:!!!!! void weak_variable (*__free_hook) (__malloc_ptr_t __ptr,
 //bad: 				   const __malloc_ptr_t) = NULL;
-#define weak_variable 
+#define weak_variable
 
 
 //
 //BAD:!!!!! __complex__ double
 //bad: __clog10 (__complex__ double x)
-#define __complex__ 
+#define __complex__
 
 //bad: int
 //bad: __strcasecmp (s1, s2 LOCALE_PARAM)
@@ -422,7 +422,7 @@ bad: }
 //bad: {
 //bad:   return &errno;
 //bad: }
-#define weak_const_function 
+#define weak_const_function
 
 
 //BAD:!!!!!   float two23 = copysignf (0x1.0p23, x);
@@ -435,15 +435,15 @@ bad: }
 #define timercmp(a,b,op) a op b
 
 //BAD:!!!!! _HURD_PORT_H_EXTERN_INLINE void
-#define _HURD_PORT_H_EXTERN_INLINE 
+#define _HURD_PORT_H_EXTERN_INLINE
 
 //BAD:!!!!! _HURD_USERLINK_H_EXTERN_INLINE int
 #define _HURD_USERLINK_H_EXTERN_INLINE
 
 //bad: weak_alias (__posix_memalign, posix_memalign)
-//bad: 
+//bad:
 //BAD:!!!!! strong_alias (__libc_calloc, __calloc) weak_alias (__libc_calloc, calloc)
-#define weak_alias(a,b) 
+#define weak_alias(a,b)
 #define strong_alias(a,b)
 //
 //BAD:!!!!!        __attribute_warn_unused_result__;
@@ -452,7 +452,7 @@ bad: }
 //
 //bad:       __real__ res = INFINITY;
 //bad:       __imag__ res = __copysign (0.0, __imag__ x);
-#define __real__ 
+#define __real__
 #define __imag__
 
 
@@ -463,7 +463,7 @@ bad: }
 //bad:   P ();
 //bad:   return x;
 //bad: }
-#define F(a) a 
+#define F(a) a
 #define TYPE double
 
 //BAD:!!!!! complex float fz;
@@ -496,20 +496,20 @@ bad: }
 //bad:      size_t len;
 //bad: {
 #define a1const const
-#define a2const const 
+#define a2const const
 
 //
 //BAD:!!!!!      __nonnull ((1)) __wur __warnattr ("getdomainname called with bigger "
 //bad: 				       "buflen than size of destination "
 //bad: 				       "buffer");
-#define __warnattr(a) 
+#define __warnattr(a)
 //
 //BAD:!!!!!       status = DL_CALL_FCT (setgrent_fct, ());
 #define DL_CALL_FCT(a,b) a
 //
 //bad:   TST_DECL_VARS (wctype_t);
 //bad:   char *class;
-//bad: 
+//bad:
 //bad:   TST_DO_TEST (wctype)
 //BAD:!!!!!   {
 //bad:     TST_HEAD_LOCALE (wctype, S_WCTYPE);
@@ -519,16 +519,16 @@ bad: }
 #define TST_DO_TEST(a) if(a)
 //
 //BAD:!!!!! TST_ISW_LOC (CNTRL, cntrl) = {
-#define TST_ISW_LOC(a,b) int b 
+#define TST_ISW_LOC(a,b) int b
 
 //bad:       TST_DO_SEQ (MBSRTOWCS_SEQNUM)
 #define TST_DO_SEQ(a) if(a)
 
 //bad:     TST_DO_REC (wcsncpy)
 //BAD:!!!!!     {
-#define TST_DO_REC(a) if(a) 
+#define TST_DO_REC(a) if(a)
 //BAD:!!!!! TST_TOW_LOC (UPPER, upper) = {
-#define TST_TOW_LOC(a,b) int b 
+#define TST_TOW_LOC(a,b) int b
 
 
 //bad:       TST_IF_RETURN (S_WCTRANS)
@@ -551,7 +551,7 @@ bad: }
 
 //BAD:!!!!! extern INT __strtol_l PARAMS ((const STRING_TYPE *nptr, STRING_TYPE **endptr,
 //bad: 			       int base));
-#define PARAMS(a) a 
+#define PARAMS(a) a
 
 
 //bad: __BEGIN_NAMESPACE_C99
@@ -563,17 +563,17 @@ bad: }
 
 
 //BAD:!!!!! libc_locked_map_ptr (extern, __gr_map_handle) attribute_hidden;
-#define libc_locked_map_ptr(a,b) int b 
+#define libc_locked_map_ptr(a,b) int b
 
 //BAD:!!!!! static const char compilation[21] = __DATE__ " " __TIME__;
 #define __DATE__ "foo"
-#define __TIME__ "bar" 
+#define __TIME__ "bar"
 
 //pad: ???
 //BAD:!!!!! static const struct timeval tottimeout = {KEY_TIMEOUT *KEY_NRETRY, 0};
 
 //pad: false positif
-//BAD:!!!!! int inlineflag = INLINE;	
+//BAD:!!!!! int inlineflag = INLINE;
 
 
 //BAD:!!!!! 	void *buffer, size_t buflen, int *errnop H_ERRNO_PROTO EXTRA_ARGS_DECL)
@@ -583,7 +583,7 @@ bad: }
 #define EXTRA_ARGS_DECL
 //
 //BAD:!!!!! 			       size_t buflen, int *errnop H_ERRNO_PROTO)
-#define H_ERRNO_PROTO 
+#define H_ERRNO_PROTO
 
 //
 //bad: int
@@ -613,7 +613,7 @@ bad: }
 
 //BAD:!!!!! extern int	getopt P((int argc, char * const argv[],
 //bad: 			const char * options));
-//but conflict :( 
+//but conflict :(
 #define P(a) a
 
 //BAD:!!!!! __STDIO_INLINE int
@@ -637,7 +637,7 @@ bad: }
 
 //bad: ARGP_FS_EI size_t
 //BAD:!!!!! __argp_fmtstream_write (argp_fmtstream_t __fs,
-#define ARGP_FS_EI 
+#define ARGP_FS_EI
 
 //BAD:!!!!! ARGP_EI int
 //bad: __NTH (__option_is_short (__const struct argp_option *__opt))
@@ -645,13 +645,13 @@ bad: }
 
 //
 //BAD:!!!!! const STRUCT_CTYPE_CLASS(1, 0) _nl_C_LC_CTYPE_class_space attribute_hidden =
-#define STRUCT_CTYPE_CLASS(a,b) 
+#define STRUCT_CTYPE_CLASS(a,b)
 //
 //BAD:!!!!!   __libc_rwlock_define (, conversions_lock);
 #define __libc_rwlock_define(a,b) int foo;
 //
 //BAD:!!!!!   __libc_rwlock_define_initialized (static, lock);
-#define __libc_rwlock_define_initialized(a,b) int foo; 
+#define __libc_rwlock_define_initialized(a,b) int foo;
 //bad:   __libc_rwlock_rdlock (tree_lock);
 
 //BAD:!!!!! 			       size_t len LOCALE_PARAM_PROTO) __THROW;
@@ -673,7 +673,7 @@ bad: }
 //BAD:!!!!!       mp_limb_t base PACK;
 //bad: #if UDIV_TIME > 2 * UMUL_TIME
 //bad:       mp_limb_t base_ninv PACK;
-#define PACK 
+#define PACK
 
 //
 //BAD:!!!!!   TEST (creal (1.0 + 1.0i), sizeof (double));
@@ -693,10 +693,10 @@ bad: }
 //bad: AB(handle_file) (const char *fname, int fd)
 //bad: {
 //BAD:!!!!!   E(Ehdr) ehdr;
-//bad: 
+//bad:
 //
-//bad: 
-//bad: 
+//bad:
+//bad:
 //bad: libc_freeres_fn (free_mem)
 //BAD:!!!!! {
 //bad:   struct link_map *l;

--- a/config/macros/macros_gtk.h
+++ b/config/macros/macros_gtk.h
@@ -1,5 +1,5 @@
-// time: start 
-//   22h03  95%? 
+// time: start
+//   22h03  95%?
 //   22h17  98%
 //   -
 //   22h28
@@ -11,7 +11,7 @@
 //BAD:!!!!! G_CONST_RETURN gchar*
 //bad: gtk_progress_bar_get_text (GtkProgressBar *pbar)
 //bad: {
-#define G_CONST_RETURN const 
+#define G_CONST_RETURN const
 //
 //bad: G_BEGIN_DECLS
 #define G_BEGIN_DECLS
@@ -23,7 +23,7 @@
 //BAD:!!!!! GType              _gtk_file_chooser_entry_get_type (void) G_GNUC_CONST;
 //#define G_GNUC_CONST const
 //pad: only c++ extension
-#define G_GNUC_CONST 
+#define G_GNUC_CONST
 
 //bad: static HRESULT STDMETHODCALLTYPE
 //BAD:!!!!! iprintdialogcallback_queryinterface (IPrintDialogCallback *This,
@@ -40,7 +40,7 @@
 //bad: {
 //bad:   return g_object_new (MSW_TYPE_RC_STYLE, NULL);
 //bad: }
-#define G_MODULE_EXPORT 
+#define G_MODULE_EXPORT
 
 //
 //BAD:!!!!! G_GNUC_INTERNAL ThemePixbuf *theme_pixbuf_new          (void);
@@ -69,7 +69,7 @@
 //BAD:!!!!! WINUSERAPI HWND WINAPI GetAncestor(HWND,UINT);
 //bad: BOOL WINAPI
 //BAD:!!!!! DllMain (HINSTANCE hinstDLL,
-#define WINUSERAPI 
+#define WINUSERAPI
 #define WINAPI
 
 
@@ -89,12 +89,12 @@
 
 
 //BAD:!!!!! GTKMAIN_C_VAR const guint gtk_major_version;
-#define GTKMAIN_C_VAR 
+#define GTKMAIN_C_VAR
 
 //
 //bad:   gint             GSEAL (num_children);
 //BAD:!!!!!   GList           *GSEAL (children);
-#define GSEAL(a) a 
+#define GSEAL(a) a
 
 //BAD:!!!!! uncompress (unsigned size, INOUT guchar ** source, OUT guchar * target, INOUT gsize * _remaining)
 #define IN

--- a/config/macros/macros_jpeg.h
+++ b/config/macros/macros_jpeg.h
@@ -1,8 +1,8 @@
-// used in firefox 
+// used in firefox
 
 #define jpeg_common_fields
 
-// conflict with minix 
+// conflict with minix
 #define EXTERN(a) a
 #define JPP(x) x
 

--- a/config/macros/macros_kdeedu.h
+++ b/config/macros/macros_kdeedu.h
@@ -1,4 +1,4 @@
-// time 
+// time
 //  start  21h35: 78%
 //         22h08  87.21%
 
@@ -6,7 +6,7 @@
 // BAD:!!!!!    emit doc->progressChanged(doc, 0);
 //BAD:!!!!! public slots:
 //bad: 	void update();
-#define slots 
+#define slots
 #define signals public
 #define emit
 

--- a/config/macros/macros_libsdl.h
+++ b/config/macros/macros_libsdl.h
@@ -1,8 +1,8 @@
-// time: 
+// time:
 //  start 13h08: 86%
 //        13h28: 95.19%
 //        13h36: 95.23%
-/* main pbs: CARD16 
+/* main pbs: CARD16
  *    vector extension
  */
 
@@ -18,7 +18,7 @@
 #define SDLCALL
 
 //BAD:!!!!! __declspec(naked)
-#define __declspec(a) 
+#define __declspec(a)
 
 //BAD:!!!!!     static void *SDL_OSX_dlsym(void *dl_restrict handle,
 #define dl_restrict
@@ -48,7 +48,7 @@
 
 //bad: /* for quicksort */
 //BAD:!!!!! static int compare(_Xconst void *, _Xconst void *);
-#define _Xconst const 
+#define _Xconst const
 
 
 #define __BEGIN_DECLS
@@ -90,7 +90,7 @@
 
 
 //BAD:!!!!! GL_API void GL_APIENTRY glAlphaFunc (GLenum func, GLclampf ref);
-#define GL_API 
+#define GL_API
 #define GL_APIENTRY
 
 //bad: GLAPI void APIENTRY glBlendEquation (GLenum);
@@ -113,7 +113,7 @@
 /*
 bad: extern "C"
 bad: {
-bad: 
+bad:
 BAD:!!!!! #include "SDL_joystick.h"
 
 

--- a/config/macros/macros_libstl.h
+++ b/config/macros/macros_libstl.h
@@ -1,5 +1,5 @@
 // time
-//  start 11h27: 
+//  start 11h27:
 //        11h44: 52% :((
 
 //BAD:!!!!! _GLIBCXX_BEGIN_NAMESPACE_TR1
@@ -9,7 +9,7 @@
 //
 //
 //bad: _GLIBCXX_BEGIN_NAMESPACE(std)
-#define _GLIBCXX_BEGIN_NAMESPACE(a) 
+#define _GLIBCXX_BEGIN_NAMESPACE(a)
 //bad: _GLIBCXX_END_NAMESPACE
 #define _GLIBCXX_END_NAMESPACE
 //

--- a/config/macros/macros_linux.h
+++ b/config/macros/macros_linux.h
@@ -1,8 +1,8 @@
-// time: hard to say, quite a lot as linux was my test case and 
+// time: hard to say, quite a lot as linux was my test case and
 //  so add extensions gradually, which allow me in turn sometimes to
 //  remove entries in this file.
 
-// 
+//
 // ----------------------------------------------------------------------------
 // Last
 // ----------------------------------------------------------------------------
@@ -12,12 +12,12 @@
 
 #define __P(a) a
 
-#define yyconst const 
+#define yyconst const
 
-#define Q_OBJECT 
+#define Q_OBJECT
 
 
-#define notrace 
+#define notrace
 
 // ----------------------------------------------------------------------------
 // Attributes
@@ -55,7 +55,7 @@
 
 #define  __pmac
 #define  __nocast
-#define  __force 
+#define  __force
 
 #define  __must_check YACFE_ATTRIBUTE
 // pb
@@ -74,7 +74,7 @@
 
 #define __initdata_refok YACFE_ATTRIBUTE
 
-// in the other part of the kernel, in arch/, mm/, etc 
+// in the other part of the kernel, in arch/, mm/, etc
 #define  __sched YACFE_ATTRIBUTE
 #define  __initmv YACFE_ATTRIBUTE
 #define  __exception YACFE_ATTRIBUTE
@@ -144,7 +144,7 @@
 // ----------------------------------------------------------------------------
 // String macros
 // ----------------------------------------------------------------------------
- 
+
 #define  KERN_EMERG		YACFE_STRING
 #define  KERN_ALERT		YACFE_STRING
 #define  KERN_CRIT		YACFE_STRING
@@ -191,7 +191,7 @@
 
 #define  PNMI_STATIC static
 #define  RLMT_STATIC static
-#define  SISINITSTATIC static 
+#define  SISINITSTATIC static
 #define  SCTP_STATIC static
 
 #define  BUGLVL if
@@ -256,23 +256,23 @@
 #define  EARLY_INIT_SECTION_ATTR
 
 // pb
-//#define  INIT 
+//#define  INIT
 
 #define  IDI_CALL_ENTITY_T
 #define  IDI_CALL_LINK_T
 
 #define uninitialized_var(x) x = x
-// as in u16 uninitialized_var(ioboard_type);	/* GCC be quiet */ 
+// as in u16 uninitialized_var(ioboard_type);	/* GCC be quiet */
 
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
 
 // YACFE_ATTRIBUTE_PARAMS, but maybe can reuse YACFE_ATTRIBUTE
-#define __releases(x) 
-#define __acquires(x) 
-#define __declspec(x) 
-#define __page_aligned(x) 
-#define __vsyscall(x) 
+#define __releases(x)
+#define __acquires(x)
+#define __declspec(x)
+#define __page_aligned(x)
+#define __vsyscall(x)
 
 // ----------------------------------------------------------------------------
 // Prototype and params compatibility
@@ -328,7 +328,7 @@ static const struct machine_desc __mach_desc_##_type	\
 
 
 // include/asm-i386/percpu.h
-// interesting macro where we see the need of __typeof__(type) with 
+// interesting macro where we see the need of __typeof__(type) with
 // for example DECLARE_PER_CPU(char[256], iucv_dbf_txt_buf);
 #define DEFINE_PER_CPU(type, name) \
     __attribute__((__section__(".data.percpu"))) __typeof__(type) per_cpu__##name
@@ -357,7 +357,7 @@ struct subsystem _name##_subsys = { \
 // ----------------------------------------------------------------------------
 
 // pb: if use this macro then we will not transform the argument of CS_CHECK
-// in some rules. 
+// in some rules.
 //#define CS_CHECK(fn, ret) \
 //  do { last_fn = (fn); if ((last_ret = (ret)) != 0) goto cs_failed; } while (0)
 
@@ -411,8 +411,8 @@ struct subsystem _name##_subsys = { \
 
 
 // net/ipv4/netfilter/ip_conntrack_helper_h323_asn1.c
-// also used in other.c that don't do any include :( 
-// but locally redefined in drivers/net/bnx2.c :( with a 
+// also used in other.c that don't do any include :(
+// but locally redefined in drivers/net/bnx2.c :( with a
 // #define FNAME	0x8
 //pb cos also used as:
 //BAD:  static unsigned FNAME(gpte_access)(struct kvm_vcpu *vcpu, pt_element_t gpte)
@@ -480,7 +480,7 @@ struct subsystem _name##_subsys = { \
 
 // drivers/net/wireless/arlan-proc.c
 // incomplete macro, the real macro is quite complex and use other macros
-#define ARLAN_SYSCTL_TABLE_TOTAL(x) 
+#define ARLAN_SYSCTL_TABLE_TOTAL(x)
 
 
 // ----------------------------------------------------------------------------
@@ -574,7 +574,7 @@ do {									\
 
 
 // Cooperation with parsing_hack.ml: MACROSTATEMENT is a magic string.
-// I can't just expand those macros into some 'whatever();' because I need 
+// I can't just expand those macros into some 'whatever();' because I need
 // to generate a TMacroStmt for solving some ambiguities in the grammar
 // for the toplevel stuff I think.
 #define ASSERT(x) MACROSTATEMENT
@@ -679,8 +679,8 @@ do {									\
 	struct meta_obj *dst, int *err)
 
 
-#define GDTH_INITFUNC(x,y) x y 
-#define ASC_INITFUNC(x,y) x y 
+#define GDTH_INITFUNC(x,y) x y
+#define ASC_INITFUNC(x,y) x y
 
 
 // ----------------------------------------------------------------------------
@@ -700,7 +700,7 @@ do {									\
 //#define __PROM_O32
 
 // ----------------------------------------------------------------------------
-// for tests-big/ macros, may be obsolete now cos fixed in latest kernel 
+// for tests-big/ macros, may be obsolete now cos fixed in latest kernel
 // ----------------------------------------------------------------------------
 
 // rule10

--- a/config/macros/macros_minix.h
+++ b/config/macros/macros_minix.h
@@ -1,7 +1,7 @@
-//#define PUBLIC  
-//#define PRIVATE 
-//#define EXTERN 
-//#define FORWARD 
+//#define PUBLIC
+//#define PRIVATE
+//#define EXTERN
+//#define FORWARD
 //#define _PROTOTYPE(a,b) a b
-//#define _CONST 
+//#define _CONST
 

--- a/config/macros/macros_mozilla.h
+++ b/config/macros/macros_mozilla.h
@@ -1,5 +1,5 @@
-// time 
-//  start 
+// time
+//  start
 
 
 
@@ -15,13 +15,13 @@
 
 //#include <macros_jpeg.h>
 #define jpeg_common_fields
-// conflict with minix 
+// conflict with minix
 #define EXTERN(a) a
 #define JPP(x) x
 
-//#include <macros_hacc.h> 
-#define YY_PROTO(x) x 
-#define yyconst const 
+//#include <macros_hacc.h>
+#define YY_PROTO(x) x
+#define yyconst const
 
 
 //#include <macros_windows.h>
@@ -33,7 +33,7 @@
 #define NEAR
 
 //BAD:!!!!! PVOID APIENTRY WinQueryProperty(HWND hwnd, PCSZ  pszNameOrAtom);
-//BAD:!!!!! BOOL APIENTRY DllMain(  HINSTANCE hModule, 
+//BAD:!!!!! BOOL APIENTRY DllMain(  HINSTANCE hModule,
 #define APIENTRY
 
 
@@ -57,7 +57,7 @@
 #define __P(a) a
 
 #define cairo_private static
-#define cairo_public 
+#define cairo_public
 #define cairo_private_no_warn
 
 #define CG_EXTERN extern
@@ -66,7 +66,7 @@
 
 #define _Xconst const
 
-/* linux also use FASTCALL but as a DefineFunc, not DefineVar, todo my 
+/* linux also use FASTCALL but as a DefineFunc, not DefineVar, todo my
  * hash allow this ? */
 
 #define FASTCALL
@@ -136,26 +136,26 @@
 #define PR_STATIC_CALLBACK static
 
 
-#define LL_CMP(a,op,b) a op b 
+#define LL_CMP(a,op,b) a op b
 
 #define UNTIL(x) while(!(x))
 
 
-#define CAIRO_PRINTF_FORMAT(a,b) 
+#define CAIRO_PRINTF_FORMAT(a,b)
 
-#define PREFIX(a) a 
+#define PREFIX(a) a
 
 
 #define JMETHOD(a, b, c) a b c
 
-#define _inline 
+#define _inline
 
-#define JS_EXTERN_API(x) x 
+#define JS_EXTERN_API(x) x
 
 #define FARDATA
 
 #define XMLCALL
-#define PTRCALL 
+#define PTRCALL
 #define PTRFASTCALL
 
 #define NSS_IMPLEMENT_DATA
@@ -164,14 +164,14 @@
 // firefox macros (for C++ code)
 // ****************************************************************************
 
-#define G_BEGIN_DECLS 
-#define G_END_DECLS 
+#define G_BEGIN_DECLS
+#define G_END_DECLS
 
 #define __BEGIN_DECLS
 #define __END_DECLS
 
 
-#define G_CONST_RETURN 
+#define G_CONST_RETURN
 
 
 //sure ?
@@ -193,7 +193,7 @@
 
 #define NS_METHOD void
 //bad: NS_METHOD_(void*)
-#define NS_METHOD_(a) a 
+#define NS_METHOD_(a) a
 
 // cast function syntax
 //#define PRUnichar(x) (char)(x)
@@ -207,7 +207,7 @@
 
 //BAD:!!!!!     NS_STDCALL_FUNCPROTO(nsresult,
 //bad:                          getter,
-//bad:                          nsIWindowsHooksSettings, GetShowDialog, 
+//bad:                          nsIWindowsHooksSettings, GetShowDialog,
 //bad:                          (PRBool*));
 #define NS_STDCALL_FUNCPROTO(a,b,c,d,e) a b
 
@@ -233,10 +233,10 @@
 #define STDMETHODIMP_(x) x
 #define STDMETHODIMP void
 
-#define __RPC_FAR 
+#define __RPC_FAR
 
 
-#define EXTERN_C 
+#define EXTERN_C
 
 #define CDECL
 
@@ -276,7 +276,7 @@
 #define NS_COM_GLUE
 
 
-#define PASCAL 
+#define PASCAL
 
 
 #define MOZILLA_NATIVE(a) a
@@ -286,7 +286,7 @@
 
 #define JX_EXPORT
 
-//pad: lots of xxx_EXPORT 
+//pad: lots of xxx_EXPORT
 
 #define PYXPCOM_EXPORT
 
@@ -296,7 +296,7 @@
 #define STDMETHODCALLTYPE
 #define __cdecl
 #define __stdcall
-#define __declspec(x) 
+#define __declspec(x)
 
 
 
@@ -347,7 +347,7 @@
 
 
 
-#define NS_HIDDEN 
+#define NS_HIDDEN
 #define NS_HIDDEN_(a) a
 
 // BAD:!!!!!   if NS_SUCCEEDED(rv)
@@ -359,7 +359,7 @@
 
 
 
-// in initializer, pb cos miss some ',' 
+// in initializer, pb cos miss some ','
 #define REFERENCE_METHOD_FAMILY(CallObjectMethod)
 
 #define TX_DOUBLE_COMPARE(a,b,c) (a b c)
@@ -368,7 +368,7 @@
 #define LL_UCMP(a,op,b) a op b
 
 
-#define GSS_MAKE_TYPEDEF 
+#define GSS_MAKE_TYPEDEF
 #define GSS_CALL_CONV
 #define GSS_FUNC(a) a
 
@@ -409,12 +409,12 @@
 
 #define NS_DEFINE_STATIC_IID_ACCESSOR(a)
 
-#define MOZ_DECL_CTOR_COUNTER(a) 
+#define MOZ_DECL_CTOR_COUNTER(a)
 
 //#define ipcMessageCast static_cast
 
 
-#define NS_DECL_ISUPPORTS 
+#define NS_DECL_ISUPPORTS
 // now in parsing_hack2.ml
 // grep "BAD:.*NS_IMPL" firefox_parse_h++_error2
 // grep "BAD:.*NS_INTERFACE" firefox_parse_h++_error2
@@ -423,7 +423,7 @@
 
 
 
-#define __gc 
+#define __gc
 
 
 #define __try try
@@ -448,7 +448,7 @@
 
 #define NS_STACK_CLASS
 
-#define NS_SPECIALIZE_TEMPLATE // template <> 
+#define NS_SPECIALIZE_TEMPLATE // template <>
 
 #define NS_DOM_INTERFACE_MAP_ENTRY_CLASSINFO(a)
 
@@ -459,7 +459,7 @@
 
 #define ATL_NO_VTABLE
 
-#define DECLARE_DYNCREATE(a) 
+#define DECLARE_DYNCREATE(a)
 
 #define GTKMOZEMBED_API(a,b,c) a b c
 #define DECLARE_EVENT_TABLE()
@@ -476,7 +476,7 @@
 #define JS_PUBLIC_API(a) a
 #define JS_FRIEND_API(a) a
 
-#define VFTDELTA_DECL(a) 
+#define VFTDELTA_DECL(a)
 
 
 #define MY_UNKNOWN_IMP
@@ -493,7 +493,7 @@
 
 #define JRI_PUBLIC_API(a) a
 
-#define NS_DEFINE_CONSTRUCTOR_DATA(a,b) 
+#define NS_DEFINE_CONSTRUCTOR_DATA(a,b)
 
 
 #define NS_STID_FOR_INDEX(a) while(a)
@@ -536,7 +536,7 @@
 
 // but mostly valid, should perhaps comment it, generates lots of passed:
 // NS_ENSURE_TRUE(window, /**/);
-#define NS_ENSURE_TRUE(a,b) 
+#define NS_ENSURE_TRUE(a,b)
 
 #define DECL_STYLE_RULE_INHERIT
 
@@ -546,7 +546,7 @@
 #define UP_IMPL_NSISUPPORTS
 
 
-#define MAKE_SAFE_VFT(a,b) a b = 
+#define MAKE_SAFE_VFT(a,b) a b =
 #define VFTFIRST_VAL()
 #define SAFE_VFT_ZEROS()
 
@@ -574,14 +574,14 @@
 //BAD:!!!!! CPluginManager::Alloc(PRUint32 size)
 
 //BAD:!!!!! DEFINE_API_C(int) main(NPNetscapeFuncs* nsTable, NPPluginFuncs* pluginFuncs, NPP_ShutdownUPP* unloadUpp)
-#define DEFINE_API_C(a) a 
+#define DEFINE_API_C(a) a
 
-//BAD:!!!!!     extern NS_IMPORT_(char **) environ; 
-#define NS_IMPORT_(a) a 
+//BAD:!!!!!     extern NS_IMPORT_(char **) environ;
+#define NS_IMPORT_(a) a
 
 
 //BAD:!!!!!   NS_ADDREF(*aResult = lf);
-#define NS_ADDREF(a) a 
+#define NS_ADDREF(a) a
 
 //bad: #ifdef NEVER_ENABLE_THIS_JAVASCRIPT
 //
@@ -590,14 +590,14 @@
 //bad: public:
 //bad: 	PyG_nsIComponentLoader(PyObject *instance) : PyG_Base(instance, NS_GET_IID(nsIComponentLoader)) {;}
 //BAD:!!!!! 	PYGATEWAY_BASE_SUPPORT(nsIComponentLoader, PyG_Base);
-//bad: 
+//bad:
 //bad: 	NS_DECL_NSICOMPONENTLOADER
 //bad: };
 
 
 //BAD:!!!!! 	PyObject_HEAD_INIT(&PyType_Type)
 //bad: 	0,
-#define PyObject_HEAD_INIT(a) a, 
+#define PyObject_HEAD_INIT(a) a,
 
 //bad: 			if ((val_use=PyNumber_Int(val))==NULL) BREAK_FALSE
 #define BREAK_FALSE
@@ -615,15 +615,15 @@
 #define TRACE_METHOD(a) a()
 
 //BAD:!!!!! lineto(nsFT_CONST FT_Vector *aEndPt, void *aClosure)
-#define nsFT_CONST const 
+#define nsFT_CONST const
 
 //BAD:!!!!! pascal void CursorSpinner::SpinCursor(EventLoopTimerRef inTimer, void *inUserData)
-#define pascal 
+#define pascal
 
 //BAD:!!!!! PRIVATE int binhex_encode_finishing(
 //bad: 	binhex_encode_object *p_bh_encode_obj)
 //bad: {
-#define PRIVATE 
+#define PRIVATE
 
 //BAD:!!!!! static int yy_flex_strlen YY_PROTO(( yyconst char * ));
 //and co
@@ -633,7 +633,7 @@
 
 
 //BAD:!!!!! extern "C" XULAPI int
-#define XULAPI 
+#define XULAPI
 
 //BAD:!!!!! extern "C" NS_EXPORT jboolean JNICALL
 //bad: JAVAPROXY_NATIVE(isSameXPCOMObject) (JNIEnv *env, jclass that, jobject aProxy1,

--- a/config/macros/macros_mysql.h
+++ b/config/macros/macros_mysql.h
@@ -82,7 +82,7 @@
 
 
 //BAD:!!!!!    "built-in default (" STRINGIFY_ARG(MYSQL_PORT) ").",
-#define STRINGIFY_ARG(a) "stringified" 
+#define STRINGIFY_ARG(a) "stringified"
 
 //BAD:!!!!!   SECTION( ATTRIBUTE_LIST_SECTION = 0 );
 #define SECTION(a) a
@@ -111,7 +111,7 @@
 //bad: MY_LOCALE my_locale_ru_UA
 //bad: (
 //BAD:!!!!!   44,
-//#define MY_LOCALE 
+//#define MY_LOCALE
 
 //BAD:!!!!!       RT_D_MBR_KORR(int8, mi_sint1korr, 1, (double));
 #define RT_D_MBR_KORR(a,b,c,d) int foo
@@ -122,23 +122,23 @@
 #define _VARARGS(a) a
 
 //BAD:!!!!! extern int ax_unreg __P((int, long));
-#define __P(a) a 
+#define __P(a) a
 
 //BAD:!!!!!   my_bool SV::*offset;
 //
 //BAD:!!!!!   String *val_str(String *) ZLIB_DEPENDED_FUNCTION
-#define ZLIB_DEPENDED_FUNCTION 
+#define ZLIB_DEPENDED_FUNCTION
 
 //BAD:!!!!! STATIC int      regtry();
 #define STATIC
 
 //BAD:!!!!! extern void __cdecl _dosmaperr(unsigned long);
-#define __cdecl 
+#define __cdecl
 
 
 //bad: static void MD5Transform PROTO_LIST ((UINT4 [4], unsigned char [64]));
 //BAD:!!!!!        void my_MD5Init PROTO_LIST ((my_MD5_CTX *));
-#define PROTO_LIST(a) a 
+#define PROTO_LIST(a) a
 
 
 //BAD:!!!!! 	   void (*free_element)(void*),uint flags CALLER_INFO_PROTO)
@@ -147,37 +147,37 @@
 //BAD:!!!!! int _export FAR PASCAL libmain(HANDLE hModule,short cbHeapSize,
 #define _export
 #define FAR
-#define PASCAL 
+#define PASCAL
 //
 //BAD:!!!!! BOOL APIENTRY LibMain(HANDLE hInst,DWORD ul_reason_being_called,
 #define APIENTRY
 //
 //BAD:!!!!! SSL_STATIC my_bool opt_use_ssl  = 0;
-#define SSL_STATIC 
+#define SSL_STATIC
 
 //BAD:!!!!!   REGISTER struct link *old;
 #define REGISTER
 //
 //BAD:!!!!! ZEXTERN const char * ZEXPORT zlibVersion OF((void));
 #define ZEXTERN extern
-#define ZEXTERN 
+#define ZEXTERN
 
 #define OF(a) a
 
 //
 //BAD:!!!!! local void bi_flush(s)
-#define local 
+#define local
 
 //BAD:!!!!! int ZEXPORTVA gzprintf (file, format, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10,
 //bad:                        a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)
-#define ZEXPORTVA 
+#define ZEXPORTVA
 
 
 //bad: NDB_COMMAND(DbAsyncGenerator, "DbAsyncGenerator",
 //bad: 	    "DbAsyncGenerator", "DbAsyncGenerator", 65535)
 //BAD:!!!!! {
 //bad:   ndb_init();
-#define NDB_COMMAND(a, str, str2, str3, i1) int a(void) 
+#define NDB_COMMAND(a, str, str2, str3, i1) int a(void)
 
 
 
@@ -190,16 +190,16 @@
 
 //BAD:!!!!! {
 //bad:   MYSQL_STORAGE_ENGINE_PLUGIN,
-#define mysql_storage_engine_plugin(q) int a = 
+#define mysql_storage_engine_plugin(q) int a =
 //mysql_declare_plugin_end;
 
 //bad: mysql_declare_plugin(blackhole)
-#define mysql_declare_plugin(q) int a = 
+#define mysql_declare_plugin(q) int a =
 #define mysql_declare_plugin_end
 
 
 //bad: #ifdef _MSC_VER
-//bad:     __declspec(naked) 
+//bad:     __declspec(naked)
 //bad: #endif
 #define __declspec(a)
 
@@ -218,7 +218,7 @@ register struct re_guts *g;
 bad: register char *cp;
 BAD:!!!!! {
 bad: 	register char *p;
-bad: 
+bad:
 bad: 	if (cs->multis == NULL)
 bad: 		return(NULL);
 bad: 	for (p = cs->multis; *p != '\0'; p += strlen(p) + 1)

--- a/config/macros/macros_pidgin.h
+++ b/config/macros/macros_pidgin.h
@@ -1,7 +1,7 @@
 //time: 1h I think
 
 //bad: G_BEGIN_DECLS
-//bad: 
+//bad:
 //bad: /**
 //bad:  * @return The GType for GntWS.
 //bad:  *
@@ -15,7 +15,7 @@
 
 
 //bad: STATIC_PROTO_INIT
-//bad: 
+//bad:
 //bad: gboolean
 //BAD:!!!!! purple_core_init(const char *ui)
 #define STATIC_PROTO_INIT
@@ -26,8 +26,8 @@
 
 //bad: struct gg_session {
 //BAD:!!!!! 	gg_common_head(struct gg_session)
-//bad: 
-#define gg_common_head(a) 
+//bad:
+#define gg_common_head(a)
 
 //BAD:!!!!! static void (DNSSD_API* _DNSServiceRefDeallocate)(DNSServiceRef sdRef);
 #define DNSSD_API
@@ -42,7 +42,7 @@
 //bad: }
 //bad: }
 //bad: END_TEST
-#define START_TEST(a) void a(void) 
+#define START_TEST(a) void a(void)
 
 #define END_TEST
 

--- a/config/macros/macros_qemu.h
+++ b/config/macros/macros_qemu.h
@@ -1,5 +1,5 @@
-// time: 
-//  start 11h32: 89% 
+// time:
+//  start 11h32: 89%
 //        11h41: 95%
 //        12h10: 96.60%
 
@@ -19,7 +19,7 @@
 
 //BAD:!!!!! static always_inline int vaxf_is_valid (float ff)
 //bad: {
-#define always_inline 
+#define always_inline
 
 //bad: DISAS_INSN(move_to_ccr)
 //BAD:!!!!! {
@@ -31,11 +31,11 @@
 
 //bad: GEN_HANDLER(fmr, 0x3F, 0x08, 0x02, 0x001F0000, PPC_FLOAT)
 //BAD:!!!!! {
-#define GEN_HANDLER(a, b, c, d, e, f) void a(void) 
+#define GEN_HANDLER(a, b, c, d, e, f) void a(void)
 
 //bad: GEN_HANDLER2(addic_, "addic.", 0x0D, 0xFF, 0xFF, 0x00000000, PPC_INTEGER)
 //BAD:!!!!! {
-#define GEN_HANDLER2(a, b, c, d, e, f, g, h) void a(void) 
+#define GEN_HANDLER2(a, b, c, d, e, f, g, h) void a(void)
 
 //bad: void HELPER(cpsr_write)(uint32_t val, uint32_t mask)
 //bad: {
@@ -47,7 +47,7 @@
 #define GCC_ATTR YACFE_ATTRIBUTE
 
 //BAD:!!!!! static void GCC_FMT_ATTR (2, 3) oss_logerr (int err, const char *fmt, ...)
-#define GCC_FMT_ATTR(a,b) 
+#define GCC_FMT_ATTR(a,b)
 
 
 
@@ -121,14 +121,14 @@
 
 
 //bad:     target_ulong tls_value; /* For usermode emulation */
-//bad: 
+//bad:
 //BAD:!!!!!     CPU_COMMON
-//bad: 
+//bad:
 #define CPU_COMMON
 
 //bad: typedef struct CirrusVGAState {
 //BAD:!!!!!     VGA_STATE_COMMON
-//bad: 
+//bad:
 //bad:     int cirrus_linear_io_addr;
 #define VGA_STATE_COMMON
 

--- a/config/macros/macros_quake3.h
+++ b/config/macros/macros_quake3.h
@@ -122,9 +122,9 @@
 //bad: typedef enum {
 //bad:   /* This is the socket callback function pointer */
 //BAD:!!!!!   CINIT(SOCKETFUNCTION, FUNCTIONPOINT, 1),
-//bad: 
+//bad:
 //bad:   /* This is the argument passed to the socket callback */
 //bad:   CINIT(SOCKETDATA, OBJECTPOINT, 2),
-//bad: 
+//bad:
 //bad:   CURLMOPT_LASTENTRY /* the last unused */
 //bad: } CURLMoption;

--- a/config/macros/macros_sparse.h
+++ b/config/macros/macros_sparse.h
@@ -9,4 +9,4 @@
 #define END_FOR_EACH_PTR(a)
 
 #define IDENT_RESERVED(a)
-#define IDENT(a) 
+#define IDENT(a)

--- a/config/macros/macros_sqlite.h
+++ b/config/macros/macros_sqlite.h
@@ -1,4 +1,4 @@
-// used in firefox 
+// used in firefox
 
 
 

--- a/config/macros/macros_yacc.h
+++ b/config/macros/macros_yacc.h
@@ -1,4 +1,4 @@
 
-#define YY_PROTO(x) x 
-#define yyconst const 
+#define YY_PROTO(x) x
+#define yyconst const
 

--- a/config/macros/standard-before-split-sync-with-other.h
+++ b/config/macros/standard-before-split-sync-with-other.h
@@ -1,4 +1,4 @@
-// clone: yacfe(master), coccinelle, acomment, 
+// clone: yacfe(master), coccinelle, acomment,
 
 // ****************************************************************************
 // Prelude, this file is to be used with the -macro_file option of the C parser
@@ -9,14 +9,14 @@
  *   - macros found in .c; macros that cannot be parsed.
  *     In the future should be autodetected
  *     (not so easy to do same for macros in .h cos require to access .h file)
- *   - macros found in ".h" 
+ *   - macros found in ".h"
  *     but where we cant detect that it will be a "bad macro"
  *   - macros found in .c; macros correctly parsed
  *     but where we cant detect that it will be a "bad macro"
  *
  * Some of those macros could be deleted and the C code rewritten because
  * they are "bad" macros.
- * 
+ *
  * todo? perhaps better if could enable/disable some of those expansions
  * as different software may use conflicting macros.
  *
@@ -38,27 +38,27 @@
 // ****************************************************************************
 
 // ****************************************************************************
-// Yacc macros 
+// Yacc macros
 // ****************************************************************************
 
-#define YY_PROTO(x) x 
-#define yyconst const 
+#define YY_PROTO(x) x
+#define yyconst const
 
 
 // ****************************************************************************
-// GNU Hello macros 
+// GNU Hello macros
 // ****************************************************************************
 
 #define __getopt_argv_const const
 
 
 // ****************************************************************************
-// Gcc (as in the source of gcc code) macros 
+// Gcc (as in the source of gcc code) macros
 // ****************************************************************************
 
 
 // ****************************************************************************
-// Linux macros 
+// Linux macros
 // ****************************************************************************
 
 // ----------------------------------------------------------------------------
@@ -96,7 +96,7 @@
 
 #define  __must_check
 // pb
-#define  __unused 
+#define  __unused
 #define  __maybe_unused
 
 
@@ -109,7 +109,7 @@
 
 #define  __xipram
 
-// in the other part of the kernel, in arch/, mm/, etc 
+// in the other part of the kernel, in arch/, mm/, etc
 #define  __sched
 #define  __initmv
 #define  __exception
@@ -155,7 +155,7 @@
 
 #define __thread
 #define __used
-#define __pure 
+#define __pure
 
 #define __ref
 #define __refdata
@@ -171,21 +171,21 @@
  * be considered as a declaration with XX being a typedef, so would
  * Have ambiguity. So at least by adding this special case, we can
  * catch more correct string-macro, no more a XX YY but now a good
- * "XX" YY 
- * 
+ * "XX" YY
+ *
  * cf include/linux/kernel.h
  *
- * For stringification I need to have at least a witness, a string, 
+ * For stringification I need to have at least a witness, a string,
  * and sometimes have just printk(KERN_WARNING MYSTR) and it could
  * be transformed in a typedef later, so better to at least
  * transform in string already the string-macro we know.
- * 
- * Perhaps better to apply also as soon as possible the 
+ *
+ * Perhaps better to apply also as soon as possible the
  * correct macro-annotation tagging (__init & co) to be able to
  * filter them as soon as possible so that they will not polluate
  * our pattern-matching that come later.
  */
-  
+
 #define  KERN_EMERG "KERN_EMERG"
 #define  KERN_ALERT "KERN_ALERT"
 #define  KERN_CRIT "KERN_CRIT"
@@ -196,15 +196,15 @@
 #define  KERN_DEBUG "KERN_DEBUG"
 
 
-/* EX_TABLE & co. 
+/* EX_TABLE & co.
  *
  * Replaced by a string. We can't put everything as comment
  * because it can be part of an expression where we wait for
- * something, where we wait for a string. So at least we 
+ * something, where we wait for a string. So at least we
  * must keep the EX_TABLE token and transform it as a string.
  *
- * normally not needed if have good stringification of macro 
- * but those macros are sometimes used multiple times 
+ * normally not needed if have good stringification of macro
+ * but those macros are sometimes used multiple times
  * as in EX_TABLE(0b) EX_TABLE(1b)  and we don't detect
  * it well yet.
  */
@@ -241,7 +241,7 @@
 
 #define  PNMI_STATIC static
 #define  RLMT_STATIC static
-#define  SISINITSTATIC static 
+#define  SISINITSTATIC static
 #define  SCTP_STATIC static
 
 #define  BUGLVL if
@@ -306,7 +306,7 @@
 #define  EARLY_INIT_SECTION_ATTR
 
 // pb
-//#define  INIT 
+//#define  INIT
 
 #define  IDI_CALL_ENTITY_T
 #define  IDI_CALL_LINK_T
@@ -316,16 +316,16 @@
  * code
  */
 #define uninitialized_var(x) x = x
-// as in u16 uninitialized_var(ioboard_type);	/* GCC be quiet */ 
+// as in u16 uninitialized_var(ioboard_type);	/* GCC be quiet */
 
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
 
-#define __releases(x) 
-#define __acquires(x) 
-#define __declspec(x) 
-#define __page_aligned(x) 
-#define __vsyscall(x) 
+#define __releases(x)
+#define __acquires(x)
+#define __declspec(x)
+#define __page_aligned(x)
+#define __vsyscall(x)
 
 // ----------------------------------------------------------------------------
 // ----------------------------------------------------------------------------
@@ -380,7 +380,7 @@ static const struct machine_desc __mach_desc_##_type	\
 
 
 // include/asm-i386/percpu.h
-// interesting macro where we see the need of __typeof__(type) with 
+// interesting macro where we see the need of __typeof__(type) with
 // for example DECLARE_PER_CPU(char[256], iucv_dbf_txt_buf);
 #define DEFINE_PER_CPU(type, name) \
     __attribute__((__section__(".data.percpu"))) __typeof__(type) per_cpu__##name
@@ -402,7 +402,7 @@ struct subsystem _name##_subsys = { \
 // ----------------------------------------------------------------------------
 
 // pb: if use this macro then we will not transform the argument of CS_CHECK
-// in some rules. 
+// in some rules.
 //#define CS_CHECK(fn, ret) \
 //  do { last_fn = (fn); if ((last_ret = (ret)) != 0) goto cs_failed; } while (0)
 
@@ -455,8 +455,8 @@ struct subsystem _name##_subsys = { \
 
 
 // net/ipv4/netfilter/ip_conntrack_helper_h323_asn1.c
-// also used in other.c that don't do any include :( 
-// but locally redefined in drivers/net/bnx2.c :( with a 
+// also used in other.c that don't do any include :(
+// but locally redefined in drivers/net/bnx2.c :( with a
 // #define FNAME	0x8
 #define FNAME(name) name,
 
@@ -497,7 +497,7 @@ struct subsystem _name##_subsys = { \
 
 // drivers/net/wireless/arlan-proc.c
 // incomplete macro, the real macro is quite complex and use other macros
-#define ARLAN_SYSCTL_TABLE_TOTAL(x) 
+#define ARLAN_SYSCTL_TABLE_TOTAL(x)
 
 
 // ----------------------------------------------------------------------------
@@ -588,7 +588,7 @@ do {									\
 
 
 // Cooperation with parsing_hack.ml: MACROSTATEMENT is a magic string.
-// I can't just expand those macros into some 'whatever();' because I need 
+// I can't just expand those macros into some 'whatever();' because I need
 // to generate a TMacroStmt for solving some ambiguities in the grammar
 // for the toplevel stuff I think.
 #define ASSERT(x) MACROSTATEMENT
@@ -689,8 +689,8 @@ do {									\
 	struct meta_obj *dst, int *err)
 
 
-#define GDTH_INITFUNC(x,y) x y 
-#define ASC_INITFUNC(x,y) x y 
+#define GDTH_INITFUNC(x,y) x y
+#define ASC_INITFUNC(x,y) x y
 
 
 // ----------------------------------------------------------------------------
@@ -710,7 +710,7 @@ do {									\
 //#define __PROM_O32
 
 // ----------------------------------------------------------------------------
-// for tests-big/ macros, may be obsolete now cos fixed in latest kernel 
+// for tests-big/ macros, may be obsolete now cos fixed in latest kernel
 // ----------------------------------------------------------------------------
 
 // rule10
@@ -720,7 +720,7 @@ do {									\
 
 
 // ****************************************************************************
-// Httpd (apache) macros 
+// Httpd (apache) macros
 // ****************************************************************************
 
 #define AP_DECLARE(x) x
@@ -751,7 +751,7 @@ do {									\
 #define EXPORT static
 #define REGISTER register
 
-#define MODSSL_D2I_SSL_SESSION_CONST const 
+#define MODSSL_D2I_SSL_SESSION_CONST const
 #define MODSSL_D2I_X509_CONST const
 #define MODSSL_D2I_PrivateKey_CONST const
 #define MODSSL_D2I_SSL_SESSION_CONST const
@@ -762,9 +762,9 @@ do {									\
 
 #define WINAPI
 //#define CALLBACK
-// generate false positive in Linux 
+// generate false positive in Linux
 #define APIENTRY
-#define __declspec(x) 
+#define __declspec(x)
 #define __stdcall
 
 
@@ -775,10 +775,10 @@ do {									\
 #define ADD_SUITE(suite) suite;
 
 // ****************************************************************************
-// CISCO vpn client macros 
+// CISCO vpn client macros
 // ****************************************************************************
 
-// #define NOREGPARM 
+// #define NOREGPARM
 // #define IN
 // #define OUT
 // #define OPTIONAL
@@ -786,18 +786,18 @@ do {									\
 
 
 // ****************************************************************************
-// minix3 macros 
+// minix3 macros
 // ****************************************************************************
 
-//#define PUBLIC  
-//#define PRIVATE 
-//#define EXTERN 
-//#define FORWARD 
+//#define PUBLIC
+//#define PRIVATE
+//#define EXTERN
+//#define FORWARD
 //#define _PROTOTYPE(a,b) a b
-//#define _CONST 
+//#define _CONST
 
 // ****************************************************************************
-// Sparse macros 
+// Sparse macros
 // ****************************************************************************
 
 #define FORMAT_ATTR(pos)
@@ -808,10 +808,10 @@ do {									\
 #define END_FOR_EACH_PTR_REVERSE(dom)
 
 #define IDENT_RESERVED(a)
-#define IDENT(a) 
+#define IDENT(a)
 
 // ****************************************************************************
-// git macros 
+// git macros
 // ****************************************************************************
 
 // #define NORETURN __attribute__((noreturn))
@@ -824,7 +824,7 @@ do {									\
 
 
 // ****************************************************************************
-// Qemu macros 
+// Qemu macros
 // ****************************************************************************
 
 // OPPROTO
@@ -835,7 +835,7 @@ do {									\
 // QEMU_LIST_ENTRY
 
 // ****************************************************************************
-// Xen macros 
+// Xen macros
 // ****************************************************************************
 
 // STATUS_PARAM
@@ -874,7 +874,7 @@ do {									\
 // sqlite
 // ****************************************************************************
 
-// used in firefox 
+// used in firefox
 
 
 
@@ -890,11 +890,11 @@ do {									\
 // jpeg
 // ****************************************************************************
 
-// used in firefox 
+// used in firefox
 
 #define jpeg_common_fields
 
-// conflict with minix 
+// conflict with minix
 #define EXTERN(a) a
 #define JPP(x) x
 
@@ -917,7 +917,7 @@ do {									\
 #define __P(a) a
 
 #define cairo_private static
-#define cairo_public 
+#define cairo_public
 #define cairo_private_no_warn
 
 #define CG_EXTERN extern
@@ -926,7 +926,7 @@ do {									\
 
 #define _Xconst const
 
-/* linux also use FASTCALL but as a DefineFunc, not DefineVar, todo my 
+/* linux also use FASTCALL but as a DefineFunc, not DefineVar, todo my
  * hash allow this ? */
 
 #define FASTCALL
@@ -997,26 +997,26 @@ do {									\
 #define PR_STATIC_CALLBACK static
 
 
-#define LL_CMP(a,op,b) a op b 
+#define LL_CMP(a,op,b) a op b
 
 #define UNTIL(x) while(!(x))
 
 
-#define CAIRO_PRINTF_FORMAT(a,b) 
+#define CAIRO_PRINTF_FORMAT(a,b)
 
-#define PREFIX(a) a 
+#define PREFIX(a) a
 
 
 #define JMETHOD(a, b, c) a b c
 
-#define _inline 
+#define _inline
 
-#define JS_EXTERN_API(x) x 
+#define JS_EXTERN_API(x) x
 
 #define FARDATA
 
 #define XMLCALL
-#define PTRCALL 
+#define PTRCALL
 #define PTRFASTCALL
 
 #define NSS_IMPLEMENT_DATA
@@ -1025,15 +1025,15 @@ do {									\
 // firefox macros (for C++ code)
 // ****************************************************************************
 
-#define G_BEGIN_DECLS 
-#define G_END_DECLS 
+#define G_BEGIN_DECLS
+#define G_END_DECLS
 
 #define __BEGIN_DECLS
 #define __END_DECLS
 
 #define CALLBACK
 
-#define G_CONST_RETURN 
+#define G_CONST_RETURN
 
 
 //sure ?
@@ -1087,10 +1087,10 @@ do {									\
 #define STDMETHODIMP_(x) x
 #define STDMETHODIMP void
 
-#define __RPC_FAR 
+#define __RPC_FAR
 
 
-#define EXTERN_C 
+#define EXTERN_C
 
 #define CDECL
 
@@ -1130,7 +1130,7 @@ do {									\
 #define NS_COM_GLUE
 
 
-#define PASCAL 
+#define PASCAL
 
 
 #define MOZILLA_NATIVE(a) a
@@ -1140,7 +1140,7 @@ do {									\
 
 #define JX_EXPORT
 
-//pad: lots of xxx_EXPORT 
+//pad: lots of xxx_EXPORT
 
 #define PYXPCOM_EXPORT
 
@@ -1197,7 +1197,7 @@ do {									\
 
 
 
-#define NS_HIDDEN 
+#define NS_HIDDEN
 #define NS_HIDDEN_(a) a
 
 // BAD:!!!!!   if NS_SUCCEEDED(rv)
@@ -1209,7 +1209,7 @@ do {									\
 
 
 
-// in initializer, pb cos miss some ',' 
+// in initializer, pb cos miss some ','
 #define REFERENCE_METHOD_FAMILY(CallObjectMethod)
 
 #define TX_DOUBLE_COMPARE(a,b,c) (a b c)
@@ -1218,7 +1218,7 @@ do {									\
 #define LL_UCMP(a,op,b) a op b
 
 
-#define GSS_MAKE_TYPEDEF 
+#define GSS_MAKE_TYPEDEF
 #define GSS_CALL_CONV
 #define GSS_FUNC(a) a
 
@@ -1262,12 +1262,12 @@ do {									\
 
 #define NS_DEFINE_STATIC_IID_ACCESSOR(a)
 
-#define MOZ_DECL_CTOR_COUNTER(a) 
+#define MOZ_DECL_CTOR_COUNTER(a)
 
 //#define ipcMessageCast static_cast
 
 
-#define NS_DECL_ISUPPORTS 
+#define NS_DECL_ISUPPORTS
 // now in parsing_hack2.ml
 // grep "BAD:.*NS_IMPL" firefox_parse_h++_error2
 // grep "BAD:.*NS_INTERFACE" firefox_parse_h++_error2
@@ -1276,7 +1276,7 @@ do {									\
 
 
 
-#define __gc 
+#define __gc
 
 
 #define __try try
@@ -1301,7 +1301,7 @@ do {									\
 
 #define NS_STACK_CLASS
 
-#define NS_SPECIALIZE_TEMPLATE // template <> 
+#define NS_SPECIALIZE_TEMPLATE // template <>
 
 #define NS_DOM_INTERFACE_MAP_ENTRY_CLASSINFO(a)
 
@@ -1312,7 +1312,7 @@ do {									\
 
 #define ATL_NO_VTABLE
 
-#define DECLARE_DYNCREATE(a) 
+#define DECLARE_DYNCREATE(a)
 
 #define GTKMOZEMBED_API(a,b,c) a b c
 #define DECLARE_EVENT_TABLE()
@@ -1329,7 +1329,7 @@ do {									\
 #define JS_PUBLIC_API(a) a
 #define JS_FRIEND_API(a) a
 
-#define VFTDELTA_DECL(a) 
+#define VFTDELTA_DECL(a)
 
 
 #define MY_UNKNOWN_IMP
@@ -1346,7 +1346,7 @@ do {									\
 
 #define JRI_PUBLIC_API(a) a
 
-#define NS_DEFINE_CONSTRUCTOR_DATA(a,b) 
+#define NS_DEFINE_CONSTRUCTOR_DATA(a,b)
 
 
 #define NS_STID_FOR_INDEX(a) while(a)
@@ -1389,7 +1389,7 @@ do {									\
 
 // but mostly valid, should perhaps comment it, generates lots of passed:
 // NS_ENSURE_TRUE(window, /**/);
-#define NS_ENSURE_TRUE(a,b) 
+#define NS_ENSURE_TRUE(a,b)
 
 #define DECL_STYLE_RULE_INHERIT
 
@@ -1399,7 +1399,7 @@ do {									\
 #define UP_IMPL_NSISUPPORTS
 
 
-#define MAKE_SAFE_VFT(a,b) a b = 
+#define MAKE_SAFE_VFT(a,b) a b =
 #define VFTFIRST_VAL()
 #define SAFE_VFT_ZEROS()
 

--- a/config/macros/standard.h
+++ b/config/macros/standard.h
@@ -1,4 +1,4 @@
-// clone: yacfe(master), coccinelle, acomment, 
+// clone: yacfe(master), coccinelle, acomment,
 
 // ****************************************************************************
 // Prelude, this file is used with -macro_file_builtins option of the C parser
@@ -6,19 +6,19 @@
 
 /* This file contains:
  *   - macros found in <.h>
- *   - macros found in ".h" 
+ *   - macros found in ".h"
  *     but where we cant detect that it will be a "bad macro"
  *   - hints, cf below.
- * 
+ *
  * A "bad macro" is a macro using free variables or when expanded
- * that influence the control-flow of the code. In those cases it 
+ * that influence the control-flow of the code. In those cases it
  * is preferable to expand the macro so that the coccinelle engine
  * has a more accurate representation of what is going on.
- * 
  *
  *
  *
- * old: this file was also containing what is below but now we 
+ *
+ * old: this file was also containing what is below but now we
  * try to expand on demand the macro found in the c file, so those cases
  * are not needed any more:
  *   - macros found in .c; macros that cannot be parsed.
@@ -29,7 +29,7 @@
  *
  * Some of those macros could be deleted and the C code rewritten because
  * they are "bad" macros.
- * 
+ *
  * todo? perhaps better if could enable/disable some of those expansions
  * as different software may use conflicting macros.
  *
@@ -49,11 +49,11 @@
 // this is defined by windows compiler, and so can not be found via a macro
 // after a -extract_macros
 #define __stdcall YACFE_ATTRIBUTE
-#define __declspec(a) 
+#define __declspec(a)
 
 #define WINAPI
 #define CALLBACK
-// generate false positive in Linux 
+// generate false positive in Linux
 
 // ****************************************************************************
 // Generic macros

--- a/config/macros/test.h
+++ b/config/macros/test.h
@@ -1,18 +1,18 @@
 // Cooperation with parsing_hack.ml: YACFE_XXX are magic strings.
-// In the case of YACFE_STATEMENT, I could not just expand those macros 
-// into some 'whatever();' because I needed 
+// In the case of YACFE_STATEMENT, I could not just expand those macros
+// into some 'whatever();' because I needed
 // to generate a TMacroStmt for solving some ambiguities in the grammar
 // for the toplevel stuff I think.
 
 // todo? add parameters ?
 
-// ex: 
+// ex:
 #define XXX_ICH(a,b,c) YACFE_ITERATOR
 
-// ex: 
+// ex:
 #define XXX_STR YACFE_STRING
 
-// ex: 
+// ex:
 #define XXX_DEC YACFE_DECLARATOR
 
 // ex:

--- a/configure
+++ b/configure
@@ -9,9 +9,9 @@
 # - gcc, as, ld (the GNU toolchain)
 # - make, perl, bash
 
-my $project = 
+my $project =
     "yacfe";
-my $projectcmdline = 
+my $projectcmdline =
     "./yacfe -dump_c demos/foo.c";
 
 ######################################################################
@@ -36,7 +36,7 @@ BEGIN { die "need Perl 5 or greater" if $] < 5 ; }
 
 #use Common;
 sub pr2 { print STDERR "@_\n" }
-sub cat { 
+sub cat {
     my ($what) = @_;
     my @list;
     open(TMP, $what);
@@ -49,7 +49,7 @@ sub plural { my ($e) = @_; if ($e > 1) { "s" } else { "" } }
 
 sub check_config { my ($command, $expect, $msggood, $msgbad) = @_;
     my $error = 0;
-		   
+
     my $full = cat($command);
     my $res = join(" ", @{$full});
 #	       pr2 $res;
@@ -68,7 +68,7 @@ my $error = 0;
 #---------------------------------------------------------------------
 # Compilers and runtimes
 #---------------------------------------------------------------------
-$error += 
+$error +=
     check_config("echo \"1;;\\n\" | ocaml |",
                  "(Objective|OCaml)(.*) ([34]\.*.*)",
                  "OCaml (the wonderful language) is present.",
@@ -96,21 +96,21 @@ We need  3.XX or more",
 #---------------------------------------------------------------------
 
 ######################################################################
-# Diagnostic 
+# Diagnostic
 ######################################################################
 
-if($error) { 
+if($error) {
     pr2 "
 ----------------------------------------------------------------------
-!!!! There seems to have problem, we have found $error missing package" . 
+!!!! There seems to have problem, we have found $error missing package" .
 plural($error) . ".
-" . (($error > 1) ? "Some of those packages" : "This package") . 
-    " may be installed by picking " . ($error > 1 ? "them" : "it") . 
+" . (($error > 1) ? "Some of those packages" : "This package") .
+    " may be installed by picking " . ($error > 1 ? "them" : "it") .
     " in $project-dependencies.tgz available
 on the $project website. !!!!
 ----------------------------------------------------------------------
 ";
-} else { 
+} else {
 
     pr2 "
 ----------------------------------------------------------------------

--- a/copyright.txt
+++ b/copyright.txt
@@ -1,12 +1,12 @@
 Yacfe - Yoann Padioleau
 
-Copyright (C) 2002, 2005, 2006, 2007, 2008, 2009 Yoann Padioleau, 
+Copyright (C) 2002, 2005, 2006, 2007, 2008, 2009 Yoann Padioleau,
 Ecole des Mines de Nantes, University of Urbana Champaign, Université de Rennes
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License (GPL)
   version 2 as published by the Free Software Foundation.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/credits.txt
+++ b/credits.txt
@@ -1,5 +1,5 @@
-Thanks to 
- - Richard Jones for his Dumper module, 
+Thanks to
+ - Richard Jones for his Dumper module,
 
 Thanks of course also to Stallman, Linus, Leroy, Knuth and their
 acolytes for respectively Emacs, Linux, OCaml, and (La)Tex.

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -36,7 +36,7 @@ OCAMLMKTOP=ocamlmktop -g -custom $(INCLUDES) -thread
 ##############################################################################
 
 PROGS=simple_zero_to_null.byte
-#c_transducer.byte 
+#c_transducer.byte
 
 all: $(PROGS)
 opt: $(PROGS:.byte=.opt)
@@ -45,7 +45,7 @@ all.opt: opt
 
 .SUFFIXES: .byte .opt
 
-%.byte: %.cmo 
+%.byte: %.cmo
 	$(OCAMLC) -o $@ $(SYSLIBS) $(LIBS)  $^
 
 %.opt: %.cmx
@@ -78,7 +78,7 @@ clean::
 .ml.cmx:
 	$(OCAMLOPT)  -c $<
 
-.ml.mldepend: 
+.ml.mldepend:
 	$(OCAMLC) -i $<
 
 clean::

--- a/demos/c_transducer.ml
+++ b/demos/c_transducer.ml
@@ -10,7 +10,7 @@ module C = Ast_c
 (* Flags *)
 (*****************************************************************************)
 (* In addition to flags that can be tweaked via -xxx options (cf the
- * full list of options in the "the options" section below), this 
+ * full list of options in the "the options" section below), this
  * program also depends on the external file data/standard.h.
  *)
 
@@ -29,34 +29,34 @@ let action = ref ""
 (* Main action *)
 (*****************************************************************************)
 
-let visit asts2 = 
+let visit asts2 =
   let asts = Parse_c.program_of_program2 asts2 in
-  let props = ref [] in 
+  let props = ref [] in
 
   let bigf = { Visitor_c.default_visitor_c with
-    Visitor_c.ktoplevel = (fun (k, bigf) top -> 
+    Visitor_c.ktoplevel = (fun (k, bigf) top ->
       k top;
       match top with
 
       (* handled by kdecl *)
-      | C.Declaration decl -> 
+      | C.Declaration decl ->
           ()
-      | C.Definition (defbis,_ii) -> 
+      | C.Definition (defbis,_ii) ->
           let name = defbis.C.f_name in
           let s = Ast_c.str_of_name name in
 
           Common.push2 ("function:" ^s) props;
-      | C.MacroTop (s,_,_ii) -> 
+      | C.MacroTop (s,_,_ii) ->
           Common.push2 ("macrotop:" ^s) props;
 
-      | _ -> 
+      | _ ->
           ()
     );
   } in
   asts +> List.iter (Visitor_c.vk_toplevel bigf);
 
   let stats = Statistics_c.statistics_of_program asts in
-  stats +> Statistics_code.assoc_of_entities_stat +> List.iter (fun (s,v) -> 
+  stats +> Statistics_code.assoc_of_entities_stat +> List.iter (fun (s,v) ->
     Common.push2 (spf "nb_%s:%d" s v) props
   );
 
@@ -65,11 +65,11 @@ let visit asts2 =
 
 
 
-let transduce  file = 
+let transduce  file =
   Flag_parsing_c.verbose_lexing := false;
   Flag_parsing_c.verbose_parsing := false;
 
-  Flag_parsing_c.debug_lexer := false; 
+  Flag_parsing_c.debug_lexer := false;
   Flag_parsing_c.debug_typedef := false;
   Flag_parsing_c.debug_cpp := false;
   Flag_parsing_c.debug_etdt := false;
@@ -83,10 +83,10 @@ let transduce  file =
 (* The options *)
 (*****************************************************************************)
 
-let all_actions () = 
+let all_actions () =
   []
 
-let options () = 
+let options () =
   Flag_parsing_c.cmdline_flags_macrofile () ++
   Flag_parsing_c.cmdline_flags_verbose () ++
   Flag_parsing_c.cmdline_flags_debugging () ++
@@ -95,10 +95,10 @@ let options () =
   Common.options_of_actions action (all_actions()) ++
   [
   (* this can not be factorized in Common *)
-  "-version",   Arg.Unit (fun () -> 
+  "-version",   Arg.Unit (fun () ->
     pr2 "version: $Date: 2008/06/08 12:32:06 $";
     raise (Common.UnixExit 0)
-  ), 
+  ),
   "   guess what";
   ]
 
@@ -107,9 +107,9 @@ let options () =
 (*****************************************************************************)
 
 
-let main () = 
-  let usage_msg = 
-    "Usage: " ^ basename Sys.argv.(0) ^ 
+let main () =
+  let usage_msg =
+    "Usage: " ^ basename Sys.argv.(0) ^
       " [options] <file> " ^ "\n" ^ "Options are:"
   in
   (* does side effect on many global flags *)
@@ -117,42 +117,42 @@ let main () =
 
   (* must be done after Arg.parse, because -macro_file can set it *)
   Parse_c.init_defs !Flag_parsing_c.std_h;
-    
+
   (* must be done after Arg.parse, because Common.profile is set by it *)
-  Common.profile_code "Main total" (fun () -> 
+  Common.profile_code "Main total" (fun () ->
 
     (match args with
-    
+
     (* --------------------------------------------------------- *)
     (* actions, useful to debug subpart *)
     (* --------------------------------------------------------- *)
-    | xs when List.mem !action (Common.action_list (all_actions())) -> 
+    | xs when List.mem !action (Common.action_list (all_actions())) ->
         Common.do_action !action xs (all_actions())
 
-    | _ when not (Common.null_string !action) -> 
+    | _ when not (Common.null_string !action) ->
         failwith ("unrecognized action or wrong params: " ^ !action)
 
     (* --------------------------------------------------------- *)
     (* main entry *)
     (* --------------------------------------------------------- *)
-    | [x] -> 
+    | [x] ->
         transduce x
 
     (* --------------------------------------------------------- *)
     (* empty entry *)
     (* --------------------------------------------------------- *)
-    | _  -> 
-        Common.usage usage_msg (options()); 
+    | _  ->
+        Common.usage usage_msg (options());
         failwith "too few arguments"
-          
+
     )
   )
 
 (*****************************************************************************)
 let _ =
-  Common.main_boilerplate (fun () -> 
+  Common.main_boilerplate (fun () ->
     main ();
   )
-    
 
-      
+
+

--- a/demos/foo.c
+++ b/demos/foo.c
@@ -1,10 +1,10 @@
-#include <stdlib.h> 
+#include <stdlib.h>
 
-#define FOO 1 
+#define FOO 1
 #define BAR 1 \
  + 1
 
-#define CSTNULL 0 
+#define CSTNULL 0
 
 
 int main()
@@ -20,7 +20,7 @@ int main()
 #endif
 
 	if(x == CSTNULL) { // dont
-	} 
+	}
 
 	if(x == 0) { // do
 	}

--- a/demos/simple_zero_to_null.ml
+++ b/demos/simple_zero_to_null.ml
@@ -2,43 +2,43 @@ open Common
 
 open Ast_c
 
-(* 
+(*
  * transformation:
  *    X == 0  -->  X == NULL when X is a pointer (copy paste of cc09.ml)
  * to compile:
- *   $ ocamlc -I ../commons/ -I ../parsing_c/ unix.cma str.cma bigarray.cma ../commons/commons.cma ../parsing_c/parsing_c.cma simple_zero_to_null.ml -o zero_to_null 
- * to test: 
+ *   $ ocamlc -I ../commons/ -I ../parsing_c/ unix.cma str.cma bigarray.cma ../commons/commons.cma ../parsing_c/parsing_c.cma simple_zero_to_null.ml -o zero_to_null
+ * to test:
  *   $ ./zero_to_null foo.c
  *   $ cat /tmp/modified.c
  *)
 
 
-let null_transfo file = 
+let null_transfo file =
   let (ast2, _stat) = Parse_c.parse_c_and_cpp file in
   let ast = Parse_c.program_of_program2 ast2 in
 
   Type_annoter_c.annotate_program !Type_annoter_c.initial_env ast;
 
-  let null_addon = 
+  let null_addon =
     Ast_cocci.ExpressionTag
-      (Ast_cocci.make_term 
+      (Ast_cocci.make_term
           (Ast_cocci.Ident
-            (Ast_cocci.make_term 
+            (Ast_cocci.make_term
                 (Ast_cocci.Id
                   ("NULL", Ast_cocci.no_info,
                   Ast_cocci.PLUS, Ast_cocci.NoMetaPos)))))
   in
 
   Visitor_c.vk_program { Visitor_c.default_visitor_c with
-    Visitor_c.kexpr = (fun (k, bigf) exp -> 
+    Visitor_c.kexpr = (fun (k, bigf) exp ->
       match Ast_c.unwrap_expr exp with
-      | Binary(e1, Logical (Eq), (((Constant(Int("0")) as _e2),_t),ii)) -> 
+      | Binary(e1, Logical (Eq), (((Constant(Int("0")) as _e2),_t),ii)) ->
 
-          (match Ast_c.get_onlytype_expr e1 with 
-          | Some (qu, (Pointer _,_ii)) -> 
+          (match Ast_c.get_onlytype_expr e1 with
+          | Some (qu, (Pointer _,_ii)) ->
 
               let idzero = Common2.tuple_of_list1 ii in
-              idzero.cocci_tag := 
+              idzero.cocci_tag :=
                 Some (Ast_cocci.MINUS (Ast_cocci.NoPos, [[null_addon]]), []);
 
           | _ -> k exp
@@ -51,5 +51,5 @@ let null_transfo file =
   Common.cat tmpfile +> List.iter pr2;
   ()
 
-let main = 
+let main =
   null_transfo Sys.argv.(1)

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 #!!!!You need to source me with "source env.sh" from the _RIGHT_ directory!!!!
 if [ ! -r config/macros/standard.h ]
-    then echo "There is no standard.h in config/macros/. 
+    then echo "There is no standard.h in config/macros/.
 Are you sure you run this script from the source directory ?
 ";
 fi

--- a/globals/Makefile
+++ b/globals/Makefile
@@ -53,7 +53,7 @@ $(TARGET).cmxa: $(OPTOBJS) $(LIBS:.cma=.cmxa)
 .ml.cmx:
 	$(OCAMLOPT) -c $<
 
-.ml.mldepend: 
+.ml.mldepend:
 	$(OCAMLC) -i $<
 
 clean::

--- a/globals/config.ml
+++ b/globals/config.ml
@@ -1,6 +1,6 @@
 let version = "0.3"
 
-let path = 
-  try (Sys.getenv "YACFE_HOME") 
+let path =
+  try (Sys.getenv "YACFE_HOME")
   with Not_found->"/usr/local/share/yacfe"
 

--- a/install.txt
+++ b/install.txt
@@ -8,7 +8,7 @@ Install both the runtime and the development libraries for:
 OCaml (see http://caml.inria.fr/download.en.html)
 make
 
-Then simply type 
+Then simply type
  ./configure
  make depend
  make
@@ -34,7 +34,7 @@ via the Godi package manager for OCaml. Download godi from
   http://godi.ocaml-programming.de/
 
 Follow installation instructions.  Then issue the commands:
- 
+
   godi_console perform -build godi-ocaml-all
 
 

--- a/main.ml
+++ b/main.ml
@@ -4,7 +4,7 @@ open Common
 (* Purpose *)
 (*****************************************************************************)
 
-(* This module handle the IO, the special name of info files. 
+(* This module handle the IO, the special name of info files.
  * the pure algorithmic stuff is in parsing_c/
  *)
 
@@ -13,9 +13,9 @@ open Common
 (*****************************************************************************)
 
 (* In addition to flags that can be tweaked via -xxx options (cf the
- * full list of options in the "the options" section below), this 
- * program also depends on the external file 
- * - macro files in macros/standard.h, 
+ * full list of options in the "the options" section below), this
+ * program also depends on the external file
+ * - macro files in macros/standard.h,
  * - and typing environment in environment_unix.h
  * Then can be set via -macro_file, -envir_file.
  *)
@@ -33,26 +33,26 @@ let macro_file = ref ""
 (* Helpers *)
 (*****************************************************************************)
 
-let parse_and_comments_of_file file = 
-  let (program2, parsing_stat) = 
+let parse_and_comments_of_file file =
+  let (program2, parsing_stat) =
     Parse_c.parse_c_and_cpp file in
-  
+
   (* let program = Parse_c.program_of_program2 program2 in *)
 
       (* let _estat = Statistics_c.statistics_of_program program in *)
-  
-  program2 +> List.iter (fun (ast, (s, toks)) -> 
+
+  program2 +> List.iter (fun (ast, (s, toks)) ->
     Parse_c.print_commentized toks
   )
-       
+
 
 (*****************************************************************************)
 (* Main action *)
 (*****************************************************************************)
 
-let main_action xs = 
+let main_action xs =
   match xs with
-  | x::xs -> 
+  | x::xs ->
         (* CQL *)
 
         let ext = "[ch]" in
@@ -64,9 +64,9 @@ let main_action xs =
         (* let comment_stat_list = ref [] in *)
         (* let entities_stat_list = ref [] in *)
 
-        Common2.check_stack_nbfiles nbfiles; 
+        Common2.check_stack_nbfiles nbfiles;
 
-        files +> Common.index_list +> List.iter (fun (file, i) -> 
+        files +> Common.index_list +> List.iter (fun (file, i) ->
 
           pr2 (spf "PARSING: %s (%d/%d)" file i nbfiles);
 
@@ -76,10 +76,10 @@ let main_action xs =
            * - comments_extraction check
            *)
 
-          let (program, parsing_stat) = 
+          let (program, parsing_stat) =
             Parse_c.parse_c_and_cpp file in
 
-          let (_comments_packed, _allx, _pinfo_mapping, _entities_stat) = 
+          let (_comments_packed, _allx, _pinfo_mapping, _entities_stat) =
             (* TOREPUT Comment_annotater.comments_of_program program *)
             (), (), (), ()
           in
@@ -116,10 +116,10 @@ let main_action xs =
 
 let score_path = "/home/pad/c-yacfe/tmp"
 
-let parse_one_file (file, i, nbfiles) = 
+let parse_one_file (file, i, nbfiles) =
   pr2 (spf "PARSING: %s (%d/%d)" file i nbfiles);
 
-  let (stat) = 
+  let (stat) =
     parse_and_comments_of_file file
   in
   file, stat
@@ -128,10 +128,10 @@ let parse_one_file (file, i, nbfiles) =
 let parse_all xs =
 
 (*
-  let dirname_opt = 
+  let dirname_opt =
     match xs with
     | [x] when Common2.is_directory x -> Some x
-    | xs -> 
+    | xs ->
         Some (xs +> Common.join "" +> Common2.md5sum_of_string)
   in
 *)
@@ -154,15 +154,15 @@ let parse_all xs =
   let newscore  = Common2.empty_score () in
   let parsing_stat_list = ref [] in
 
-  let biglist = (fun () -> 
+  let biglist = (fun () ->
 
-    let files = 
+    let files =
       if (xs +> List.for_all Common2.is_directory)
       then
         let ext = "[ch]" in
         let ext2 = "java" in
         let ext3 = ".*\\.\\(cpp\\|cc\\|C\\|cxx\\|hpp\\|hxx\\)$" in
-        
+
         let files1 = Common2.files_of_dir_or_files ext (xs) in
         let files2 = Common2.files_of_dir_or_files ext2 (xs) in
         let files3 = Common2.files_of_dir_or_files_no_vcs_post_filter ext3 xs in
@@ -171,47 +171,47 @@ let parse_all xs =
       else xs
     in
     let nbfiles = List.length files in
-    Common2.check_stack_nbfiles nbfiles; 
+    Common2.check_stack_nbfiles nbfiles;
 
     files +> Common.index_list +> List.map (fun (i,j) -> (i,j,nbfiles))
   )
   in
   let map_ex = parse_one_file in
 
-  let reduce_ex = (fun xxs -> 
+  let reduce_ex = (fun xxs ->
     let stats_parse = xxs in
 
-    stats_parse +> List.iter (fun (file, stat) -> 
-      let s = 
-        spf "bad = %d, timeout = %B" 
+    stats_parse +> List.iter (fun (file, stat) ->
+      let s =
+        spf "bad = %d, timeout = %B"
           stat.Statistics_parsing.bad stat.Statistics_parsing.have_timeout
       in
-      
+
       Common.push stat  parsing_stat_list;
 
-      if stat.Statistics_parsing.bad = 0 && 
+      if stat.Statistics_parsing.bad = 0 &&
         not stat.Statistics_parsing.have_timeout
       then Hashtbl.add newscore file (Common2.Ok)
       else Hashtbl.add newscore file (Common2.Pb s)
     );
 
- 
-    dirname_opt +> Common.do_option (fun dirname -> 
+
+    dirname_opt +> Common.do_option (fun dirname ->
       pr2 "--------------------------------";
       pr2 "regression testing  information";
       pr2 "--------------------------------";
       let str = Str.global_replace (Str.regexp "/") "__" dirname in
       let def = if !Flag_parsing_c.filter_define_error then "_def_" else "" in
       let ext = "_all_" in
-      Common2.regression_testing newscore 
+      Common2.regression_testing newscore
         (Filename.concat score_path
             ("score_parsing__" ^str ^ def ^ ext ^ ".marshalled"))
     );
-    
+
     Common2.pr2_xxxxxxxxxxxxxxxxx();
     Parsing_stat.print_stat_numbers ();
     Statistics_parsing.print_parsing_stat_list !parsing_stat_list;
-    
+
 
     !parsing_stat_list, newscore
   ) in
@@ -232,14 +232,14 @@ let yacfe_extra_actions () = [
 (*****************************************************************************)
 let (++) = (@)
 
-let all_actions () = 
+let all_actions () =
    yacfe_extra_actions() ++
    Test.actions() ++
    Test_parsing_c.actions() ++
 
    []
 
-let options () = 
+let options () =
   Flag_parsing_c.cmdline_flags_macrofile () ++
   Flag_parsing_c.cmdline_flags_envfile () ++
   Flag_parsing_c.cmdline_flags_cpp () ++
@@ -250,7 +250,7 @@ let options () =
   Flag_parsing_c.cmdline_flags_checks () ++
 
   [
-    "-macro_file", Arg.Set_string macro_file, 
+    "-macro_file", Arg.Set_string macro_file,
     " <file>";
   ] ++
   Common.options_of_actions action (all_actions()) ++
@@ -258,33 +258,33 @@ let options () =
   Common2.cmdline_flags_verbose () ++
   Common2.cmdline_flags_other () ++
   [
-  "-version",   Arg.Unit (fun () -> 
+  "-version",   Arg.Unit (fun () ->
     pr2 (spf "yacfe version: %s" Config.version);
     exit 0;
-  ), 
+  ),
     "  guess what";
 
   (* this can not be factorized in Common *)
-  "-date",   Arg.Unit (fun () -> 
+  "-date",   Arg.Unit (fun () ->
     pr2 "version: $Date: 2008/10/26 00:44:57 $";
     raise (Common.UnixExit 0)
-    ), 
+    ),
   "   guess what";
   ]
 
- 
+
 (*****************************************************************************)
 (* Main entry point *)
 (*****************************************************************************)
 
-let main () = 
+let main () =
   (*Common_extra.set_link(); *)
   (*let argv = Features.Distribution.mpi_adjust_argv Sys.argv in *)
   let argv = Sys.argv in
 
 
-  let usage_msg = 
-    "Usage: " ^ Filename.basename Sys.argv.(0) ^ 
+  let usage_msg =
+    "Usage: " ^ Filename.basename Sys.argv.(0) ^
       " [options] <file or dir> " ^ "\n" ^ "Options are:"
   in
   (* does side effect on many global flags *)
@@ -293,46 +293,46 @@ let main () =
   (* must be done after Arg.parse, because -macro_file can set it *)
   Parse_c.init_defs_builtins !Flag_parsing_c.std_h;
 
-  if !macro_file <> "" 
+  if !macro_file <> ""
   then Parse_c.init_defs !macro_file;
 
   Type_annoter_c.init_env !Flag_parsing_c.std_envir;
 
   Cpp_ast_c.show_cpp_i_opts !Flag_parsing_c.cpp_i_opts;
   Cpp_ast_c.show_cpp_d_opts !Flag_parsing_c.cpp_d_opts;
-    
+
   (* must be done after Arg.parse, because Common.profile is set by it *)
-  Common.profile_code "Main total" (fun () -> 
+  Common.profile_code "Main total" (fun () ->
 
     (match args with
-    
+
     (* --------------------------------------------------------- *)
     (* actions, useful to debug subpart *)
     (* --------------------------------------------------------- *)
-    | xs when List.mem !action (Common.action_list (all_actions())) -> 
+    | xs when List.mem !action (Common.action_list (all_actions())) ->
         Common.do_action !action xs (all_actions())
 
-    | _ when not (Common.null_string !action) -> 
+    | _ when not (Common.null_string !action) ->
         failwith ("unrecognized action or wrong params: " ^ !action)
 
     (* --------------------------------------------------------- *)
     (* main entry *)
     (* --------------------------------------------------------- *)
-    | x::xs -> 
+    | x::xs ->
         main_action (x::xs)
 
     (* --------------------------------------------------------- *)
     (* empty entry *)
     (* --------------------------------------------------------- *)
-    | [] -> 
-        Common.usage usage_msg (options()); 
+    | [] ->
+        Common.usage usage_msg (options());
         failwith "too few arguments"
-          
+
     )
   )
 
 (*****************************************************************************)
 let _ =
-  Common.main_boilerplate (fun () -> 
+  Common.main_boilerplate (fun () ->
     main ();
   )

--- a/parsing_c/Makefile
+++ b/parsing_c/Makefile
@@ -21,25 +21,25 @@ SRC= flag_parsing_c.ml parsing_stat.ml \
 
 
 # ast_cocci.ml and unparse_cocci.ml should be deleted in the futur
-# to make parsing_c really independent of coccinelle. 
+# to make parsing_c really independent of coccinelle.
 # control_flow_c have also coccinelle dependencies.
-# old: parsing_c now depends on cocci_parser because in addition to decorate 
+# old: parsing_c now depends on cocci_parser because in addition to decorate
 # the token in Ast_c with some parse info, we now also make some place to
 # welcome some mcodekind of Ast_cocci.
 #LIBS=../commons/commons.cma ../globals/globals.cma \
 #     ../parsing_cocci/cocci_parser.cma
 #
-#INCLUDES= -I ../commons -I ../globals -I  ../parsing_cocci 
+#INCLUDES= -I ../commons -I ../globals -I  ../parsing_cocci
 
 LIBS=../commons/commons.cma
 INCLUDES= -I ../commons -I ../commons_ocollection -I ../pl_info
-SYSLIBS= str.cma unix.cma 
+SYSLIBS= str.cma unix.cma
 
 ##############################################################################
 # Generic variables
 ##############################################################################
 
-#for warning:  -w A 
+#for warning:  -w A
 #for profiling:  -p -inline 0   with OCAMLOPT
 OCAMLCFLAGS ?= -g -dtypes
 
@@ -129,7 +129,7 @@ locindiv:
 .ml.cmx:
 	$(OCAMLOPT) -c $<
 
-.ml.mldepend: 
+.ml.mldepend:
 	$(OCAMLC) -i $<
 
 clean::

--- a/parsing_c/ast_c.ml
+++ b/parsing_c/ast_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2002, 2006, 2007, 2008, 2009 Yoann Padioleau
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -18,9 +18,9 @@ open Common
 (*****************************************************************************)
 (*
  * Some stuff are tagged semantic: which means that they are computed
- * after parsing. 
- * 
- * This means that some elements in this AST are present only if 
+ * after parsing.
+ *
+ * This means that some elements in this AST are present only if
  * some annotation/transformation has been done on the original AST returned
  * by the parser. Cf type_annotater, comment_annotater, cpp_ast_c, etc.
  *)
@@ -30,38 +30,38 @@ open Common
 (* Token/info *)
 (* ------------------------------------------------------------------------- *)
 
-(* To allow some transformations over the AST, we keep as much information 
- * as possible in the AST such as the tokens content and their locations. 
+(* To allow some transformations over the AST, we keep as much information
+ * as possible in the AST such as the tokens content and their locations.
  * Those info are called 'info' (how original) and can be tagged.
  * For instance one tag may say that the unparser should remove this token.
- * 
+ *
  * Update: Now I use a ref! in those 'info' so take care.
  * That means that modifications of the info of tokens can have
- * an effect on the info stored in the ast (which is sometimes 
+ * an effect on the info stored in the ast (which is sometimes
  * convenient, cf unparse_c.ml or comment_annotater_c.ml)
- * 
- * convention: I often use 'ii' for the name of a list of info. 
- * 
- * Sometimes we want to add someting at the beginning or at the end 
+ *
+ * convention: I often use 'ii' for the name of a list of info.
+ *
+ * Sometimes we want to add someting at the beginning or at the end
  * of a construct. For 'function' and 'decl' we want to add something
  * to their left and for 'if' 'while' et 'for' and so on at their right.
  * We want some kinds of "virtual placeholders" that represent the start or
  * end of a construct. We use fakeInfo for that purpose.
  * To identify those cases I have added a fakestart/fakeend comment.
- * 
+ *
  * cocci: Each token will be decorated in the future by the mcodekind
  * of cocci. It is the job of the pretty printer to look at this
  * information and decide to print or not the token (and also the
  * pending '+' associated sometimes with the token).
- * 
+ *
  * The first time that we parse the original C file, the mcodekind is
  * empty, or more precisely all is tagged as a CONTEXT with NOTHING
  * associated. This is what I call a "clean" expr/statement/....
- * 
+ *
  * Each token will also be decorated in the future with an environment,
  * because the pending '+' may contain metavariables that refer to some
  * C code.
- * 
+ *
  *)
 
 (* forunparser: *)
@@ -73,7 +73,7 @@ type posl = int * int (* line-col, for MetaPosValList, for position variables *)
 type virtual_position = Parse_info.t * int (* character offset *)
  (* with sexp *)
 
-type parse_info = 
+type parse_info =
   (* Present both in ast and list of tokens *)
   | OriginTok of Parse_info.t
   (* Present only in ast and generated after parsing. Used mainly
@@ -89,11 +89,11 @@ type parse_info =
   | AbstractLineTok of Parse_info.t (* local to the abstracted thing *)
  (* with sexp *)
 
-type info = { 
+type info = {
   pinfo : parse_info;
 
   (* this cocci_tag can be changed, which is how we can express some program
-   * transformations by tagging the tokens involved in this transformation. 
+   * transformations by tagging the tokens involved in this transformation.
    *)
   cocci_tag: (Ast_cocci.mcodekind * metavars_binding) option ref;
   (* set in comment_annotater_c.ml *)
@@ -114,16 +114,16 @@ and 'a wrap2 = 'a * il
 (* ------------------------------------------------------------------------- *)
 
 (* was called 'ident' before, but 'name' is I think better
- * as concatenated strings can be used not only for identifiers and for 
+ * as concatenated strings can be used not only for identifiers and for
  * declarators, but also for fields, for labels, etc.
  *)
-and name = 
+and name =
    | RegularName of string wrap
    | CppConcatenatedName of (string wrap) wrap2 (* the ## separators *) list
    (* normally only used inside list of things, as in parameters or arguments
     * in which case, cf cpp-manual, it has a special meaning *)
    | CppVariadicName of string wrap (* ## s *)
-   | CppIdentBuilder of string wrap (* s ( ) *) * 
+   | CppIdentBuilder of string wrap (* s ( ) *) *
                        ((string wrap) wrap2 list) (* arguments *)
 
 
@@ -136,19 +136,19 @@ and name =
  * concern. So I put '=>' to mean what we would really like. In fact
  * what we really like is defining another fullType, expression, etc
  * from scratch, because many stuff are just sugar.
- * 
+ *
  * invariant: Array and FunctionType have also typeQualifier but they
  * dont have sense. I put this to factorise some code. If you look in
  * the grammar, you see that we can never specify const for the array
- * himself (but we can do it for pointer) or function, we always 
+ * himself (but we can do it for pointer) or function, we always
  * have in the action rule of the grammar a { (nQ, FunctionType ...) }.
- * 
- * 
+ *
+ *
  * Because of ExprStatement, we can have more 'new scope' events, but
  * rare I think. For instance with 'array of constExpression' there can
  * have an exprStatement and a new (local) struct defined. Same for
  * Constructor.
- * 
+ *
  *)
 
 
@@ -162,41 +162,41 @@ and fullType = typeQualifier * typeC
   | Array           of constExpression option * fullType
   | FunctionType    of functionType
 
-  | Enum            of string option * enumType    
+  | Enum            of string option * enumType
   | StructUnion     of structUnion * string option * structType (* new scope *)
 
   | EnumName        of string
-  | StructUnionName of structUnion * string 
+  | StructUnionName of structUnion * string
 
   | TypeName   of name * fullType option (* semantic: filled later *)
- 
+
   | ParenType of fullType (* forunparser: *)
 
-  (* gccext: TypeOfType below may seems useless; Why declare a 
-   *     __typeof__(int) x; ? 
+  (* gccext: TypeOfType below may seems useless; Why declare a
+   *     __typeof__(int) x; ?
    * When used with macros, it allows to fix a problem of C which
    * is that type declaration can be spread around the ident. Indeed it
-   * may be difficult to have a macro such as 
-   *    '#define macro(type, ident) type ident;' 
-   * because when you want to do a 
-   *     macro(char[256], x), 
-   * then it will generate invalid code, but with a 
-   *       '#define macro(type, ident) __typeof(type) ident;' 
-   * it will work. 
+   * may be difficult to have a macro such as
+   *    '#define macro(type, ident) type ident;'
+   * because when you want to do a
+   *     macro(char[256], x),
+   * then it will generate invalid code, but with a
+   *       '#define macro(type, ident) __typeof(type) ident;'
+   * it will work.
    *)
-  | TypeOfExpr of expression  
-  | TypeOfType of fullType    
+  | TypeOfExpr of expression
+  | TypeOfType of fullType
 
   (* cppext: IfdefType TODO *)
-      
-(* -------------------------------------- *)    
-     and  baseType = Void 
-                   | IntType   of intType 
+
+(* -------------------------------------- *)
+     and  baseType = Void
+                   | IntType   of intType
 		   | FloatType of floatType
 
-	  (* stdC: type section 
+	  (* stdC: type section
            * add  a | SizeT ?
-           * note: char and signed char are semantically different!! 
+           * note: char and signed char are semantically different!!
            *)
           and intType   = CChar (* obsolete? | CWchar  *)
 	                | Si of signed
@@ -208,16 +208,16 @@ and fullType = typeQualifier * typeC
           and floatType = CFloat | CDouble | CLongDouble
 
 
-     (* -------------------------------------- *)    
+     (* -------------------------------------- *)
      and structUnion = Struct | Union
-     and structType  = field list 
-         and field = 
+     and structType  = field list
+         and field =
            | DeclarationField of field_declaration
            (* gccext: *)
            | EmptyField of info
 
             (* cppext: *)
-           | MacroDeclField of (string * argument wrap2 list) 
+           | MacroDeclField of (string * argument wrap2 list)
                                wrap (* optional ';'*)
 
             (* cppext: *)
@@ -226,30 +226,30 @@ and fullType = typeQualifier * typeC
 
 
         (* before unparser, I didn't have a FieldDeclList but just a Field. *)
-         and field_declaration  = 
+         and field_declaration  =
            | FieldDeclList of fieldkind wrap2 list (* , *) wrap  (* ; *)
 
           (* At first I thought that a bitfield could be only Signed/Unsigned.
            * But it seems that gcc allow char i:4. C rule must say that you
-           * can cast into int so enum too, ... 
+           * can cast into int so enum too, ...
            *)
-           and fieldkind = 
+           and fieldkind =
              | Simple   of name option * fullType
-             | BitField of name option * fullType * 
+             | BitField of name option * fullType *
                  info (* : *) * constExpression
-              (* fullType => BitFieldInt | BitFieldUnsigned *) 
+              (* fullType => BitFieldInt | BitFieldUnsigned *)
 
 
-     (* -------------------------------------- *)    
-     and enumType = (name * (info (* = *) * constExpression) option) 
-                    wrap2 (* , *) list 
+     (* -------------------------------------- *)
+     and enumType = (name * (info (* = *) * constExpression) option)
+                    wrap2 (* , *) list
                    (* => string * int list *)
 
 
-     (* -------------------------------------- *)    
+     (* -------------------------------------- *)
      (* return * (params * has "...") *)
      and functionType = fullType * (parameterType wrap2 list * bool wrap)
-        and parameterType = 
+        and parameterType =
         { p_namei: name option;
           p_register: bool wrap;
           p_type: fullType;
@@ -257,13 +257,13 @@ and fullType = typeQualifier * typeC
         (* => (bool (register) * fullType) list * bool *)
 
 
-and typeQualifier = typeQualifierbis wrap 
+and typeQualifier = typeQualifierbis wrap
 and typeQualifierbis = {const: bool; volatile: bool}
 
 (* gccext: cppext: *)
 and attribute = attributebis wrap
   and attributebis =
-    | Attribute of string 
+    | Attribute of string
 
 (* ------------------------------------------------------------------------- *)
 (* C expression *)
@@ -274,14 +274,14 @@ and expression = (expressionbis * exp_info ref (* semantic: *)) wrap
     and local = LocalVar of parse_info | NotLocalVar (* cocci: *)
   and test = Test | NotTest (* cocci: *)
 
- and expressionbis = 
+ and expressionbis =
 
   (* Ident can be a enumeration constant, a simple variable, a name of a func.
    * With cppext, Ident can also be the name of a macro. Sparse says
    * "an identifier with a meaning is a symbol" *)
   | Ident          of name (* todo? more semantic info such as LocalFunc *)
 
-  | Constant       of constant                                  
+  | Constant       of constant
   | FunCall        of expression * argument wrap2 (* , *) list
   (* gccext: x ? /* empty */ : y <=> x ? x : y;  hence the 'option' below *)
   | CondExpr       of expression * expression option * expression
@@ -294,8 +294,8 @@ and expression = (expressionbis * exp_info ref (* semantic: *)) wrap
   | Postfix        of expression * fixOp
   | Infix          of expression * fixOp
 
-  | Unary          of expression * unaryOp                      
-  | Binary         of expression * binaryOp * expression        
+  | Unary          of expression * unaryOp
+  | Binary         of expression * binaryOp * expression
 
   | ArrayAccess    of expression * expression
 
@@ -304,62 +304,62 @@ and expression = (expressionbis * exp_info ref (* semantic: *)) wrap
   | RecordPtAccess of expression * name
   (* redundant normally, could replace it by DeRef RecordAcces *)
 
-  | SizeOfExpr     of expression                                
-  | SizeOfType     of fullType                                  
-  | Cast           of fullType * expression                     
+  | SizeOfExpr     of expression
+  | SizeOfType     of fullType
+  | Cast           of fullType * expression
 
-  (* gccext: *)        
-  | StatementExpr of compound wrap (* ( )     new scope *) 
-  | Constructor  of fullType * initialiser wrap2 (* , *) list 
+  (* gccext: *)
+  | StatementExpr of compound wrap (* ( )     new scope *)
+  | Constructor  of fullType * initialiser wrap2 (* , *) list
 
   (* forunparser: *)
-  | ParenExpr of expression 
+  | ParenExpr of expression
 
   (* cppext: IfdefExpr TODO *)
 
   (* cppext: normmally just expression *)
   and argument = (expression, weird_argument) Common.either
-   and weird_argument = 
+   and weird_argument =
        | ArgType of parameterType
        | ArgAction of action_macro
-      and action_macro = 
+      and action_macro =
         (* todo: ArgStatement of statement, possibly have ghost token *)
-         | ActMisc of il 
+         | ActMisc of il
 
 
   (* I put string for Int and Float because int would not be enough because
    * OCaml int are 31 bits. So simpler to do string. Same reason to have
    * string instead of int list for the String case.
-   * 
+   *
    * note: -2 is not a constant, it is the unary operator '-'
    * applied to constant 2. So the string must represent a positive
    * integer only. *)
 
-  and constant = 
+  and constant =
     | String of (string * isWchar)
     | MultiString of string list (* can contain MacroString, todo: more info *)
     | Char   of (string * isWchar) (* normally it is equivalent to Int *)
-    | Int    of (string  (* * intType*)) 
+    | Int    of (string  (* * intType*))
     | Float  of (string * floatType)
 
     and isWchar = IsWchar | IsChar
 
-  
-  and unaryOp  = GetRef | DeRef | UnPlus |  UnMinus | Tilde | Not 
+
+  and unaryOp  = GetRef | DeRef | UnPlus |  UnMinus | Tilde | Not
                  | GetRefLabel (* gccext: GetRefLabel, via &&label notation *)
   and assignOp = SimpleAssign | OpAssign of arithOp
   and fixOp    = Dec | Inc
 
   and binaryOp = Arith of arithOp | Logical of logicalOp
 
-       and arithOp   = 
+       and arithOp   =
          | Plus | Minus | Mul | Div | Mod
-         | DecLeft | DecRight 
+         | DecLeft | DecRight
          | And | Or | Xor
 
-       and logicalOp = 
-         | Inf | Sup | InfEq | SupEq 
-         | Eq | NotEq 
+       and logicalOp =
+         | Inf | Sup | InfEq | SupEq
+         | Eq | NotEq
          | AndLog | OrLog
 
  and constExpression = expression (* => int *)
@@ -370,14 +370,14 @@ and expression = (expressionbis * exp_info ref (* semantic: *)) wrap
 (* ------------------------------------------------------------------------- *)
 (* note: that assignement is not a statement but an expression;
  * wonderful C langage.
- * 
+ *
  * note: I use 'and' for type definition cos gccext allow statement as
- * expression, so need mutual recursive type definition. 
- * 
+ * expression, so need mutual recursive type definition.
+ *
  *)
 
-and statement = statementbis wrap 
- and statementbis = 
+and statement = statementbis wrap
+ and statementbis =
   | Labeled       of labeled
   | Compound      of compound   (* new scope *)
   | ExprStatement of exprStatement
@@ -386,7 +386,7 @@ and statement = statementbis wrap
   | Jump          of jump
 
   (* simplify cocci: only at the beginning of a compound normally *)
-  | Decl  of declaration 
+  | Decl  of declaration
 
   (* gccext: *)
   | Asm of asmbody
@@ -394,63 +394,63 @@ and statement = statementbis wrap
 
   (* cppext: *)
   | MacroStmt
-  
+
 
 
   and labeled = Label   of name * statement
-              | Case    of expression * statement 
+              | Case    of expression * statement
               | CaseRange of expression * expression * statement (* gccext: *)
 	      |	Default of statement
 
-  (* cppext: 
-   * old: compound = (declaration list * statement list) 
-   * old: (declaration, statement) either list 
+  (* cppext:
+   * old: compound = (declaration list * statement list)
+   * old: (declaration, statement) either list
    * Simplify cocci to just have statement list, by integrating Decl in stmt.
-   * 
+   *
    * update: now introduce also the _sequencable to allow ifdef in the middle.
    * Indeed, I now allow ifdefs in the ast but they must be only between
    * "sequencable" elements. They can be put in a type only if this type
-   * is used in a list, like at the toplevel, used in a 'toplevel list', 
-   * or inside a compound, used in a 'statement list'. I must not allow 
-   * ifdef anywhere. For instance I can not make ifdef a statement 
+   * is used in a list, like at the toplevel, used in a 'toplevel list',
+   * or inside a compound, used in a 'statement list'. I must not allow
+   * ifdef anywhere. For instance I can not make ifdef a statement
    * cos some instruction like If accept only one statement and the
    * ifdef directive must not take the place of a legitimate instruction.
    * We had a similar phenomena in SmPL where we have the notion
-   * of statement and sequencable statement too. Once you have 
+   * of statement and sequencable statement too. Once you have
    * such a type of sequencable thing, then s/xx list/xx_sequencable list/
    * and introduce the ifdef.
-   * 
+   *
    * update: those ifdefs are either passed, or present in the AST but in
    * a flat form. To structure those flat ifdefs you have to run
    * a transformation that will put in a tree the statements inside
    * ifdefs branches. Cf cpp_ast_c.ml. This is for instance the difference
    * between a IfdefStmt (flat) and IfdefStmt2 (tree structured).
-   * 
+   *
    *)
-  and compound = statement_sequencable list 
+  and compound = statement_sequencable list
 
   (* cppext: easier to put at statement_list level than statement level *)
-  and statement_sequencable = 
+  and statement_sequencable =
     | StmtElem of statement
 
-    (* cppext: *) 
+    (* cppext: *)
     | CppDirectiveStmt of cpp_directive
-    | IfdefStmt of ifdef_directive 
+    | IfdefStmt of ifdef_directive
 
     (* this will be build in cpp_ast_c from the previous flat IfdefStmt *)
     | IfdefStmt2 of ifdef_directive list * (statement_sequencable list) list
 
   and exprStatement = expression option
 
- (* for Switch, need check that all elements in the compound start 
+ (* for Switch, need check that all elements in the compound start
   * with a case:, otherwise unreachable code.
   *)
-  and selection     = 
+  and selection     =
    | If     of expression * statement * statement
-   | Switch of expression * statement 
+   | Switch of expression * statement
 
 
-  and iteration     = 
+  and iteration     =
     | While   of expression * statement
     | DoWhile of statement * expression
     | For     of exprStatement wrap * exprStatement wrap * exprStatement wrap *
@@ -459,7 +459,7 @@ and statement = statementbis wrap
     | MacroIteration of string * argument wrap2 list * statement
 
   and jump  = Goto of name
-            | Continue | Break 
+            | Continue | Break
             | Return   | ReturnExpr of expression
             | GotoComputed of expression (* gccext: goto *exp ';' *)
 
@@ -474,26 +474,26 @@ and statement = statementbis wrap
 (* ------------------------------------------------------------------------- *)
 (* Declaration *)
 (* ------------------------------------------------------------------------- *)
-(* (string * ...) option cos can have empty declaration or struct tag 
+(* (string * ...) option cos can have empty declaration or struct tag
  * declaration.
- *   
- * Before I had a Typedef constructor, but why make this special case and not 
- * have StructDef, EnumDef, ... so that 'struct t {...} v' will generate 2 
+ *
+ * Before I had a Typedef constructor, but why make this special case and not
+ * have StructDef, EnumDef, ... so that 'struct t {...} v' will generate 2
  * declarations ? So I try to generalise and not have Typedef either. This
  * requires more work in parsing. Better to separate concern.
- * 
+ *
  * Before the need for unparser, I didn't have a DeclList but just a Decl.
  *
  * I am not sure what it means to declare a prototype inline, but gcc
- * accepts it. 
+ * accepts it.
  *)
 
-and declaration = 
+and declaration =
   | DeclList of onedecl wrap2 (* , *) list wrap (* ; fakestart sto *)
   (* cppext: *)
   | MacroDecl of (string * argument wrap2 list) wrap (* fakestart *)
 
-     and onedecl = 
+     and onedecl =
        { v_namei: (name * (info (* = *) * initialiser) option) option;
          v_type: fullType;
          v_storage: storage;
@@ -507,36 +507,36 @@ and declaration =
      and local_decl = LocalDecl | NotLocalDecl
 
      and initialiser = initialiserbis wrap
-       and initialiserbis = 
-          | InitExpr of expression 
-          | InitList of initialiser wrap2 (* , *) list 
+       and initialiserbis =
+          | InitExpr of expression
+          | InitList of initialiser wrap2 (* , *) list
           (* gccext: *)
           | InitDesignators of designator list * initialiser
           | InitFieldOld  of string * initialiser
           | InitIndexOld  of expression * initialiser
 
        (* ex: [2].y = x,  or .y[2]  or .y.x. They can be nested *)
-       and designator = designatorbis wrap 
-        and designatorbis = 
-            | DesignatorField of string 
+       and designator = designatorbis wrap
+        and designatorbis =
+            | DesignatorField of string
             | DesignatorIndex of expression
             | DesignatorRange of expression * expression
-        
+
 (* ------------------------------------------------------------------------- *)
 (* Function definition *)
 (* ------------------------------------------------------------------------- *)
-(* Normally we should define another type functionType2 because there 
- * are more restrictions on what can define a function than a pointer 
+(* Normally we should define another type functionType2 because there
+ * are more restrictions on what can define a function than a pointer
  * function. For instance a function declaration can omit the name of the
  * parameter whereas a function definition can not. But, in some cases such
- * as 'f(void) {', there is no name too, so I simplified and reused the 
+ * as 'f(void) {', there is no name too, so I simplified and reused the
  * same functionType type for both declaration and function definition.
- * 
+ *
  * Also old style C does not have type in the parameter, so again simpler
  * to abuse the functionType and allow missing type.
  *)
 and definition = definitionbis wrap (* ( ) { } fakestart sto *)
-  and definitionbis = 
+  and definitionbis =
   { f_name: name;
     f_type: functionType; (* less? a functionType2 ? *)
     f_storage: storage;
@@ -550,19 +550,19 @@ and definition = definitionbis wrap (* ( ) { } fakestart sto *)
 (* cppext: cpp directives, #ifdef, #define and #include body *)
 (* ------------------------------------------------------------------------- *)
 and cpp_directive =
-  | Define of define 
-  | Include of includ 
+  | Define of define
+  | Include of includ
   | Undef of string wrap
-  | PragmaAndCo of il 
+  | PragmaAndCo of il
 (*| Ifdef ? no, ifdefs are handled differently, cf ifdef_directive below *)
 
 and define = string wrap (* #define s *) * (define_kind * define_val)
    and define_kind =
    | DefineVar
    | DefineFunc   of ((string wrap) wrap2 list) wrap (* () *)
-   and define_val = 
+   and define_val =
      (* most common case; e.g. to define int constant *)
-     | DefineExpr of expression 
+     | DefineExpr of expression
 
      | DefineStmt of statement
      | DefineType of fullType
@@ -580,31 +580,31 @@ and define = string wrap (* #define s *) * (define_kind * define_val)
 
 
 
-and includ = 
+and includ =
   { i_include: inc_file wrap; (* #include s *)
     (* cocci: computed in ? *)
     i_rel_pos: include_rel_pos option ref;
     (* cocci: cf -test incl *)
-    i_is_in_ifdef: bool; 
+    i_is_in_ifdef: bool;
     (* cf cpp_ast_c.ml. set to None at parsing time. *)
     i_content: (Common.filename (* full path *) * program) option;
   }
- and inc_file = 
+ and inc_file =
   | Local    of inc_elem list
   | NonLocal of inc_elem list
   | Weird of string (* ex: #include SYSTEM_H *)
   and inc_elem = string
 
  (* cocci: to tag the first of #include <xx/> and last of #include <yy/>
-  * 
+  *
   * The first_of and last_of store the list of prefixes that was
   * introduced by the include. On #include <a/b/x>, if the include was
   * the first in the file, it would give in first_of the following
-  * prefixes a/b/c; a/b/; a/ ; <empty> 
-  * 
+  * prefixes a/b/c; a/b/; a/ ; <empty>
+  *
   * This is set after parsing, in cocci.ml, in update_rel_pos.
   *)
- and include_rel_pos = { 
+ and include_rel_pos = {
    first_of : string list list;
    last_of :  string list list;
  }
@@ -614,17 +614,17 @@ and includ =
 (* todo? to specialize if someone need more info *)
 and ifdef_directive = (* or and 'a ifdefed = 'a list wrap *)
   | IfdefDirective of (ifdefkind * matching_tag) wrap
-  and ifdefkind = 
+  and ifdefkind =
     | Ifdef (* todo? of string ? of formula_cpp ? *)
     | IfdefElseif (* same *)
     | IfdefElse (* same *)
-    | IfdefEndif 
-  (* set in Parsing_hacks.set_ifdef_parenthize_info. It internally use 
+    | IfdefEndif
+  (* set in Parsing_hacks.set_ifdef_parenthize_info. It internally use
    * a global so it means if you parse the same file twice you may get
-   * different id. I try now to avoid this pb by resetting it each 
+   * different id. I try now to avoid this pb by resetting it each
    * time I parse a file.
    *)
-  and matching_tag = 
+  and matching_tag =
     IfdefTag of (int (* tag *) * int (* total with this tag *))
 
 
@@ -637,14 +637,14 @@ and ifdef_directive = (* or and 'a ifdefed = 'a list wrap *)
 and toplevel =
   | Declaration of declaration
   | Definition of definition
-         
+
   (* cppext: *)
   | CppTop of cpp_directive
   | IfdefTop of ifdef_directive (* * toplevel list *)
 
   (* cppext: *)
-  | MacroTop of string * argument wrap2 list * il 
-         
+  | MacroTop of string * argument wrap2 list * il
+
   | EmptyDef of il      (* gccext: allow redundant ';' *)
   | NotParsedCorrectly of il
 
@@ -656,12 +656,12 @@ and program = toplevel list
 (*****************************************************************************)
 (* Cocci Bindings *)
 (*****************************************************************************)
-(* Was previously in pattern.ml, but because of the transformer, 
- * we need to decorate each token with some cocci code AND the environment 
+(* Was previously in pattern.ml, but because of the transformer,
+ * we need to decorate each token with some cocci code AND the environment
  * for this cocci code.
  *)
 and metavars_binding = (Ast_cocci.meta_name, metavar_binding_kind) assoc
-  and metavar_binding_kind = 
+  and metavar_binding_kind =
   | MetaIdVal        of string
   | MetaFuncVal      of string
   | MetaLocalFuncVal of string
@@ -690,7 +690,7 @@ and metavars_binding = (Ast_cocci.meta_name, metavar_binding_kind) assoc
 (* C comments *)
 (*****************************************************************************)
 
-(* convention: I often use "m" for comments as I can not use "c" 
+(* convention: I often use "m" for comments as I can not use "c"
  * (already use for c stuff) and "com" is too long.
  *)
 
@@ -716,7 +716,7 @@ and comments_around = {
     *)
    mpos: int;
    (* todo?
-    *  cppbetween: bool; touse? if false positive 
+    *  cppbetween: bool; touse? if false positive
     *  is_alone_in_line: bool; (*for labels, to avoid false positive*)
    *)
   }
@@ -731,7 +731,7 @@ and com = comment list ref
 (* Some constructors *)
 (*****************************************************************************)
 let nullQualif = ({const=false; volatile= false}, [])
-let nQ = nullQualif 
+let nQ = nullQualif
 
 let defaultInt = (BaseType (IntType (Si (Signed, CInt))))
 
@@ -740,18 +740,18 @@ let noInstr = (ExprStatement (None), [])
 let noTypedefDef () = None
 
 
-let emptyMetavarsBinding = 
+let emptyMetavarsBinding =
   ([]: metavars_binding)
 
 let emptyAnnotCocci =
   (Ast_cocci.CONTEXT (Ast_cocci.NoPos,Ast_cocci.NOTHING),
   emptyMetavarsBinding)
 
-let emptyAnnot = 
+let emptyAnnot =
   (None: (Ast_cocci.mcodekind * metavars_binding) option)
 
 (* compatibility mode *)
-let mcode_and_env_of_cocciref aref = 
+let mcode_and_env_of_cocciref aref =
   match !aref with
   | Some x -> x
   | None -> emptyAnnotCocci
@@ -766,20 +766,20 @@ let emptyComments= {
 
 
 (* for include, some meta information needed by cocci *)
-let noRelPos () = 
+let noRelPos () =
   ref (None: include_rel_pos option)
-let noInIfdef () = 
+let noInIfdef () =
   ref false
 
 
-(* When want add some info in ast that does not correspond to 
+(* When want add some info in ast that does not correspond to
  * an existing C element.
  * old: or when don't want 'synchronize' on it in unparse_c.ml
  * (now have other mark for tha matter).
  *)
 let no_virt_pos = ({Parse_info.str="";charpos=0;line=0;column=0;file=""},-1)
 
-let fakeInfo pi  = 
+let fakeInfo pi  =
   { pinfo = FakeTok ("",no_virt_pos);
     cocci_tag = ref emptyAnnot;
     comments_tag = ref emptyComments;
@@ -805,12 +805,12 @@ let set_type_expr ((unwrap_e, oldtyp), iie) newtyp =
   oldtyp := newtyp
   (* old: (unwrap_e, newtyp), iie *)
 
-let get_onlytype_expr ((unwrap_e, typ), iie) = 
+let get_onlytype_expr ((unwrap_e, typ), iie) =
   match !typ with
   | Some (ft,_local), _test -> Some ft
   | None, _ -> None
 
-let get_onlylocal_expr ((unwrap_e, typ), iie) = 
+let get_onlylocal_expr ((unwrap_e, typ), iie) =
   match !typ with
   | Some (ft,local), _test -> Some local
   | None, _ -> None
@@ -822,7 +822,7 @@ let rewrap_typeC (qu, (typeC, ii)) newtypeC  = (qu, (newtypeC, ii))
 
 
 (* ------------------------------------------------------------------------- *)
-let rewrap_str s ii =  
+let rewrap_str s ii =
   {ii with pinfo =
     (match ii.pinfo with
       OriginTok pi -> OriginTok { pi with Parse_info.str = s;}
@@ -830,7 +830,7 @@ let rewrap_str s ii =
     | FakeTok (_,vpi) -> FakeTok (s,vpi)
     | AbstractLineTok pi -> OriginTok { pi with Parse_info.str = s;})}
 
-let rewrap_pinfo pi ii =  
+let rewrap_pinfo pi ii =
   {ii with pinfo = pi}
 
 (* info about the current location *)
@@ -885,7 +885,7 @@ let is_fake ii =
     FakeTok (_,_) -> true
   | _ -> false
 
-let is_origintok ii = 
+let is_origintok ii =
   match ii.pinfo with
   | OriginTok pi -> true
   | _ -> false
@@ -916,7 +916,7 @@ let compare_pos ii1 ii2 =
       |	0 -> compare o1 o2
       |	x -> x
 
-let equal_posl (l1,c1) (l2,c2) = 
+let equal_posl (l1,c1) (l2,c2) =
   (l1 =|= l2) && (c1 =|= c2)
 
 let info_to_fixpos ii =
@@ -943,12 +943,12 @@ let is_test (e : expression) =
  * ocaml '=' to compare Ast elements. To overcome this problem, to be
  * able to use again '=', we just have to get rid of all those extra
  * information, to "abstract those line" (al) information.
- * 
+ *
  * Julia then modifies it a little to have a tokenindex, so the original
  * true al_info is in fact real_al_info.
  *)
 
-let al_info tokenindex x = 
+let al_info tokenindex x =
   { pinfo =
     (AbstractLineTok
        {Parse_info.charpos = tokenindex;
@@ -960,15 +960,15 @@ let al_info tokenindex x =
     comments_tag = ref emptyComments;
   }
 
-let semi_al_info x = 
+let semi_al_info x =
   { x with
     cocci_tag = ref emptyAnnot;
     comments_tag = ref emptyComments;
   }
 
-let magic_real_number = -10 
+let magic_real_number = -10
 
-let real_al_info x = 
+let real_al_info x =
   { pinfo =
     (AbstractLineTok
        {Parse_info.charpos = magic_real_number;
@@ -993,7 +993,7 @@ let al_comments x =
    mafter2=[];
   }
 
-let al_info_cpp tokenindex x = 
+let al_info_cpp tokenindex x =
   { pinfo =
     (AbstractLineTok
        {Parse_info.charpos = tokenindex;
@@ -1005,13 +1005,13 @@ let al_info_cpp tokenindex x =
     comments_tag = ref (al_comments !(x.comments_tag));
   }
 
-let semi_al_info_cpp x = 
+let semi_al_info_cpp x =
   { x with
     cocci_tag = ref emptyAnnot;
     comments_tag = ref (al_comments !(x.comments_tag));
   }
 
-let real_al_info_cpp x = 
+let real_al_info_cpp x =
   { pinfo =
     (AbstractLineTok
        {Parse_info.charpos = magic_real_number;
@@ -1032,27 +1032,27 @@ let real_al_info_cpp x =
  * represented via the wrap2 and associated with an element, with
  * a list where the comma are on their own. f(1,2,2) was
  * [(1,[]); (2,[,]); (2,[,])] and become [1;',';2;',';2].
- * 
+ *
  * Used in cocci_vs_c.ml, to have a more direct correspondance between
  * the ast_cocci of julia and ast_c.
  *)
-let rec (split_comma: 'a wrap2 list -> ('a, il) either list) = 
+let rec (split_comma: 'a wrap2 list -> ('a, il) either list) =
   function
   | [] -> []
-  | (e, ii)::xs -> 
-      if null ii 
+  | (e, ii)::xs ->
+      if null ii
       then (Left e)::split_comma xs
       else Right ii::Left e::split_comma xs
 
-let rec (unsplit_comma: ('a, il) either list -> 'a wrap2 list) = 
+let rec (unsplit_comma: ('a, il) either list -> 'a wrap2 list) =
   function
   | [] -> []
-  | Right ii::Left e::xs -> 
+  | Right ii::Left e::xs ->
       (e, ii)::unsplit_comma xs
-  | Left e::xs -> 
+  | Left e::xs ->
       let empty_ii = [] in
       (e, empty_ii)::unsplit_comma xs
-  | Right ii::_ -> 
+  | Right ii::_ ->
       raise Impossible
 
 
@@ -1062,92 +1062,92 @@ let rec (unsplit_comma: ('a, il) either list -> 'a wrap2 list) =
 (* Helpers, could also be put in lib_parsing_c.ml instead *)
 (*****************************************************************************)
 
-let rec stmt_elems_of_sequencable xs = 
-  xs +> List.map (fun x -> 
+let rec stmt_elems_of_sequencable xs =
+  xs +> List.map (fun x ->
     match x with
     | StmtElem e -> [e]
     | CppDirectiveStmt _
-    | IfdefStmt _ 
-        -> 
+    | IfdefStmt _
+        ->
         pr2_once ("stmt_elems_of_sequencable: filter a directive");
         []
-    | IfdefStmt2 (_ifdef, xxs) -> 
+    | IfdefStmt2 (_ifdef, xxs) ->
         pr2 ("stmt_elems_of_sequencable: IfdefStm2 TODO?");
-        xxs +> List.map (fun xs -> 
+        xxs +> List.map (fun xs ->
           let xs' = stmt_elems_of_sequencable xs in
           xs'
         ) +> List.flatten
   ) +> List.flatten
-        
-  
+
+
 
 
 (* should maybe be in pretty_print_c ? *)
 
-let s_of_inc_file inc_file = 
+let s_of_inc_file inc_file =
   match inc_file with
   | Local xs -> xs +> Common.join "/"
   | NonLocal xs -> xs +> Common.join "/"
   | Weird s -> s
 
-let s_of_inc_file_bis inc_file = 
+let s_of_inc_file_bis inc_file =
   match inc_file with
   | Local xs -> "\"" ^ xs +> Common.join "/" ^ "\""
   | NonLocal xs -> "<" ^ xs +> Common.join "/" ^ ">"
   | Weird s -> s
 
-let fieldname_of_fieldkind fieldkind = 
+let fieldname_of_fieldkind fieldkind =
   match fieldkind with
   | Simple (sopt, ft) -> sopt
   | BitField (sopt, ft, info, expr) -> sopt
 
 
-let s_of_attr attr = 
+let s_of_attr attr =
   attr
   +> List.map (fun (Attribute s, ii) -> s)
   +> Common.join ","
 
-let str_of_name ident = 
+let str_of_name ident =
   match ident with
   | RegularName (s,ii) -> s
-  | CppConcatenatedName xs -> 
+  | CppConcatenatedName xs ->
       xs +> List.map (fun (x,iiop) -> unwrap x) +> Common.join "##"
   | CppVariadicName (s, ii) -> "##" ^ s
-  | CppIdentBuilder ((s,iis), xs) -> 
-      s ^ "(" ^ 
+  | CppIdentBuilder ((s,iis), xs) ->
+      s ^ "(" ^
         (xs +> List.map (fun ((x,iix), iicomma) -> x) +> Common.join ",") ^
         ")"
 
-let info_of_name ident = 
+let info_of_name ident =
   match ident with
   | RegularName (s,ii) -> List.hd ii
-  | CppConcatenatedName xs -> 
+  | CppConcatenatedName xs ->
       (match xs with
       | [] -> raise Impossible
-      | ((x,ii1),ii2)::xs -> 
+      | ((x,ii1),ii2)::xs ->
           List.hd ii1
       )
-  | CppVariadicName (s, ii) -> 
-      let (iihash, iis) = Common2.tuple_of_list2 ii in 
+  | CppVariadicName (s, ii) ->
+      let (iihash, iis) = Common2.tuple_of_list2 ii in
       iihash
-  | CppIdentBuilder ((s,iis),xs) -> 
+  | CppIdentBuilder ((s,iis),xs) ->
       List.hd iis
 
-let get_s_and_ii_of_name name = 
+let get_s_and_ii_of_name name =
   match name with
-  | RegularName (s, iis) -> s, List.hd iis 
+  | RegularName (s, iis) -> s, List.hd iis
   | CppIdentBuilder ((s, iis), xs) -> s, List.hd iis
-  | CppVariadicName (s,iis)  -> 
+  | CppVariadicName (s,iis)  ->
       let (iop, iis) = Common2.tuple_of_list2 iis in
       s, iis
-  | CppConcatenatedName xs -> 
+  | CppConcatenatedName xs ->
       (match xs with
       | [] -> raise Impossible
-      | ((s,iis),noiiop)::xs -> 
+      | ((s,iis),noiiop)::xs ->
           s, List.hd iis
       )
 
 
-let name_of_parameter param = 
+let name_of_parameter param =
   param.p_namei +> Common2.map_option (str_of_name)
 

--- a/parsing_c/ast_cocci.ml
+++ b/parsing_c/ast_cocci.ml
@@ -3,31 +3,31 @@
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
- * 
+ *
  * This file was part of Coccinelle.
  *)
 
 (* old: simplified
  *
- * type mcodekind = 
+ * type mcodekind =
  * CONTEXT of pos * unit befaft
  * and pos = NoPos | DontCarePos | FixPos of (int * int)
- * 
+ *
  * and meta_name = ()
- * 
+ *
  * and 'a befaft =
  * BEFORE      of 'a list list
  * | AFTER       of 'a list list
  * | BEFOREAFTER of 'a list list * 'a list list
  * | NOTHING
- * 
- * 
- * 
+ *
+ *
+ *
  * and fixpos =
  * Real of int (* charpos *) | Virt of int * int (* charpos + offset *)
  *)

--- a/parsing_c/ast_to_flow.ml
+++ b/parsing_c/ast_to_flow.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2006, 2007 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -24,19 +24,19 @@ open Oassocb
 
 (*****************************************************************************)
 (* todo?: compute target level with goto (but rare that different I think)
- * ver1: just do init, 
+ * ver1: just do init,
  * ver2: compute depth of label (easy, intercept compound in the visitor)
- * 
+ *
  * checktodo: after a switch, need check that all the st in the
  * compound start with a case: ?
- * 
+ *
  * checktodo: how ensure that when we call aux_statement recursivly, we
  * pass it xi_lbl and not just auxinfo ? how enforce that ?
  * in fact we must either pass a xi_lbl or a newxi
- * 
+ *
  * todo: can have code (and so nodes) in many places, in the size of an
  * array, in the init of initializer, but also in StatementExpr, ...
- * 
+ *
  * todo?: steal code from CIL ? (but seems complicated ... again) *)
 (*****************************************************************************)
 
@@ -44,7 +44,7 @@ open Oassocb
 (* Types *)
 (*****************************************************************************)
 
-type error = 
+type error =
   | DeadCode          of Parse_info.t option
   | CaseNoSwitch      of Parse_info.t
   | OnlyBreakInSwitch of Parse_info.t
@@ -62,15 +62,15 @@ exception Error of error
 (* Helpers *)
 (*****************************************************************************)
 
-let add_node node labels nodestr g = 
+let add_node node labels nodestr g =
    g#add_node (Control_flow_c.mk_node node labels [] nodestr)
-let add_bc_node node labels parent_labels nodestr g = 
+let add_bc_node node labels parent_labels nodestr g =
    g#add_node (Control_flow_c.mk_node node labels parent_labels  nodestr)
-let add_arc_opt (starti, nodei) g = 
+let add_arc_opt (starti, nodei) g =
   starti +> do_option (fun starti -> g#add_arc ((starti, nodei), Direct))
 
 
-let lbl_0 = [] 
+let lbl_0 = []
 
 let pinfo_of_ii ii = Ast_c.get_opi (List.hd ii).Ast_c.pinfo
 
@@ -81,78 +81,78 @@ let pinfo_of_ii ii = Ast_c.get_opi (List.hd ii).Ast_c.pinfo
 (*****************************************************************************)
 
 (* Sometimes have a continue/break and we must know where we must jump.
- *    
- * ctl_brace: The node list in context_info record the number of '}' at the 
+ *
+ * ctl_brace: The node list in context_info record the number of '}' at the
  * context point, for instance at the switch point. So that when deeper,
  * we can compute the difference between the number of '}' from root to
- * the context point to close the good number of '}' . For instance 
+ * the context point to close the good number of '}' . For instance
  * where there is a 'continue', we must close only until the for.
  *)
 type context_info =
-  | NoInfo 
+  | NoInfo
   | LoopInfo   of nodei * nodei (* start, end *) * node list * int list
   | SwitchInfo of nodei * nodei (* start, end *) * node list * int list
 
-(* for the Compound case I need to do different things depending if 
+(* for the Compound case I need to do different things depending if
  * the compound is the compound of the function definition, the compound of
  * a switch, so this type allows to specify this and enable to factorize
  * code for the Compound
  *)
-and compound_caller = 
+and compound_caller =
   FunctionDef | Statement | Switch of (nodei -> xinfo -> xinfo)
 
-(* other information used internally in ast_to_flow and passed recursively *) 
-and xinfo =  { 
+(* other information used internally in ast_to_flow and passed recursively *)
+and xinfo =  {
 
   ctx: context_info; (* cf above *)
   ctx_stack: context_info list;
 
   (* are we under a ifthen[noelse]. Used for ErrorExit *)
-  under_ifthen: bool; 
+  under_ifthen: bool;
   compound_caller: compound_caller;
 
   (* does not change recursively. Some kind of globals. *)
-  labels_assoc: (string, nodei) oassoc; 
+  labels_assoc: (string, nodei) oassoc;
   exiti:      nodei option;
   errorexiti: nodei option;
 
   (* ctl_braces: the nodei list is to handle current imbrication depth.
-   * It contains the must-close '}'. 
-   * update: now it is instead a node list. 
+   * It contains the must-close '}'.
+   * update: now it is instead a node list.
    *)
   braces: node list;
 
   (* ctl: *)
-  labels: int list; 
+  labels: int list;
   }
 
 
 let initial_info = {
-  ctx = NoInfo; 
+  ctx = NoInfo;
   ctx_stack = [];
   under_ifthen = false;
   compound_caller = Statement;
   braces = [];
-  labels = []; 
+  labels = [];
 
   (* don't change when recurse *)
   labels_assoc = new oassocb [];
   exiti = None;
   errorexiti = None;
-} 
+}
 
 
 (*****************************************************************************)
 (* (Semi) Globals, Julia's style. *)
 (*****************************************************************************)
 (* global graph *)
-let g = ref (new ograph_mutable) 
+let g = ref (new ograph_mutable)
 
 let counter_for_labels = ref 0
 let counter_for_braces = ref 0
 
 (* For switch we use compteur too (or pass int ref) cos need know order of the
- * case if then later want to go from CFG to (original) AST. 
+ * case if then later want to go from CFG to (original) AST.
  * update: obsolete now I think
  *)
 let counter_for_switch = ref 0
@@ -162,31 +162,31 @@ let counter_for_switch = ref 0
 (* helpers *)
 (*****************************************************************************)
 
-(* alt: do via a todo list, so can do all in one pass (but more complex) 
- * todo: can also count the depth level and associate it to the node, for 
- * the ctl_braces: 
+(* alt: do via a todo list, so can do all in one pass (but more complex)
+ * todo: can also count the depth level and associate it to the node, for
+ * the ctl_braces:
  *)
-let compute_labels_and_create_them st = 
+let compute_labels_and_create_them st =
 
   (* map C label to index number in graph *)
   let (h: (string, nodei) oassoc ref) = ref (new oassocb []) in
 
   begin
-    st +> Visitor_c.vk_statement { Visitor_c.default_visitor_c with 
-      Visitor_c.kstatement = (fun (k, bigf) st -> 
+    st +> Visitor_c.vk_statement { Visitor_c.default_visitor_c with
+      Visitor_c.kstatement = (fun (k, bigf) st ->
         match st with
-        | Labeled (Ast_c.Label (name, _st)),ii -> 
+        | Labeled (Ast_c.Label (name, _st)),ii ->
             (* at this point I put a lbl_0, but later I will put the
              * good labels. *)
             let s = Ast_c.str_of_name name in
-            let newi = !g +> add_node (Label (st,name, ((),ii))) lbl_0  (s^":") 
+            let newi = !g +> add_node (Label (st,name, ((),ii))) lbl_0  (s^":")
             in
             begin
               (* the C label already exists ? *)
               if (!h#haskey s) then raise (Error (DuplicatedLabel s));
               h := !h#add (s, newi);
               (* not k _st !!! otherwise in lbl1: lbl2: i++; we miss lbl2 *)
-              k st; 
+              k st;
             end
         | st -> k st
       )
@@ -196,9 +196,9 @@ let compute_labels_and_create_them st =
 
 
 (* ctl_braces: *)
-let insert_all_braces xs starti = 
-  xs  +> List.fold_left (fun acc node -> 
-    (* Have to build a new node (clone), cos cant share it. 
+let insert_all_braces xs starti =
+  xs  +> List.fold_left (fun acc node ->
+    (* Have to build a new node (clone), cos cant share it.
      * update: This is now done by the caller. The clones are in xs.
      *)
     let newi = !g#add_node node in
@@ -211,15 +211,15 @@ let insert_all_braces xs starti =
 (*****************************************************************************)
 
 (* Take in a (optional) start node, return an (optional) end node.
- * 
+ *
  * history:
- * 
+ *
  * ver1: old code was returning an nodei, but goto has no end, so
  * aux_statement should return nodei option.
- * 
+ *
  * ver2: old code was taking a nodei, but should also take nodei
  * option.
- * 
+ *
  * ver3: deadCode detection. What is dead code ? When there is no
  * starti to start from ? So make starti an option too ? Si on arrive
  * sur un label: au moment d'un deadCode, on peut verifier les
@@ -231,41 +231,41 @@ let insert_all_braces xs starti =
  * moment d'arriver sur near: on n'a pas encore de predecesseurs pour
  * ce label. De meme, meme le cas simple ou la derniere instruction
  * c'est un return, alors ca va generer un DeadCode :(
- * 
+ *
  * So make a first pass where dont launch exn at all. Create nodes,
  * if starti is None then dont add arc. Then make a second pass that
  * just checks that all nodes (except enter) have predecessors.
  * So make starti an option too. So type is now
- * 
+ *
  *      nodei option -> statement -> nodei option.
- * 
- * todo?: if the pb is at a fake node, then try first successos that 
- * is non fake. 
- * 
+ *
+ * todo?: if the pb is at a fake node, then try first successos that
+ * is non fake.
+ *
  * ver4: because of special needs of coccinelle, need pass more info, cf
  * type additionnal_info defined above.
- * 
+ *
  * - to complete (break, continue (and enclosing loop), switch (and
  * associated case, casedefault)) we need to pass additionnal info.
  * The start/exit when enter in a loop, to know the current 'for'.
- * 
+ *
  * - to handle the braces, need again pass additionnal info.
- * 
+ *
  * - need pass the labels.
- * 
+ *
  * convention: xi for the auxinfo passed recursively
- * 
+ *
  *)
 
-let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) = 
+let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
  fun (starti, xi) stmt ->
 
   if not !Flag_parsing_c.label_strategy_2
   then incr counter_for_labels;
-    
-  let lbl = 
-    if !Flag_parsing_c.label_strategy_2 
-    then xi.labels 
+
+  let lbl =
+    if !Flag_parsing_c.label_strategy_2
+    then xi.labels
     else xi.labels @ [!counter_for_labels]
   in
 
@@ -273,22 +273,22 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
    * But in some cases we add additionnal stuff in which case we don't use
    * this 'xi_lbl' but a 'newxi' specially built.
    *)
-  let xi_lbl = 
+  let xi_lbl =
     if !Flag_parsing_c.label_strategy_2
     then { xi with
       compound_caller = Statement;
     }
-    else { xi with 
-      labels = xi.labels @ [ !counter_for_labels ]; 
+    else { xi with
+      labels = xi.labels @ [ !counter_for_labels ];
       compound_caller = Statement;
-    } 
+    }
   in
-      
-  (* ------------------------- *)        
+
+  (* ------------------------- *)
   match stmt with
 
   (*  coupling: the Switch case copy paste parts of the Compound case *)
-  | Ast_c.Compound statxs, ii -> 
+  | Ast_c.Compound statxs, ii ->
       (* flow_to_ast: *)
       let (i1, i2) = Common2.tuple_of_list2 ii in
 
@@ -304,7 +304,7 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
         | Statement -> xi.labels @ [!counter_for_labels]
         | Switch _ -> xi.labels
       in
- 
+
       let newi = !g +> add_node (SeqStart (stmt, brace, i1)) lbl s1 in
       let endnode = mk_node     (SeqEnd (brace, i2))         lbl [] s2 in
       let endnode_dup = mk_fake_node (SeqEnd (brace, i2))    lbl [] s2 in
@@ -316,7 +316,7 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       let newxi = { xi_lbl with braces = endnode_dup:: xi_lbl.braces } in
 
       let newxi = match xi.compound_caller with
-        | Switch todo_in_compound -> 
+        | Switch todo_in_compound ->
             (* note that side effect in todo_in_compound *)
             todo_in_compound newi newxi
         | FunctionDef | Statement -> newxi
@@ -328,10 +328,10 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       aux_statement_list starti (xi, newxi) statxs
 
       (* braces: *)
-      +> Common2.fmap (fun starti -> 
+      +> Common2.fmap (fun starti ->
             (* subtil: not always return a Some.
              * Note that if starti is None, alors forcement ca veut dire
-             * qu'il y'a eu un return (ou goto), et donc forcement les 
+             * qu'il y'a eu un return (ou goto), et donc forcement les
              * braces auront au moins ete crée une fois, et donc flow_to_ast
              * marchera.
              * Sauf si le goto revient en arriere ? mais dans ce cas
@@ -340,12 +340,12 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
              *)
             let endi = !g#add_node endnode in
             !g#add_arc ((starti, endi), Direct);
-            endi 
-           ) 
+            endi
+           )
 
 
-   (* ------------------------- *)        
-  | Labeled (Ast_c.Label (name, st)), ii -> 
+   (* ------------------------- *)
+  | Labeled (Ast_c.Label (name, st)), ii ->
       let s = Ast_c.str_of_name name in
       let ilabel = xi.labels_assoc#find s in
       let node = mk_node (unwrap (!g#nodes#find ilabel)) lbl [] (s ^ ":") in
@@ -354,77 +354,77 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       aux_statement (Some ilabel, xi_lbl) st
 
 
-  | Jump (Ast_c.Goto name), ii -> 
+  | Jump (Ast_c.Goto name), ii ->
       let s = Ast_c.str_of_name name in
      (* special_cfg_ast: *)
      let newi = !g +> add_node (Goto (stmt, name, ((),ii))) lbl ("goto "^s^":")
      in
      !g +> add_arc_opt (starti, newi);
 
-     let ilabel = 
-       try xi.labels_assoc#find s 
-       with Not_found -> 
-         (* jump vers ErrorExit a la place ? 
-          * pourquoi tant de "cant jump" ? pas detecté par gcc ? 
+     let ilabel =
+       try xi.labels_assoc#find s
+       with Not_found ->
+         (* jump vers ErrorExit a la place ?
+          * pourquoi tant de "cant jump" ? pas detecté par gcc ?
           *)
          raise (Error (GotoCantFindLabel (s, pinfo_of_ii ii)))
      in
-     (* !g +> add_arc_opt (starti, ilabel); 
+     (* !g +> add_arc_opt (starti, ilabel);
       * todo: special_case: suppose that always goto to toplevel of function,
-      * hence the Common.init 
-      * todo?: can perhaps report when a goto is not a classic error_goto ? 
+      * hence the Common.init
+      * todo?: can perhaps report when a goto is not a classic error_goto ?
       * that is when it does not jump to the toplevel of the function.
       *)
      let newi = insert_all_braces (Common2.list_init xi.braces) newi in
      !g#add_arc ((newi, ilabel), Direct);
      None
-      
-  | Jump (Ast_c.GotoComputed e), ii -> 
+
+  | Jump (Ast_c.GotoComputed e), ii ->
       raise (Error (ComputedGoto))
-      
-   (* ------------------------- *)        
-  | Ast_c.ExprStatement opte, ii -> 
+
+   (* ------------------------- *)
+  | Ast_c.ExprStatement opte, ii ->
       (* flow_to_ast:   old: when opte = None, then do not add in CFG. *)
-      let s = 
+      let s =
         match opte with
         | None -> "empty;"
-        | Some e -> 
+        | Some e ->
             let ((unwrap_e, typ), ii) = e in
             (match unwrap_e with
-            | FunCall (((Ident (namef), _typ), _ii), _args) -> 
+            | FunCall (((Ident (namef), _typ), _ii), _args) ->
                 Ast_c.str_of_name namef ^ "(...)"
-            | Assignment (((Ident (namevar), _typ), _ii), SimpleAssign, e) -> 
+            | Assignment (((Ident (namevar), _typ), _ii), SimpleAssign, e) ->
                 Ast_c.str_of_name namevar ^ " = ... ;"
-            | Assignment 
+            | Assignment
                 (((RecordAccess (((Ident (namevar), _typ), _ii), field), _typ2),
                   _ii2),
-                 SimpleAssign, 
-                 e) -> 
+                 SimpleAssign,
+                 e) ->
                 let sfield = Ast_c.str_of_name field in
                 Ast_c.str_of_name namevar ^ "." ^ sfield ^ " = ... ;"
-                   
+
             | _ -> "statement"
         )
       in
       let newi = !g +> add_node (ExprStatement (stmt, (opte, ii))) lbl s in
       !g +> add_arc_opt (starti, newi);
       Some newi
-      
 
-   (* ------------------------- *)        
+
+   (* ------------------------- *)
   | Selection  (Ast_c.If (e, st1, (Ast_c.ExprStatement (None), []))), ii ->
       (* sometome can have ExprStatement None but it is a if-then-else,
        * because something like   if() xx else ;
-       * so must force to have [] in the ii associated with ExprStatement 
+       * so must force to have [] in the ii associated with ExprStatement
        *)
-      
+
       let (i1,i2,i3, iifakeend) = Common2.tuple_of_list4 ii in
       let ii = [i1;i2;i3] in
      (* starti -> newi --->   newfakethen -> ... -> finalthen --> lasti
       *                  |                                      |
       *                  |->   newfakeelse -> ... -> finalelse -|
       * update: there is now also a link directly to lasti.
-      *  
+      *
       * because of CTL, now do different things if we are in a ifthen or
       * ifthenelse.
       *)
@@ -449,14 +449,14 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       !g +> add_arc_opt (finalthen, lasti);
       Some lasti
 
-      
-  | Selection  (Ast_c.If (e, st1, st2)), ii -> 
+
+  | Selection  (Ast_c.If (e, st1, st2)), ii ->
      (* starti -> newi --->   newfakethen -> ... -> finalthen --> lasti
       *                 |                                      |
       *                 |->   newfakeelse -> ... -> finalelse -|
       * update: there is now also a link directly to lasti.
       *)
-      let (iiheader, iielse, iifakeend) = 
+      let (iiheader, iielse, iifakeend) =
         match ii with
         | [i1;i2;i3;i4;i5] -> [i1;i2;i3], i4, i5
         | _ -> raise Impossible
@@ -476,12 +476,12 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       let finalthen = aux_statement (Some newfakethen, xi_lbl) st1 in
       let finalelse = aux_statement (Some elsenode, xi_lbl) st2 in
 
-      (match finalthen, finalelse with 
+      (match finalthen, finalelse with
         | (None, None) -> None
-        | _ -> 
-            let lasti = 
+        | _ ->
+            let lasti =
               !g +> add_node (EndStatement(Some iifakeend)) lbl "[endif]" in
-            let afteri = 
+            let afteri =
               !g +> add_node AfterNode lbl "[after]" in
             !g#add_arc ((newi, afteri),  Direct);
             !g#add_arc ((afteri, lasti), Direct);
@@ -490,18 +490,18 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
               !g +> add_arc_opt (finalelse, lasti);
               Some lasti
            end)
-        
-      
-   (* ------------------------- *)        
-  | Selection  (Ast_c.Switch (e, st)), ii -> 
+
+
+   (* ------------------------- *)
+  | Selection  (Ast_c.Switch (e, st)), ii ->
       let (i1,i2,i3, iifakeend) = Common2.tuple_of_list4 ii in
       let ii = [i1;i2;i3] in
 
       (* The newswitchi is for the labels to know where to attach.
        * The newendswitch (endi) is for the 'break'. *)
-      let newswitchi= 
+      let newswitchi=
         !g+> add_node (SwitchHeader(stmt,(e,ii))) lbl "switch" in
-      let newendswitch = 
+      let newendswitch =
         !g +> add_node (EndStatement (Some iifakeend)) lbl "[endswitch]" in
 
       !g +> add_arc_opt (starti, newswitchi);
@@ -510,33 +510,33 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
         * because we need to build a context_info that need some of the
         * information build inside the compound case: the nodei of {
         *)
-       let finalthen = 
+       let finalthen =
          match st with
-         | Ast_c.Compound statxs, ii -> 
+         | Ast_c.Compound statxs, ii ->
              let statxs = Ast_c.stmt_elems_of_sequencable statxs in
-             
+
              (* todo? we should not allow to match a stmt that corresponds
               * to a compound of a switch, so really SeqStart (stmt, ...)
               * here ? so maybe should change the SeqStart labeling too.
               * So need pass a todo_in_compound2 function.
               *)
-             let todo_in_compound newi newxi = 
-               let newxi' = { newxi with 
+             let todo_in_compound newi newxi =
+               let newxi' = { newxi with
                  ctx = SwitchInfo (newi(*!!*), newendswitch, xi.braces, lbl);
                  ctx_stack = newxi.ctx::newxi.ctx_stack
                }
                in
-               !g#add_arc ((newswitchi, newi), Direct); 
-               (* new: if have not a default case, then must add an edge 
+               !g#add_arc ((newswitchi, newi), Direct);
+               (* new: if have not a default case, then must add an edge
                 * between start to end.
-                * todo? except if the case[range] coverthe whole spectrum 
+                * todo? except if the case[range] coverthe whole spectrum
                 *)
-               if not (statxs +> List.exists (function 
+               if not (statxs +> List.exists (function
                | (Labeled (Ast_c.Default _), _) -> true
                | _ -> false
                ))
                then begin
-                 (* when there is no default, then a valid path is 
+                 (* when there is no default, then a valid path is
                   * from the switchheader to the end. In between we
                   * add a Fallthrough.
                   *)
@@ -551,9 +551,9 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
                end;
                newxi'
              in
-             let newxi = { xi with compound_caller = 
-                 Switch todo_in_compound 
-             } 
+             let newxi = { xi with compound_caller =
+                 Switch todo_in_compound
+             }
              in
              aux_statement (None (* no starti *), newxi) st
          | x -> raise Impossible
@@ -562,12 +562,12 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
 
 
        (* what if has only returns inside. We must  try to see if the
-        * newendswitch has been used via a 'break;'  or because no 
+        * newendswitch has been used via a 'break;'  or because no
         * 'default:')
         *)
-       let res = 
+       let res =
          (match finalthen with
-         | Some finalthen -> 
+         | Some finalthen ->
 
              let afteri = !g +> add_node AfterNode lbl "[after]" in
              !g#add_arc ((newswitchi, afteri),  Direct);
@@ -576,7 +576,7 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
 
              !g#add_arc ((finalthen, newendswitch), Direct);
              Some newendswitch
-         | None -> 
+         | None ->
              if (!g#predecessors newendswitch)#null
              then begin
                  assert ((!g#successors newendswitch)#null);
@@ -595,37 +595,37 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
          )
        in
        res
-       
+
 
   | Labeled (Ast_c.Case  (_, _)), ii
-  | Labeled (Ast_c.CaseRange  (_, _, _)), ii -> 
+  | Labeled (Ast_c.CaseRange  (_, _, _)), ii ->
 
       incr counter_for_switch;
       let switchrank = !counter_for_switch in
-      let node, st = 
-        match stmt with 
-        | Labeled (Ast_c.Case  (e, st)), ii -> 
+      let node, st =
+        match stmt with
+        | Labeled (Ast_c.Case  (e, st)), ii ->
             (Case (stmt, (e, ii))),  st
-        | Labeled (Ast_c.CaseRange  (e, e2, st)), ii -> 
+        | Labeled (Ast_c.CaseRange  (e, e2, st)), ii ->
             (CaseRange (stmt, ((e, e2), ii))), st
         | _ -> raise Impossible
       in
 
       let newi = !g +> add_node node  lbl "case:" in
 
-      (match Common2.optionise (fun () -> 
+      (match Common2.optionise (fun () ->
         (* old: xi.ctx *)
-        (xi.ctx::xi.ctx_stack) +> Common.find_some (function 
+        (xi.ctx::xi.ctx_stack) +> Common.find_some (function
         | SwitchInfo (a, b, c, _) -> Some (a, b, c)
         | _ -> None
         ))
       with
-      | Some (startbrace, switchendi, _braces) -> 
+      | Some (startbrace, switchendi, _braces) ->
           (* no need to attach to previous for the first case, cos would be
            * redundant. *)
-          starti +> do_option (fun starti -> 
+          starti +> do_option (fun starti ->
             if starti <> startbrace
-            then !g +> add_arc_opt (Some starti, newi); 
+            then !g +> add_arc_opt (Some starti, newi);
             );
 
           let s = ("[casenode] " ^ i_to_s switchrank) in
@@ -635,9 +635,9 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       | None -> raise (Error (CaseNoSwitch (pinfo_of_ii ii)))
       );
       aux_statement (Some newi, xi_lbl) st
-      
 
-  | Labeled (Ast_c.Default st), ii -> 
+
+  | Labeled (Ast_c.Default st), ii ->
       incr counter_for_switch;
       let switchrank = !counter_for_switch in
 
@@ -645,7 +645,7 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       !g +> add_arc_opt (starti, newi);
 
       (match xi.ctx with
-      | SwitchInfo (startbrace, switchendi, _braces, _parent_lbl) -> 
+      | SwitchInfo (startbrace, switchendi, _braces, _parent_lbl) ->
           let s = ("[casenode] " ^ i_to_s switchrank) in
           let newcasenodei = !g +> add_node (CaseNode switchrank) lbl s in
           !g#add_arc ((startbrace, newcasenodei), Direct);
@@ -659,11 +659,11 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
 
 
 
-   (* ------------------------- *)        
-  | Iteration  (Ast_c.While (e, st)), ii -> 
+   (* ------------------------- *)
+  | Iteration  (Ast_c.While (e, st)), ii ->
      (* starti -> newi ---> newfakethen -> ... -> finalthen -
       *             |---|-----------------------------------|
-      *                 |-> newfakelse 
+      *                 |-> newfakelse
       *)
 
       let (i1,i2,i3, iifakeend) = Common2.tuple_of_list4 ii in
@@ -674,7 +674,7 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       let newfakethen = !g +> add_node InLoopNode  lbl "[whiletrue]" in
       (* let newfakeelse = !g +> add_node FalseNode lbl "[endwhile]" in *)
       let newafter = !g +> add_node FallThroughNode lbl "[whilefall]" in
-      let newfakeelse = 
+      let newfakeelse =
         !g +> add_node (EndStatement (Some iifakeend)) lbl "[endwhile]" in
 
       let newxi = { xi_lbl with
@@ -690,22 +690,22 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       !g +> add_arc_opt (finalthen, newi);
       Some newfakeelse
 
-      
+
   (* This time, may return None, for instance if goto in body of dowhile
-   * (whereas While cant return None). But if return None, certainly 
+   * (whereas While cant return None). But if return None, certainly
    * some deadcode.
    *)
-  | Iteration  (Ast_c.DoWhile (st, e)), ii -> 
+  | Iteration  (Ast_c.DoWhile (st, e)), ii ->
      (* starti -> doi ---> ... ---> finalthen (opt) ---> whiletaili
       *             |--------- newfakethen ---------------|  |---> newfakelse
       *)
-      let is_zero = 
+      let is_zero =
         match Ast_c.unwrap_expr e with
         | Constant (Int "0") -> true
         | _ -> false
       in
 
-      let (iido, iiwhiletail, iifakeend) = 
+      let (iido, iiwhiletail, iifakeend) =
         match ii with
         | [i1;i2;i3;i4;i5;i6] -> i1, [i2;i3;i4;i5], i6
         | _ -> raise Impossible
@@ -714,11 +714,11 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       !g +> add_arc_opt (starti, doi);
       let taili = !g +> add_node (DoWhileTail (e, iiwhiletail)) lbl "whiletail"
       in
-      
+
 
       (*let newfakeelse = !g +> add_node FalseNode lbl "[enddowhile]" in *)
       let newafter = !g +> add_node FallThroughNode lbl "[dowhilefall]" in
-      let newfakeelse = 
+      let newfakeelse =
         !g +> add_node (EndStatement (Some iifakeend)) lbl "[enddowhile]" in
 
       let newxi = { xi_lbl with
@@ -730,42 +730,42 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       if not is_zero
       then begin
         let newfakethen = !g +> add_node InLoopNode lbl "[dowhiletrue]" in
-        !g#add_arc ((taili, newfakethen), Direct); 
-        !g#add_arc ((newfakethen, doi), Direct); 
+        !g#add_arc ((taili, newfakethen), Direct);
+        !g#add_arc ((newfakethen, doi), Direct);
       end;
 
       !g#add_arc ((newafter, newfakeelse), Direct);
       !g#add_arc ((taili, newafter), Direct);
 
 
-      let finalthen = aux_statement (Some doi, newxi) st in 
+      let finalthen = aux_statement (Some doi, newxi) st in
       (match finalthen with
-      | None -> 
+      | None ->
           if (!g#predecessors taili)#null
           then raise (Error (DeadCode (Some (pinfo_of_ii ii))))
           else Some newfakeelse
-      | Some finali -> 
+      | Some finali ->
           !g#add_arc ((finali, taili), Direct);
           Some newfakeelse
       )
-          
 
 
-  | Iteration  (Ast_c.For (e1opt, e2opt, e3opt, st)), ii -> 
+
+  | Iteration  (Ast_c.For (e1opt, e2opt, e3opt, st)), ii ->
       let (i1,i2,i3, iifakeend) = Common2.tuple_of_list4 ii in
       let ii = [i1;i2;i3] in
 
-      let newi = 
+      let newi =
         !g+>add_node(ForHeader(stmt,((e1opt,e2opt,e3opt),ii))) lbl "for" in
       !g +> add_arc_opt (starti, newi);
       let newfakethen = !g +> add_node InLoopNode  lbl "[fortrue]" in
       (*let newfakeelse = !g +> add_node FalseNode lbl "[endfor]" in*)
       let newafter = !g +> add_node FallThroughNode lbl "[forfall]" in
-      let newfakeelse = 
+      let newfakeelse =
         !g +> add_node (EndStatement (Some iifakeend)) lbl "[endfor]" in
 
       let newxi = { xi_lbl with
-           ctx = LoopInfo (newi, newfakeelse, xi_lbl.braces, lbl); 
+           ctx = LoopInfo (newi, newfakeelse, xi_lbl.braces, lbl);
            ctx_stack = xi_lbl.ctx::xi_lbl.ctx_stack
         }
       in
@@ -781,26 +781,26 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
   (* to generate less exception with the breakInsideLoop, analyse
    * correctly the loop deguisé comme list_for_each. Add a case ForMacro
    * in ast_c (and in lexer/parser), and then do code that imitates the
-   * code for the For. 
-   * update: the list_for_each was previously converted into Tif by the 
+   * code for the For.
+   * update: the list_for_each was previously converted into Tif by the
    * lexer, now they are returned as Twhile so less pbs. But not perfect.
    * update: now I recognize the list_for_each macro so no more problems.
    *)
-  | Iteration  (Ast_c.MacroIteration (s, es, st)), ii -> 
+  | Iteration  (Ast_c.MacroIteration (s, es, st)), ii ->
       let (i1,i2,i3, iifakeend) = Common2.tuple_of_list4 ii in
       let ii = [i1;i2;i3] in
 
-      let newi = 
+      let newi =
         !g+>add_node(MacroIterHeader(stmt,((s,es),ii))) lbl "foreach" in
       !g +> add_arc_opt (starti, newi);
       let newfakethen = !g +> add_node InLoopNode  lbl "[fortrue]" in
       (*let newfakeelse = !g +> add_node FalseNode lbl "[endfor]" in*)
       let newafter = !g +> add_node FallThroughNode lbl "[foreachfall]" in
-      let newfakeelse = 
+      let newfakeelse =
         !g +> add_node (EndStatement (Some iifakeend)) lbl "[endforeach]" in
 
       let newxi = { xi_lbl with
-           ctx = LoopInfo (newi, newfakeelse, xi_lbl.braces, lbl); 
+           ctx = LoopInfo (newi, newfakeelse, xi_lbl.braces, lbl);
            ctx_stack = xi_lbl.ctx::xi_lbl.ctx_stack
         }
       in
@@ -814,19 +814,19 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
 
 
 
-   (* ------------------------- *)        
-  | Jump ((Ast_c.Continue|Ast_c.Break) as x),ii ->  
+   (* ------------------------- *)
+  | Jump ((Ast_c.Continue|Ast_c.Break) as x),ii ->
       let context_info =
 	match xi.ctx with
-	  SwitchInfo (startbrace, loopendi, braces, parent_lbl) -> 
+	  SwitchInfo (startbrace, loopendi, braces, parent_lbl) ->
             if x =*= Ast_c.Break
 	    then xi.ctx
 	    else
-	      (try 
-                xi.ctx_stack +> Common.find_some (function 
+	      (try
+                xi.ctx_stack +> Common.find_some (function
                     LoopInfo (_,_,_,_) as c ->  Some c
                   | _ -> None)
-              with Not_found -> 
+              with Not_found ->
                 raise (Error (OnlyBreakInSwitch (pinfo_of_ii ii))))
         | LoopInfo (loopstarti, loopendi, braces, parent_lbl) -> xi.ctx
 	| NoInfo -> raise (Error (NoEnclosingLoop (pinfo_of_ii ii))) in
@@ -859,11 +859,11 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       (* let newi = some starti in *)
 
       (match context_info with
-      | LoopInfo (loopstarti, loopendi, braces, parent_lbl) -> 
-          let desti = 
-            (match x with 
-            | Ast_c.Break -> loopendi 
-            | Ast_c.Continue -> loopstarti 
+      | LoopInfo (loopstarti, loopendi, braces, parent_lbl) ->
+          let desti =
+            (match x with
+            | Ast_c.Break -> loopendi
+            | Ast_c.Continue -> loopstarti
             | x -> raise Impossible
             ) in
           let difference = List.length xi.braces - List.length braces in
@@ -884,20 +884,20 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
       | NoInfo -> raise Impossible
       )
 
-  | Jump ((Ast_c.Return | Ast_c.ReturnExpr _) as kind), ii -> 
+  | Jump ((Ast_c.Return | Ast_c.ReturnExpr _) as kind), ii ->
      (match xi.exiti, xi.errorexiti with
      | None, None -> raise (Error (NoExit (pinfo_of_ii ii)))
-     | Some exiti, Some errorexiti -> 
+     | Some exiti, Some errorexiti ->
 
       (* flow_to_ast: *)
-      let s = 
+      let s =
         match kind with
         | Ast_c.Return -> "return"
         | Ast_c.ReturnExpr _ -> "return ..."
         | _ -> raise Impossible
       in
-      let newi = 
-        !g +> add_node 
+      let newi =
+        !g +> add_node
           (match kind with
           | Ast_c.Return ->       Return (stmt, ((),ii))
           | Ast_c.ReturnExpr e -> ReturnExpr (stmt, (e, ii))
@@ -917,67 +917,67 @@ let rec (aux_statement: (nodei option * xinfo) -> statement -> nodei option) =
      )
 
 
-  (* ------------------------- *)        
-  | Ast_c.Decl decl, ii -> 
-     let s = 
+  (* ------------------------- *)
+  | Ast_c.Decl decl, ii ->
+     let s =
        match decl with
-       | (Ast_c.DeclList 
+       | (Ast_c.DeclList
              ([{v_namei = Some (name, _); v_type = typ; v_storage = sto}, _], _)) ->
 	   "decl:" ^ Ast_c.str_of_name name
        | _ -> "decl_novar_or_multivar"
      in
-            
+
      let newi = !g +> add_node (Decl (decl)) lbl s in
      !g +> add_arc_opt (starti, newi);
      Some newi
-      
-  (* ------------------------- *)        
-  | Ast_c.Asm body, ii -> 
+
+  (* ------------------------- *)
+  | Ast_c.Asm body, ii ->
       let newi = !g +> add_node (Asm (stmt, ((body,ii)))) lbl "asm;" in
       !g +> add_arc_opt (starti, newi);
       Some newi
 
-  | Ast_c.MacroStmt, ii -> 
+  | Ast_c.MacroStmt, ii ->
       let newi = !g +> add_node (MacroStmt (stmt, ((),ii))) lbl "macro;" in
       !g +> add_arc_opt (starti, newi);
       Some newi
 
 
-  (* ------------------------- *)        
-  | Ast_c.NestedFunc def, ii -> 
+  (* ------------------------- *)
+  | Ast_c.NestedFunc def, ii ->
       raise (Error NestedFunc)
-      
 
 
 
 
 
 
-and aux_statement_list starti (xi, newxi) statxs = 
-  statxs 
+
+and aux_statement_list starti (xi, newxi) statxs =
+  statxs
   +> List.fold_left (fun starti statement_seq ->
     if !Flag_parsing_c.label_strategy_2
     then incr counter_for_labels;
-    
-    let newxi' = 
+
+    let newxi' =
       if !Flag_parsing_c.label_strategy_2
-      then { newxi with labels = xi.labels @ [ !counter_for_labels ] } 
+      then { newxi with labels = xi.labels @ [ !counter_for_labels ] }
       else newxi
     in
 
     match statement_seq with
-    | Ast_c.StmtElem statement -> 
+    | Ast_c.StmtElem statement ->
         aux_statement (starti, newxi') statement
 
-    | Ast_c.CppDirectiveStmt directive -> 
+    | Ast_c.CppDirectiveStmt directive ->
         pr2_once ("ast_to_flow: filter a directive");
         starti
 
-    | Ast_c.IfdefStmt ifdef -> 
+    | Ast_c.IfdefStmt ifdef ->
         pr2_once ("ast_to_flow: filter a directive");
         starti
 
-    | Ast_c.IfdefStmt2 (ifdefs, xxs) -> 
+    | Ast_c.IfdefStmt2 (ifdefs, xxs) ->
 
         let (head, body, tail) = Common2.head_middle_tail ifdefs in
 
@@ -985,20 +985,20 @@ and aux_statement_list starti (xi, newxi) statxs =
         let taili = !g +> add_node (IfdefEndif (tail)) newxi'.labels "[endif]" in
         !g +> add_arc_opt (starti, newi);
 
-        let elsenodes = 
-          body +> List.map (fun elseif -> 
-            let elsei = 
+        let elsenodes =
+          body +> List.map (fun elseif ->
+            let elsei =
               !g +> add_node (IfdefElse (elseif)) newxi'.labels "[elseif]" in
             !g#add_arc ((newi, elsei), Direct);
             elsei
           ) in
 
-        let _finalxs = 
-          Common2.zip (newi::elsenodes) xxs +> List.map (fun (start_nodei, xs)-> 
-            let finalthen = 
+        let _finalxs =
+          Common2.zip (newi::elsenodes) xxs +> List.map (fun (start_nodei, xs)->
+            let finalthen =
               aux_statement_list (Some start_nodei) (newxi, newxi) xs in
             !g +> add_arc_opt (finalthen, taili);
-          ) 
+          )
         in
         Some taili
 
@@ -1013,17 +1013,17 @@ let (aux_definition: nodei -> definition -> unit) = fun topi funcdef ->
 
   let lbl_start = [!counter_for_labels] in
 
-  let ({f_name = namefuncs; 
-        f_type = functype; 
-        f_storage= sto; 
+  let ({f_name = namefuncs;
+        f_type = functype;
+        f_storage= sto;
         f_body= compound;
         f_attr= attrs;
         f_old_c_style = oldstyle;
         }, ii) = funcdef in
-  let iifunheader, iicompound = 
-    (match ii with 
-    | ioparen::icparen::iobrace::icbrace::iifake::isto -> 
-        ioparen::icparen::iifake::isto,     
+  let iifunheader, iicompound =
+    (match ii with
+    | ioparen::icparen::iobrace::icbrace::iifake::isto ->
+        ioparen::icparen::iifake::isto,
         [iobrace;icbrace]
     | _ -> raise Impossible
     )
@@ -1031,8 +1031,8 @@ let (aux_definition: nodei -> definition -> unit) = fun topi funcdef ->
 
   let topstatement = Ast_c.Compound compound, iicompound in
 
-  let headi = !g +> add_node 
-    (FunHeader ({ 
+  let headi = !g +> add_node
+    (FunHeader ({
       Ast_c.f_name = namefuncs;
       f_type = functype;
       f_storage = sto;
@@ -1050,14 +1050,14 @@ let (aux_definition: nodei -> definition -> unit) = fun topi funcdef ->
 
   (* ---------------------------------------------------------------- *)
   (* todocheck: assert ? such as we have "consommer" tous les labels  *)
-  let info = 
-    { initial_info with 
+  let info =
+    { initial_info with
       labels = lbl_start;
       labels_assoc = compute_labels_and_create_them topstatement;
       exiti      = Some exiti;
       errorexiti = Some errorexiti;
       compound_caller = FunctionDef;
-    } 
+    }
   in
 
   let lasti = aux_statement (Some enteri, info) topstatement in
@@ -1067,13 +1067,13 @@ let (aux_definition: nodei -> definition -> unit) = fun topi funcdef ->
 (* Entry point *)
 (*****************************************************************************)
 
-(* Helpers for SpecialDeclMacro. 
- * 
+(* Helpers for SpecialDeclMacro.
+ *
  * could also force the coccier to define
  * the toplevel macro statement as in @@ toplevel_declarator MACRO_PARAM;@@
  * and so I would not need this hack and instead I would to a cleaner
  * match in cocci_vs_c_3.ml of a A.MacroTop vs B.MacroTop
- * 
+ *
  * todo: update: now I do what I just described, so can remove this code ?
  *)
 let specialdeclmacro_to_stmt (s, args, ii) =
@@ -1086,9 +1086,9 @@ let specialdeclmacro_to_stmt (s, args, ii) =
 
 
 
-let ast_to_control_flow e = 
+let ast_to_control_flow e =
 
-  (* globals (re)initialialisation *) 
+  (* globals (re)initialialisation *)
   g := (new ograph_mutable);
   counter_for_labels := 1;
   counter_for_braces := 0;
@@ -1096,25 +1096,25 @@ let ast_to_control_flow e =
 
   let topi = !g +> add_node TopNode lbl_0 "[top]" in
 
-  match e with 
-  | Ast_c.Definition ((defbis,_) as def) -> 
+  match e with
+  | Ast_c.Definition ((defbis,_) as def) ->
       let _funcs = defbis.f_name in
       let _c = defbis.f_body in
       (* if !Flag.show_misc then pr2 ("build info function " ^ funcs); *)
       aux_definition topi def;
       Some !g
 
-  | Ast_c.Declaration _ 
+  | Ast_c.Declaration _
   | Ast_c.CppTop (Ast_c.Include _)
   | Ast_c.MacroTop _
-    -> 
-      let (elem, str) = 
-        match e with 
-        | Ast_c.Declaration decl -> 
+    ->
+      let (elem, str) =
+        match e with
+        | Ast_c.Declaration decl ->
             (Control_flow_c.Decl decl),  "decl"
-        | Ast_c.CppTop (Ast_c.Include inc) -> 
+        | Ast_c.CppTop (Ast_c.Include inc) ->
             (Control_flow_c.Include inc), "#include"
-        | Ast_c.MacroTop (s, args, ii) -> 
+        | Ast_c.MacroTop (s, args, ii) ->
             let (st, (e, ii)) = specialdeclmacro_to_stmt (s, args, ii) in
             (Control_flow_c.ExprStatement (st, (Some e, ii))), "macrotoplevel"
           (*(Control_flow_c.MacroTop (s, args,ii), "macrotoplevel") *)
@@ -1127,25 +1127,25 @@ let ast_to_control_flow e =
       !g#add_arc ((ei, endi),Direct);
       Some !g
 
-  | Ast_c.CppTop (Ast_c.Define ((id,ii), (defkind, defval)))  -> 
+  | Ast_c.CppTop (Ast_c.Define ((id,ii), (defkind, defval)))  ->
       let s = ("#define " ^ id) in
       let headeri = !g+>add_node (DefineHeader ((id, ii), defkind)) lbl_0 s in
       !g#add_arc ((topi, headeri),Direct);
 
       (match defval with
-      | Ast_c.DefineExpr e -> 
+      | Ast_c.DefineExpr e ->
           let ei   = !g +> add_node (DefineExpr e) lbl_0 "defexpr" in
           let endi = !g +> add_node EndNode        lbl_0 "[end]" in
           !g#add_arc ((headeri, ei) ,Direct);
           !g#add_arc ((ei, endi) ,Direct);
-          
-      | Ast_c.DefineType ft -> 
+
+      | Ast_c.DefineType ft ->
           let ei   = !g +> add_node (DefineType ft) lbl_0 "deftyp" in
           let endi = !g +> add_node EndNode         lbl_0 "[end]" in
           !g#add_arc ((headeri, ei) ,Direct);
           !g#add_arc ((ei, endi) ,Direct);
 
-      | Ast_c.DefineStmt st -> 
+      | Ast_c.DefineStmt st ->
 
           (* can have some return; inside the statement *)
           let exiti      = !g +> add_node Exit      lbl_0 "[exit]"      in
@@ -1156,56 +1156,56 @@ let ast_to_control_flow e =
             labels_assoc = goto_labels;
             exiti      = Some exiti;
             errorexiti = Some errorexiti;
-          } 
+          }
           in
 
           let lasti = aux_statement (Some headeri , info) st in
-          lasti +> do_option (fun lasti -> 
+          lasti +> do_option (fun lasti ->
             (* todo? if don't have a lasti ? no EndNode ? CTL will work ? *)
             let endi = !g +> add_node EndNode lbl_0 "[end]" in
             !g#add_arc ((lasti, endi), Direct)
           )
-          
 
-      | Ast_c.DefineDoWhileZero ((st,_e), ii) -> 
-          let headerdoi = 
+
+      | Ast_c.DefineDoWhileZero ((st,_e), ii) ->
+          let headerdoi =
             !g +> add_node (DefineDoWhileZeroHeader ((),ii)) lbl_0 "do0" in
           !g#add_arc ((headeri, headerdoi), Direct);
           let info = initial_info in
           let lasti = aux_statement (Some headerdoi , info) st in
-          lasti +> do_option (fun lasti -> 
+          lasti +> do_option (fun lasti ->
             let endi = !g +> add_node EndNode lbl_0 "[end]" in
             !g#add_arc ((lasti, endi), Direct)
           )
 
-      | Ast_c.DefineFunction def -> 
+      | Ast_c.DefineFunction def ->
           aux_definition headeri def;
 
-      | Ast_c.DefineText (s, s_ii) -> 
+      | Ast_c.DefineText (s, s_ii) ->
           raise (Error(Define(pinfo_of_ii ii)))
-      | Ast_c.DefineEmpty -> 
+      | Ast_c.DefineEmpty ->
           let endi = !g +> add_node EndNode lbl_0 "[end]" in
           !g#add_arc ((headeri, endi),Direct);
-      | Ast_c.DefineInit _ -> 
+      | Ast_c.DefineInit _ ->
           raise (Error(Define(pinfo_of_ii ii)))
-      | Ast_c.DefineTodo -> 
+      | Ast_c.DefineTodo ->
           raise (Error(Define(pinfo_of_ii ii)))
 
 (* old:
-      | Ast_c.DefineText (s, ii) -> 
+      | Ast_c.DefineText (s, ii) ->
           let endi = !g +> add_node EndNode lbl_0 "[end]" in
           !g#add_arc ((headeri, endi),Direct);
-      | Ast_c.DefineInit _ -> 
+      | Ast_c.DefineInit _ ->
           let endi = !g +> add_node EndNode lbl_0 "[end]" in
           !g#add_arc ((headeri, endi),Direct);
-      | Ast_c.DefineTodo -> 
+      | Ast_c.DefineTodo ->
           let endi = !g +> add_node EndNode lbl_0 "[end]" in
           !g#add_arc ((headeri, endi),Direct);
 *)
       );
 
       Some !g
-      
+
 
   | _ -> None
 
@@ -1218,18 +1218,18 @@ let annotate_loop_nodes g =
   let firsti = Control_flow_c.first_node g in
 
   (* just for opti a little *)
-  let already = Hashtbl.create 101 in 
+  let already = Hashtbl.create 101 in
 
-  g +> Ograph_extended.dfs_iter_with_path firsti (fun xi path -> 
+  g +> Ograph_extended.dfs_iter_with_path firsti (fun xi path ->
     Hashtbl.add already xi true;
     let succ = g#successors xi in
     let succ = succ#tolist in
-    succ +> List.iter (fun (yi,_edge) -> 
+    succ +> List.iter (fun (yi,_edge) ->
       if Hashtbl.mem already yi && List.mem yi (xi::path)
       then
         let node = g#nodes#find yi in
         let ((node2, nodeinfo), nodestr) = node in
-        let node' = ((node2, {nodeinfo with is_loop = true}), (nodestr ^ "*")) 
+        let node' = ((node2, {nodeinfo with is_loop = true}), (nodestr ^ "*"))
         in
         g#replace_node (yi, node');
     );
@@ -1245,31 +1245,31 @@ let annotate_loop_nodes g =
 
 (* the second phase, deadcode detection. Old code was raising DeadCode if
  * lasti = None, but maybe not. In fact if have 2 return in the then
- * and else of an if ? 
- * 
+ * and else of an if ?
+ *
  * alt: but can assert that at least there exist
  * a node to exiti, just check #pred of exiti.
- * 
- * Why so many deadcode in Linux ? Ptet que le label est utilisé 
+ *
+ * Why so many deadcode in Linux ? Ptet que le label est utilisé
  * mais dans le corps d'une macro et donc on le voit pas :(
- * 
+ *
  *)
-let deadcode_detection g = 
+let deadcode_detection g =
 
-  g#nodes#iter (fun (k, node) -> 
+  g#nodes#iter (fun (k, node) ->
     let pred = g#predecessors k in
-    if pred#null then 
+    if pred#null then
       (match unwrap node with
-      (* old: 
+      (* old:
        * | Enter -> ()
-       * | EndStatement _ -> pr2 "deadcode sur fake node, pas grave"; 
+       * | EndStatement _ -> pr2 "deadcode sur fake node, pas grave";
        *)
       | TopNode -> ()
       | FunHeader _ -> ()
       | ErrorExit -> ()
       | Exit -> ()     (* if have 'loop: if(x) return; i++; goto loop' *)
       | SeqEnd _ -> () (* todo?: certaines '}' deviennent orphelins *)
-      | x -> 
+      | x ->
           (match Control_flow_c.extract_fullstatement node with
           | Some (st, ii) -> raise (Error (DeadCode (Some (pinfo_of_ii ii))))
           | _ -> pr2 "CFG: orphelin nodes, maybe something weird happened"
@@ -1281,10 +1281,10 @@ let deadcode_detection g =
 (* special_cfg_braces: the check are really specific to the way we
  * have build our control_flow, with the { } in the graph so normally
  * all those checks here are useless.
- * 
+ *
  * ver1: to better error reporting, to report earlier the message, pass
  * the list of '{' (containing morover a brace_identifier) instead of
- * just the depth. 
+ * just the depth.
  *)
 
 let (check_control_flow: cflow -> unit) = fun g ->
@@ -1295,60 +1295,60 @@ let (check_control_flow: cflow -> unit) = fun g ->
 
   let print_trace_error xs =  pr2 "PB with flow:";  Common.pr2_gen xs; in
 
-  let rec dfs (nodei, (* Depth depth,*) startbraces,  trace)  = 
+  let rec dfs (nodei, (* Depth depth,*) startbraces,  trace)  =
     let trace2 = nodei::trace in
-    if !visited#haskey nodei 
-    then 
+    if !visited#haskey nodei
+    then
       (* if loop back, just check that go back to a state where have same depth
          number *)
       let (*(Depth depth2)*) startbraces2 = !visited#find nodei in
       if  (*(depth = depth2)*) startbraces <> startbraces2
-      then  
-        begin 
-          pr2 (spf "PB with flow: the node %d has not same braces count" 
-                 nodei);  
-          print_trace_error trace2  
+      then
+        begin
+          pr2 (spf "PB with flow: the node %d has not same braces count"
+                 nodei);
+          print_trace_error trace2
         end
-    else 
+    else
       let children = g#successors nodei in
       let _ = visited := !visited#add (nodei, (* Depth depth*) startbraces) in
 
       (* old: good, but detect a missing } too late, only at the end
-      let newdepth = 
+      let newdepth =
         (match fst (nodes#find nodei) with
         | StartBrace i -> Depth (depth + 1)
         | EndBrace i   -> Depth (depth - 1)
         | _ -> Depth depth
-        ) 
+        )
       in
       *)
-      let newdepth = 
+      let newdepth =
         (match unwrap (nodes#find nodei),  startbraces with
         | SeqStart (_,i,_), xs  -> i::xs
-        | SeqEnd (i,_), j::xs -> 
-            if i =|= j 
+        | SeqEnd (i,_), j::xs ->
+            if i =|= j
             then xs
-            else 
-              begin 
-                pr2 (spf ("PB with flow: not corresponding match between }%d and excpeted }%d at node %d") i j nodei); 
-                print_trace_error trace2; 
-                xs 
+            else
+              begin
+                pr2 (spf ("PB with flow: not corresponding match between }%d and excpeted }%d at node %d") i j nodei);
+                print_trace_error trace2;
+                xs
               end
-        | SeqEnd (i,_), [] -> 
+        | SeqEnd (i,_), [] ->
             pr2 (spf "PB with flow: too much } at }%d " i);
-            print_trace_error trace2; 
+            print_trace_error trace2;
             []
         | _, xs ->  xs
-        ) 
+        )
       in
 
-   
+
       if null children#tolist
-      then 
+      then
         if (* (depth = 0) *) startbraces <> []
         then print_trace_error trace2
-      else 
-        children#tolist +> List.iter (fun (nodei,_) -> 
+      else
+        children#tolist +> List.iter (fun (nodei,_) ->
           dfs (nodei, newdepth, trace2)
         )
     in
@@ -1359,31 +1359,31 @@ let (check_control_flow: cflow -> unit) = fun g ->
 (* Error report *)
 (*****************************************************************************)
 
-let report_error error = 
-  let error_from_info info = 
+let report_error error =
+  let error_from_info info =
     Parse_info.error_message_short info.Parse_info.file ("", info.charpos)
   in
   match error with
-  | DeadCode          infoopt -> 
+  | DeadCode          infoopt ->
       (match infoopt with
       | None ->   pr2 "FLOW: deadcode detected, but cant trace back the place"
       | Some info -> pr2 ("FLOW: deadcode detected: " ^ error_from_info info)
       )
-  | CaseNoSwitch      info -> 
+  | CaseNoSwitch      info ->
       pr2 ("FLOW: case without corresponding switch: " ^ error_from_info info)
-  | OnlyBreakInSwitch info -> 
+  | OnlyBreakInSwitch info ->
       pr2 ("FLOW: only break are allowed in switch: " ^ error_from_info info)
-  | NoEnclosingLoop   (info) -> 
+  | NoEnclosingLoop   (info) ->
       pr2 ("FLOW: can't find enclosing loop: " ^ error_from_info info)
   | GotoCantFindLabel (s, info) ->
       pr2 ("FLOW: cant jump to " ^ s ^ ": because we can't find this label")
-  | NoExit info -> 
+  | NoExit info ->
       pr2 ("FLOW: can't find exit or error exit: " ^ error_from_info info)
-  | DuplicatedLabel s -> 
+  | DuplicatedLabel s ->
       pr2 ("FLOW: duplicate label" ^ s)
-  | NestedFunc  -> 
+  | NestedFunc  ->
       pr2 ("FLOW: not handling yet nested function")
-  | ComputedGoto -> 
+  | ComputedGoto ->
       pr2 ("FLOW: not handling computed goto yet")
   | Define info ->
       pr2 ("Unsupported form of #define: " ^ error_from_info info)

--- a/parsing_c/ast_to_flow.mli
+++ b/parsing_c/ast_to_flow.mli
@@ -6,7 +6,7 @@ val check_control_flow : Control_flow_c.cflow -> unit
 
 val annotate_loop_nodes : Control_flow_c.cflow -> Control_flow_c.cflow
 
-type error = 
+type error =
   | DeadCode          of Parse_info.t option
   | CaseNoSwitch      of Parse_info.t
   | OnlyBreakInSwitch of Parse_info.t

--- a/parsing_c/clone.doc
+++ b/parsing_c/clone.doc
@@ -15,7 +15,7 @@ comment (darcs and ../hg)
 *** use transplant
 
 for coccinelle, they diverge so need cherry-pick via transplant
-interactive mode. 
+interactive mode.
 
 hg transplant -s ~/coccinelle/parsing_c/
 hg transplant -s ~/mobile/project-yacfe/parsing_c/

--- a/parsing_c/comment_annotater_c.ml
+++ b/parsing_c/comment_annotater_c.ml
@@ -5,7 +5,7 @@
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,7 +22,7 @@ module T = Token_c
 (*****************************************************************************)
 
 (* A trimmed down version of my comment_annotater of CComment. In CComment
- * I was also trying to associate the comment to the relevant entity, not 
+ * I was also trying to associate the comment to the relevant entity, not
  * just the closest token (e.g. a function comment is not placed next to the
  * identifier of the function but before its return type or storage).
  *)
@@ -32,24 +32,24 @@ module T = Token_c
 (* Helpers *)
 (*****************************************************************************)
 
-let is_comment_or_space_or_stuff tok = 
+let is_comment_or_space_or_stuff tok =
   Token_helpers.is_not_in_ast tok && Token_helpers.is_origin tok
 
 (* coupling with token_helpers.is_not_in_ast, and of course with tokens_c.ml *)
-let convert_relevant_tokens x = 
+let convert_relevant_tokens x =
   assert (Token_helpers.is_origin x);
 
-  match x with 
-  | Parser_c.TCommentSpace info -> 
+  match x with
+  | Parser_c.TCommentSpace info ->
       Token_c.TCommentSpace, (Ast_c.parse_info_of_info info)
-  | Parser_c.TCommentNewline info -> 
+  | Parser_c.TCommentNewline info ->
       Token_c.TCommentNewline, (Ast_c.parse_info_of_info info)
 
   | Parser_c.TComment info ->
       Token_c.TComment, (Ast_c.parse_info_of_info info)
 
   (* the passed tokens because of our limited handling of cpp *)
-  | Parser_c.TCommentCpp(cppcommentkind, info) -> 
+  | Parser_c.TCommentCpp(cppcommentkind, info) ->
       Token_c.TCommentCpp cppcommentkind, (Ast_c.parse_info_of_info info)
 
   | _ -> raise Impossible
@@ -59,48 +59,48 @@ let convert_relevant_tokens x =
 (* Main entry *)
 (*****************************************************************************)
 
-(* right now we just add comment-like and origin-tok tokens, 
+(* right now we just add comment-like and origin-tok tokens,
  * as explained in token_c.ml.
  *
  * This simplified comment_annotater (compared to CComment) is really
  * simple as the tokens and the Ast_c.info in the asts actually share
  * the same refs.
- * So, modifying fields in the tokens will also modify the info in 
+ * So, modifying fields in the tokens will also modify the info in
  * the ast. Sometimes side effects simplify programming ...
  * We use similar tricks in unparse_c.ml. So really the asts argument
  * is not needed.
- * 
- * ex: C1 C2 T1 T2 C3 C4 T3 C5 T4. 
+ *
+ * ex: C1 C2 T1 T2 C3 C4 T3 C5 T4.
  *  => infoT1(-C1C2,+), infoT2(-,+C3C4), infoT3(-C3C4,+C5), infoT4(-C5,+)
  *)
 
 (*
-let (agglomerate_either: 
+let (agglomerate_either:
  ('a, 'a) Common.either list -> ('a list, 'a list) Common.either list) = fun xs ->
   raise Todo
 
-let (span_and_pack: 
- ('a -> ('a, 'a) Common.either) -> 'a list -> 
-      ('a list, 'a list) Common.either list) = fun f_either xs -> 
+let (span_and_pack:
+ ('a -> ('a, 'a) Common.either) -> 'a list ->
+      ('a list, 'a list) Common.either list) = fun f_either xs ->
   let xs' = List.map f_either xs in
   agglomerate_either xs'
 *)
 
 
-(* the asts is not really used, we do all via side effect on the tokens, 
+(* the asts is not really used, we do all via side effect on the tokens,
  * which share the info reference with the elements in the ast.
  *)
-let annotate_program toks asts = 
+let annotate_program toks asts =
    (* Common.exclude_but_keep_attached gather all comments before a
     * token and then associates to this token those comments. Note that
     * if reverse the list of tokens then this function can also be used
-    * to gather all the comments after a token :) 
+    * to gather all the comments after a token :)
     *)
 
    (* before phase *)
-   let toks_with_before = 
+   let toks_with_before =
      Common2.exclude_but_keep_attached is_comment_or_space_or_stuff
-       toks 
+       toks
    in
 
   (* after phase. trick: reverse the tokens and reuse previous func *)
@@ -108,15 +108,15 @@ let annotate_program toks asts =
      List.rev
        (List.map
 	  (function (x,l) -> (x,List.rev l))
-	  (Common2.exclude_but_keep_attached is_comment_or_space_or_stuff 
+	  (Common2.exclude_but_keep_attached is_comment_or_space_or_stuff
              (List.rev toks)))
    in
 
   (* merge *)
    assert(List.length toks_with_after =|= List.length toks_with_before);
 
-   Common2.zip toks_with_before toks_with_after 
-   +> List.iter (fun ((t1, before), (t2, after)) -> 
+   Common2.zip toks_with_before toks_with_after
+   +> List.iter (fun ((t1, before), (t2, after)) ->
 
      assert(t1 =*= t2);
 
@@ -130,13 +130,13 @@ let annotate_program toks asts =
          mbefore2 = [];
          mafter2 = [];
        };
-     
+
    );
-   (* modified via side effect. I return it just to have a 
+   (* modified via side effect. I return it just to have a
     * clean signature.
     *)
    asts
-   
-  
-  
-  
+
+
+
+

--- a/parsing_c/comment_annotater_c.mli
+++ b/parsing_c/comment_annotater_c.mli
@@ -1,5 +1,5 @@
 (* !!Annotate via side effects!!. Fill in the comments_around
  * information that was put to empty during parsing.
  *)
-val annotate_program : 
+val annotate_program :
   Parser_c.token list -> Ast_c.toplevel list -> Ast_c.toplevel list

--- a/parsing_c/compare_c.ml
+++ b/parsing_c/compare_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2006, 2007 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -17,8 +17,8 @@ open Common2
 open Ast_c
 
 
-type compare_result = 
-  | Correct 
+type compare_result =
+  | Correct
   | Pb of string
   | PbOnlyInNotParsedCorrectly of string
 
@@ -40,53 +40,53 @@ let cvs_keyword_list = [
  * yet committed the file. After the commit it would be a dollarIddollar:.
  * If reput Id:, do not join the regexp!! otherwise CVS will modify it :)
  *)
-let cvs_keyword_regexp = Str.regexp 
+let cvs_keyword_regexp = Str.regexp
   ("\\$\\([A-Za-z_]+\\):[^\\$]*\\$")
 
 
-let cvs_compute_newstr s = 
-  Str.global_substitute cvs_keyword_regexp (fun _s -> 
+let cvs_compute_newstr s =
+  Str.global_substitute cvs_keyword_regexp (fun _s ->
     let substr = Str.matched_string s in
     assert (substr ==~ cvs_keyword_regexp); (* use its side-effect *)
     let tag = matched1 substr in
 
     if not (List.mem tag cvs_keyword_list)
     then failwith ("unknown CVS keyword: " ^ tag);
-    
-    "CVS_MAGIC_STRING" 
-  ) s 
+
+    "CVS_MAGIC_STRING"
+  ) s
 
 
 
 
 (* todo: get rid of the type for expressions  ? *)
-let normal_form_program xs = 
-  let bigf = { Visitor_c.default_visitor_c_s with 
+let normal_form_program xs =
+  let bigf = { Visitor_c.default_visitor_c_s with
 
-    Visitor_c.kini_s = (fun (k,bigf) ini -> 
+    Visitor_c.kini_s = (fun (k,bigf) ini ->
       match ini with
-      | InitList xs, [i1;i2;iicommaopt] -> 
+      | InitList xs, [i1;i2;iicommaopt] ->
           k (InitList xs, [i1;i2])
       | _ -> k ini
     );
-    Visitor_c.kexpr_s = (fun (k,bigf) e -> 
+    Visitor_c.kexpr_s = (fun (k,bigf) e ->
       match e with
       (* todo: should also do something for multistrings *)
-      | (Constant (String (s,kind)), typ), [ii] 
-          when Common2.string_match_substring cvs_keyword_regexp s -> 
+      | (Constant (String (s,kind)), typ), [ii]
+          when Common2.string_match_substring cvs_keyword_regexp s ->
           let newstr = cvs_compute_newstr s in
           (Constant (String (newstr,kind)), typ), [rewrap_str newstr ii]
-      | _ -> k e    
+      | _ -> k e
 
     );
-    Visitor_c.ktoplevel_s = (fun (k,bigf) p -> 
+    Visitor_c.ktoplevel_s = (fun (k,bigf) p ->
       match p with
-      | CppTop (Define _) -> 
+      | CppTop (Define _) ->
           raise Todo
           (*
           let (i1, i2, i3) = Common.tuple_of_list3 ii in
           if Common.string_match_substring cvs_keyword_regexp body
-          then 
+          then
             let newstr = cvs_compute_newstr body in
             Define ((s, newstr), [i1;i2;rewrap_str newstr i3])
           else p
@@ -95,10 +95,10 @@ let normal_form_program xs =
     );
 
 (*
-    Visitor_c.kinfo_s = (fun (k,bigf) i -> 
+    Visitor_c.kinfo_s = (fun (k,bigf) i ->
       let s = Ast_c.get_str_of_info i in
       if Common.string_match_substring cvs_keyword_regexp s
-      then 
+      then
         let newstr = cvs_compute_newstr s in
         rewrap_str newstr i
       else i
@@ -114,30 +114,30 @@ let normal_form_program xs =
 
 
 
-let normal_form_token x = 
-  let x' = 
-    match x with 
+let normal_form_token x =
+  let x' =
+    match x with
     | Parser_c.TString ((s, kind),i1) -> Parser_c.TString (("",kind), i1)
     | x -> x
   in
-  x' +> Token_helpers.visitor_info_of_tok (fun info -> 
+  x' +> Token_helpers.visitor_info_of_tok (fun info ->
     let info = Ast_c.al_info 0 info in
     let str = Ast_c.str_of_info info in
     if Common2.string_match_substring cvs_keyword_regexp str
-    then 
+    then
       let newstr = cvs_compute_newstr str in
       rewrap_str newstr info
     else info
   )
 
-    
+
 (*****************************************************************************)
 (* Compare at Ast level *)
 (*****************************************************************************)
 
 (* Note that I do a (simple) astdiff to know if there is a difference, but
  * then I use diff to print the differences. So sometimes you have to dig
- * a little to find really where the real difference (one not involving 
+ * a little to find really where the real difference (one not involving
  * just spacing difference) was.
  * Note also that the astdiff is not very accurate. As I skip comments,
  * macro definitions, those are not in the Ast and if there is a diff
@@ -146,7 +146,7 @@ let normal_form_token x =
  * update: You can use token_compare for more precise diff.
  *
  * todo?: finer grain astdiff, better report, more precise.
- * 
+ *
  * todo: do iso between if() S and  if() { S }
  *)
 let compare_ast filename1 filename2  =
@@ -155,18 +155,18 @@ let compare_ast filename1 filename2  =
     match !Flag_parsing_c.diff_lines with
       None ->
 	Common.cmd_to_list ("diff -u -b -B "^filename1^ " "  ^ filename2)
-    | Some n -> 
+    | Some n ->
 	Common.cmd_to_list ("diff -U "^n^" -b -B "^filename1^" "^filename2) in
 
   (* get rid of the --- and +++ lines *)
-  let xs = 
-    if null xs 
-    then xs 
+  let xs =
+    if null xs
+    then xs
     else Common.drop 2 xs
   in
 
 
-  let process_filename filename = 
+  let process_filename filename =
     let (c, _stat) = Parse_c.parse_print_error_heuristic filename in
     let c = List.map fst c in
     c +> Lib_parsing_c.al_program +> normal_form_program
@@ -174,33 +174,33 @@ let compare_ast filename1 filename2  =
 
   let c1 = process_filename filename1 in
   let c2 = process_filename filename2 in
-  
+
   let error = ref 0 in
   let pb_notparsed = ref 0 in
-  
-  let res = 
-    if List.length c1 <> List.length c2 
+
+  let res =
+    if List.length c1 <> List.length c2
     then Pb "not same number of entities (func, decl, ...)"
-    else 
+    else
       begin
         zip c1 c2 +> List.iter (function
         | Declaration a, Declaration b -> if not (a =*= b) then incr error
         | Definition a, Definition b ->   if not (a =*= b) then incr error
         | EmptyDef a, EmptyDef b ->       if not (a =*= b) then incr error
-        | MacroTop (a1,b1,c1), MacroTop (a2,b2,c2) -> 
+        | MacroTop (a1,b1,c1), MacroTop (a2,b2,c2) ->
             if not ((a1,b1,c1) =*= (a2,b2,c2)) then incr error
-        | CppTop (Include {i_include = a}), CppTop (Include {i_include = b}) -> 
+        | CppTop (Include {i_include = a}), CppTop (Include {i_include = b}) ->
             if not (a =*= b) then incr error
-        | CppTop Define _, CppTop Define _ ->   
+        | CppTop Define _, CppTop Define _ ->
             raise Todo
             (* if not (a =*= b) then incr error *)
-        | NotParsedCorrectly a, NotParsedCorrectly b -> 
+        | NotParsedCorrectly a, NotParsedCorrectly b ->
             if not (a =*= b) then incr pb_notparsed
-        | NotParsedCorrectly a, _ -> 
+        | NotParsedCorrectly a, _ ->
             (* Pb only in generated file *)
             incr error;
 
-        | _, NotParsedCorrectly b -> 
+        | _, NotParsedCorrectly b ->
             incr pb_notparsed
         | FinalDef a, FinalDef b -> if not (a =*= b) then incr error
 
@@ -209,10 +209,10 @@ let compare_ast filename1 filename2  =
         | (FinalDef _|EmptyDef _|
            MacroTop (_, _, _)|IfdefTop _|
            CppTop _|Definition _|Declaration _), _ -> incr error
-    
+
         );
         (match () with
-        | _ when !pb_notparsed > 0 && !error =|= 0 -> 
+        | _ when !pb_notparsed > 0 && !error =|= 0 ->
             PbOnlyInNotParsedCorrectly ""
         | _ when !error > 0 -> Pb ""
         | _ -> Correct
@@ -231,24 +231,24 @@ let compare_ast filename1 filename2  =
  * compare_ast may say that 2 programs are equal whereas they are not.
  * Here I compare token, and so have still the TCommentCpp and TCommentMisc
  * so at least detect such differences.
- * 
+ *
  * Morover compare_ast is not very precise in his report when it
  * detects a difference. So token_diff is better.
- * 
+ *
  * I do token_diff but I use programCelement2, so that
- * I know if I am in a "notparsable" zone. The tokens are 
+ * I know if I am in a "notparsable" zone. The tokens are
  * in (snd programCelement2).
- * 
- * Faire aussi un compare_token qui se moque des TCommentMisc, 
- * TCommentCPP et TIfdef ? Normalement si fait ca retrouvera 
+ *
+ * Faire aussi un compare_token qui se moque des TCommentMisc,
+ * TCommentCPP et TIfdef ? Normalement si fait ca retrouvera
  * les meme resultats que compare_ast.
- * 
+ *
  *)
 
 
 (* Pass only "true" comments, dont pass TCommentMisc and TCommentCpp *)
 let is_normal_space_or_comment = function
-  | Parser_c.TComment _ 
+  | Parser_c.TComment _
   | Parser_c.TCommentSpace _
   | Parser_c.TCommentNewline _
 
@@ -257,50 +257,50 @@ let is_normal_space_or_comment = function
   | _ -> false
 
 
-(* convetion: compare_token generated_file  expected_res 
- * because when there is a notparsablezone in generated_file, I 
+(* convetion: compare_token generated_file  expected_res
+ * because when there is a notparsablezone in generated_file, I
  * don't issue a PbOnlyInNotParsedCorrectly
  *)
-let compare_token filename1 filename2 = 
+let compare_token filename1 filename2 =
 
 
-  let rec loop xs ys = 
+  let rec loop xs ys =
     match xs, ys with
     | [], [] -> None
 
     (* UGLY, because of gcc_opt_comma isomorphism  *)
     | (Parser_c.TComma _::Parser_c.TCBrace _::xs),  (Parser_c.TCBrace _::ys) ->
         loop xs ys
-    | (Parser_c.TCBrace _::xs), (Parser_c.TComma _::Parser_c.TCBrace _::ys) -> 
+    | (Parser_c.TCBrace _::xs), (Parser_c.TComma _::Parser_c.TCBrace _::ys) ->
         loop xs ys
 
-    | [], x::xs -> 
+    | [], x::xs ->
         Some "not same number of tokens inside C elements"
-    | x::xs, [] -> 
+    | x::xs, [] ->
         Some "not same number of tokens inside C elements"
-        
-    | x::xs, y::ys -> 
+
+    | x::xs, y::ys ->
         let x' = normal_form_token x in
         let y' = normal_form_token y in
-        if x' =*= y' 
+        if x' =*= y'
         then loop xs ys
-        else 
-          let str1, pos1 = 
+        else
+          let str1, pos1 =
             Token_helpers.str_of_tok x, Token_helpers.pos_of_tok x in
-          let str2, pos2 = 
+          let str2, pos2 =
             Token_helpers.str_of_tok y, Token_helpers.pos_of_tok y in
           Some ("diff token: " ^ str1 ^" VS " ^ str2 ^ "\n" ^
                    Parse_info.error_message filename1 (str1, pos1) ^ "\n" ^
                    Parse_info.error_message filename2 (str2, pos2) ^ "\n"
           )
-            
+
   in
-  let final_loop xs ys = 
+  let final_loop xs ys =
     loop
       (xs +> List.filter (fun x -> not (is_normal_space_or_comment x)))
       (ys +> List.filter (fun x -> not (is_normal_space_or_comment x)))
   in
-  
+
   (*
     let toks1 = Parse_c.tokens filename1 in
     let toks2 = Parse_c.tokens filename2 in
@@ -310,23 +310,23 @@ let compare_token filename1 filename2 =
   let (c1, _stat) = Parse_c.parse_print_error_heuristic filename1 in
   let (c2, _stat) = Parse_c.parse_print_error_heuristic filename2 in
 
-  let res = 
-    if List.length c1 <> List.length c2 
+  let res =
+    if List.length c1 <> List.length c2
     then Pb "not same number of entities (func, decl, ...)"
-    else 
-        zip c1 c2 +> Common2.fold_k (fun acc ((a,infoa),(b,infob)) k -> 
+    else
+        zip c1 c2 +> Common2.fold_k (fun acc ((a,infoa),(b,infob)) k ->
           match a, b with
-          | NotParsedCorrectly a, NotParsedCorrectly b -> 
+          | NotParsedCorrectly a, NotParsedCorrectly b ->
               (match final_loop (snd infoa) (snd infob) with
               | None -> k acc
               | Some s -> PbOnlyInNotParsedCorrectly s
               )
-              
-          | NotParsedCorrectly a, _ -> 
+
+          | NotParsedCorrectly a, _ ->
               Pb "PB parsing only in generated-file"
-          | _, NotParsedCorrectly b -> 
+          | _, NotParsedCorrectly b ->
               PbOnlyInNotParsedCorrectly "PB parsing only in expected-file"
-          | _, _ -> 
+          | _, _ ->
               (match final_loop (snd infoa) (snd infob) with
               | None  -> k acc
               | Some s -> Pb s
@@ -339,18 +339,18 @@ let compare_token filename1 filename2 =
     match !Flag_parsing_c.diff_lines with
       None ->
 	Common.cmd_to_list ("diff -u -b -B "^filename1^ " "  ^ filename2)
-    | Some n -> 
+    | Some n ->
 	Common.cmd_to_list ("diff -U "^n^" -b -B "^filename1^" "^filename2) in
 
   (* get rid of the --- and +++ lines *)
-  let xs = 
-    if null xs 
-    then xs 
+  let xs =
+    if null xs
+    then xs
     else Common.drop 2 xs
   in
 
-  if null xs && (res <> Correct) 
-  then failwith 
+  if null xs && (res <> Correct)
+  then failwith
     "Impossible: How can diff be null and have not Correct in compare_c?";
 
   res, xs
@@ -360,23 +360,23 @@ let compare_token filename1 filename2 =
 
 (*****************************************************************************)
 
-let compare_default = compare_token 
+let compare_default = compare_token
 
 
 let compare_result_to_string (correct, diffxs) =
   match correct with
-  | Correct -> 
+  | Correct ->
       "seems correct" ^ "\n"
-  | Pb s -> 
+  | Pb s ->
       ("seems incorrect: " ^ s) ^ "\n" ^
         "diff (result(-) vs expected_result(+)) = " ^ "\n" ^
         (diffxs +> Common.join "\n") ^ "\n"
-  | PbOnlyInNotParsedCorrectly s -> 
+  | PbOnlyInNotParsedCorrectly s ->
       "seems incorrect, but only because of code that was not parsable" ^ "\n"^
         ("explanation:" ^ s) ^ "\n" ^
         "diff (result(-) vs expected_result(+)) = " ^ "\n" ^
         (diffxs +> Common.join "\n") ^ "\n"
 
 
-let compare_result_to_bool correct = 
+let compare_result_to_bool correct =
   correct =*= Correct

--- a/parsing_c/compare_c.mli
+++ b/parsing_c/compare_c.mli
@@ -1,15 +1,15 @@
 open Common
 
-type compare_result = 
-  | Correct 
+type compare_result =
+  | Correct
   | Pb of string
   | PbOnlyInNotParsedCorrectly of string
 
 
 (* the string list is the output of diff *)
 
-val compare_ast : 
- filename -> filename -> compare_result * string list 
+val compare_ast :
+ filename -> filename -> compare_result * string list
 
 val compare_token :
   filename -> filename -> compare_result * string list

--- a/parsing_c/control_flow_c.ml
+++ b/parsing_c/control_flow_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2006, 2007, 2008 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -16,11 +16,11 @@ open Common
 open Ast_c
 
 (*****************************************************************************)
-(* 
+(*
  * There is more information in the CFG we build that in the CFG usually built
  * in a compiler. This is because:
  *
- *  - We need later to go back from flow to original ast, because we are 
+ *  - We need later to go back from flow to original ast, because we are
  *    doing a refactoring tool, so different context. So we have to add
  *    some nodes for '{' or '}' or goto that normally disapear in a CFG.
  *    We must keep those entities, in the same way that we must keep the parens
@@ -28,23 +28,23 @@ open Ast_c
  *
  *    Moreover, the coccier can mention in his semantic patch those entities,
  *    so we must keep those entities in the CFG.
- *    
- *    We also have to add some extra nodes to make the process that goes from 
- *    flow to ast deterministic with for instance the CaseNode, or easier 
+ *
+ *    We also have to add some extra nodes to make the process that goes from
+ *    flow to ast deterministic with for instance the CaseNode, or easier
  *    with for instance the Fake node.
  *
  *  - The coccinelle engine later transforms some nodes, and we need to rebuild
- *    the ast from a statement now defined and altered in different nodes. 
+ *    the ast from a statement now defined and altered in different nodes.
  *    So we can't just put all the parsing info (Ast_c.il) in the top node of
- *    a statement. We have to split those Ast_c.il in different nodes, to 
+ *    a statement. We have to split those Ast_c.il in different nodes, to
  *    later reconstruct a full Ast_c.il from different nodes. This is why
  *    we need the Else node, ...
- * 
- *    Note that at the same time, we also need to store the fullstatement 
+ *
+ *    Note that at the same time, we also need to store the fullstatement
  *    in the top node, because the CTL engine need to get that information
  *    when dealing with MetaStatement (statement S; in a Semantic Patch).
- *    
- *    
+ *
+ *
  *  - The CTL engine needs more information than just the CFG, and we use
  *    tricks to encode those informations in the nodes:
  *
@@ -56,42 +56,42 @@ open Ast_c
  *       - We need to mark each braces with an identifier so that the CTL
  *         can know if one specific '}' correspond to a specific '{'.
  *
- *       - We add some labels to each node to handle the MetaRuleElem and 
+ *       - We add some labels to each node to handle the MetaRuleElem and
  *         MetaStatement. It allows to groups nodes that belong to the same
  *         statement. Normally CFG are there to abstract from this, but in
  *         Coccinelle we need sometimes the CFG view, and sometimes the Ast
  *         view and the labels allow that.
  *
  *       - We even add nodes. We add '}', not only to be able to go back to AST
- *         but also because of the CTL engine. So one '}' may in fact be 
+ *         but also because of the CTL engine. So one '}' may in fact be
  *         represented by multiple nodes, one in each CFG path.
- * 
- *       - need After, 
+ *
+ *       - need After,
  *       - need FallThrough.
- *       - Need know if ErrorExit, 
+ *       - Need know if ErrorExit,
  *
  * choice: Julia proposed that the flow is in fact just
  * a view through the Ast, which means just Ocaml ref, so that when we
- * modify some nodes, in fact it modifies the ast. But I prefer do it 
+ * modify some nodes, in fact it modifies the ast. But I prefer do it
  * the functionnal way.
- * 
+ *
  * The node2 type should be as close as possible to Ast_cocci.rule_elem to
  * facilitate the job of cocci_vs_c.
- * 
+ *
  *)
 
 (*****************************************************************************)
 
-type fullstatement = statement 
+type fullstatement = statement
 
 (* ---------------------------------------------------------------------- *)
-(* The string is for debugging. Used by Ograph_extended.print_graph. 
- * The int list are Labels. Trick used for CTL engine. Must not 
+(* The string is for debugging. Used by Ograph_extended.print_graph.
+ * The int list are Labels. Trick used for CTL engine. Must not
  * transform that in a triple or record because print_graph would
  * not work.
  *)
-type node = node1 * string  
-  and node1 = node2 * nodeinfo 
+type node = node1 * string
+  and node1 = node2 * nodeinfo
     and nodeinfo = {
       labels: int list;
       bclabels: int list; (* parent of a break or continue node *)
@@ -106,16 +106,16 @@ type node = node1 * string
    * indefinitely. So must tag some nodes as the beginning and end of
    * the graph so that some fix_ctl function can easily find those
    * nodes.
-   * 
+   *
    * If have a function, then no need for EndNode; Exit and ErrorExit
    * will play that role.
-   * 
+   *
    * When everything we analyze was a function there was no pb. We used
    * FunHeader as a Topnode and Exit for EndNode but now that we also
    * analyse #define body, so we need those nodes.
    *)
-   | TopNode 
-   | EndNode 
+   | TopNode
+   | EndNode
 
    (* ------------------------ *)
    | FunHeader of definition (* but empty body *)
@@ -129,14 +129,14 @@ type node = node1 * string
     * ctl: to make possible the forall (AX, A[...]), have to add more than
     * one node sometimes for the same '}' (one in each CFG path) in the graph.
     *
-    * ctl: Morover, the int in the type is here to indicate to what { } 
-    * they correspond. Two pairwise { } share the same number. kind of 
+    * ctl: Morover, the int in the type is here to indicate to what { }
+    * they correspond. Two pairwise { } share the same number. kind of
     * "brace_identifier". Used for debugging or for checks and more importantly,
     * needed by CTL engine.
     *
     * Because of those nodes, there is no equivalent for Compound.
-    * 
-    * There was a problem with SeqEnd. Some info can be tagged on it 
+    *
+    * There was a problem with SeqEnd. Some info can be tagged on it
     * but there is multiple SeqEnd that correspond to the same '}' even
     * if they are in different nodes. Solved by using shared ref
     * and allow the "already-tagged" token.
@@ -153,7 +153,7 @@ type node = node1 * string
   | WhileHeader of fullstatement * expression wrap
   | DoHeader of fullstatement * info
   | DoWhileTail of expression wrap
-  | ForHeader of fullstatement * 
+  | ForHeader of fullstatement *
                  (exprStatement wrap * exprStatement wrap * exprStatement wrap)
                  wrap
   | SwitchHeader of fullstatement * expression wrap
@@ -161,37 +161,37 @@ type node = node1 * string
 
   (* Used to mark the end of if, while, dowhile, for, switch. Later we
    * will be able to "tag" some cocci code on this node.
-   * 
+   *
    * This is because in
-   * 
+   *
    * - S + foo();
-   * 
+   *
    * the S can be anything, including an if, and this is internally
    * translated in a series of MetaRuleElem, and the last element is a
    * EndStatement, and we must tag foo() to this EndStatement.
    * Otherwise, without this last common node, we would tag foo() to 2
    * nodes :( So having a unique node makes it correct, and in
    * flow_to_ast we must propagate back this + foo() to the last token
-   * of an if (maybe a '}', maybe a ';') 
-   * 
-   * The problem is that this stuff should be in transformation.ml,  
+   * of an if (maybe a '}', maybe a ';')
+   *
+   * The problem is that this stuff should be in transformation.ml,
    * but need information available in flow_to_ast, but we dont want
    * to polluate both files.
-   * 
-   * So the choices are 
-   * 
+   *
+   * So the choices are
+   *
    * - soluce julia1, extend Ast_c by adding a fake token to the if
-   * 
+   *
    * - extend Ast with a Skip, and add this next to EndStatement node,
    * and do special case in flow_to_ast to start from this node
    * (not to get_next EndStatement, but from EndStatement directly)
    * and so add a case when have directly a EndStatement node an extract
    * the statement from it.
-   * 
-   * - remonter dans le graphe pour accrocher le foo() non plus au 
-   * EndStatement (qui n'a pas d'equivalent niveau token dans l'ast_c), 
+   *
+   * - remonter dans le graphe pour accrocher le foo() non plus au
+   * EndStatement (qui n'a pas d'equivalent niveau token dans l'ast_c),
    * mais au dernier token de la branche Else (ou Then si y'a pas de else).
-   * 
+   *
    * I first did solution 2 and then when we decided to use ref,
    * I use julia'as solution. Have virtual-placeholders, the fakeInfo
    * for the if, while, and put this shared ref in the EndStatement.
@@ -210,7 +210,7 @@ type node = node1 * string
   (* ------------------------ *)
   | DefineHeader of string wrap * define_kind
 
-  | DefineExpr of expression 
+  | DefineExpr of expression
   | DefineType of fullType
   | DefineDoWhileZeroHeader of unit wrap
   | DefineTodo
@@ -218,7 +218,7 @@ type node = node1 * string
   | Include of includ
 
   (* obsolete? *)
-  | MacroTop of string * argument wrap2 list * il 
+  | MacroTop of string * argument wrap2 list * il
 
   (* ------------------------ *)
   | Case  of fullstatement * expression wrap
@@ -238,22 +238,22 @@ type node = node1 * string
 
   (* ------------------------ *)
   (* some control nodes *)
-  | Enter 
+  | Enter
   | Exit
 
 
   (* Redundant nodes, often to mark the end of an if/switch.
-   * That makes it easier to do later the flow_to_ast. 
+   * That makes it easier to do later the flow_to_ast.
    * update: no more used for the end. see Endstatement. Just used
    * to mark the start of the function, as required by julia.
    * Maybe would be better to use instead a Enter2.
    *)
-  | Fake 
+  | Fake
 
   (* flow_to_ast: In this case, I need to know the  order between the children
-   * of the switch in the graph. 
+   * of the switch in the graph.
    *)
-  | CaseNode of int 
+  | CaseNode of int
 
   (* ------------------------ *)
   (* for ctl:  *)
@@ -276,11 +276,11 @@ let unwrap ((node, info), nodestr) = node
 let rewrap ((_node, info), nodestr) node = (node, info), nodestr
 let extract_labels ((node, info), nodestr) = info.labels
 let extract_bclabels ((node, info), nodestr) = info.bclabels
-let extract_is_loop ((node, info), nodestr) = info.is_loop 
+let extract_is_loop ((node, info), nodestr) = info.is_loop
 let extract_is_fake ((node, info), nodestr) = info.is_fake
 
 let mk_any_node is_fake node labels bclabels nodestr =
-  let nodestr = 
+  let nodestr =
     if !Flag_parsing_c.show_flow_labels
     then nodestr ^ ("[" ^ (labels +> List.map i_to_s +> join ",") ^ "]")
     else nodestr
@@ -292,35 +292,35 @@ let mk_node = mk_any_node false
 let mk_fake_node = mk_any_node true (* for duplicated braces *)
 
 (* ------------------------------------------------------------------------ *)
-let first_node g = 
-  g#nodes#tolist +> List.find (fun (i, node) -> 
+let first_node g =
+  g#nodes#tolist +> List.find (fun (i, node) ->
     match unwrap node with TopNode -> true | _ -> false
     ) +> fst
 
-let find_node f g = 
-  g#nodes#tolist +> List.find (fun (nodei, node) -> 
-    f (unwrap node)) 
+let find_node f g =
+  g#nodes#tolist +> List.find (fun (nodei, node) ->
+    f (unwrap node))
      +> fst
 
 
 (* remove an intermediate node and redirect the connexion  *)
-let remove_one_node nodei g = 
+let remove_one_node nodei g =
   let preds = (g#predecessors nodei)#tolist in
   let succs = (g#successors nodei)#tolist in
   assert (not (null preds));
 
-  preds +> List.iter (fun (predi, Direct) -> 
+  preds +> List.iter (fun (predi, Direct) ->
     g#del_arc ((predi, nodei), Direct);
   );
-  succs +> List.iter (fun (succi, Direct) -> 
+  succs +> List.iter (fun (succi, Direct) ->
     g#del_arc ((nodei, succi), Direct);
   );
-  
+
   g#del_node nodei;
-  
+
   (* connect in-nodes to out-nodes *)
-  preds +> List.iter (fun (pred, Direct) -> 
-    succs +> List.iter (fun (succ, Direct) -> 
+  preds +> List.iter (fun (pred, Direct) ->
+    succs +> List.iter (fun (succ, Direct) ->
       g#add_arc ((pred, succ), Direct);
     );
   )
@@ -329,27 +329,27 @@ let remove_one_node nodei g =
 
 (* ------------------------------------------------------------------------ *)
 
-let extract_fullstatement node = 
+let extract_fullstatement node =
   match unwrap node with
-  | Decl decl -> 
+  | Decl decl ->
       (* new policy. no more considered as a statement *)
       (* old: Some (Ast_c.Decl decl, []) *)
-      None 
+      None
   | MacroStmt (st, _) -> Some st
   | MacroIterHeader (st, _) -> Some st
 
-  | Include _ 
+  | Include _
   | DefineHeader _ | DefineType _ | DefineExpr  _ | DefineDoWhileZeroHeader _
   | DefineTodo
   | MacroTop _
       -> None
 
-  | IfdefHeader _ | IfdefElse _ | IfdefEndif _ 
+  | IfdefHeader _ | IfdefElse _ | IfdefEndif _
       -> None
 
-  | SeqStart (st,_,_) 
+  | SeqStart (st,_,_)
   | ExprStatement (st, _)
-  | IfHeader  (st, _) 
+  | IfHeader  (st, _)
   | WhileHeader (st, _)
   | DoHeader (st, _)
   | ForHeader (st, _)
@@ -369,11 +369,11 @@ let extract_fullstatement node =
 
   | TopNode|EndNode
   | FunHeader _
-  | SeqEnd  _ 
-  | Else _ 
+  | SeqEnd  _
+  | Else _
   | EndStatement _
   | DoWhileTail _
-  | Enter 
+  | Enter
   | Exit
   | Fake
   | CaseNode _

--- a/parsing_c/control_flow_c.mli
+++ b/parsing_c/control_flow_c.mli
@@ -1,7 +1,7 @@
 open Ast_c
 
 type node = node1 * string (* For debugging. Used by print_graph *)
-  and node1 = node2 * nodeinfo 
+  and node1 = node2 * nodeinfo
    and nodeinfo = {
       labels: int list;   (* Labels. Trick used for CTL engine *)
       bclabels: int list; (* parent of a break or continue node *)
@@ -9,7 +9,7 @@ type node = node1 * string (* For debugging. Used by print_graph *)
       is_fake: bool;
     }
   and node2 =
-  | TopNode 
+  | TopNode
   | EndNode
 
   | FunHeader     of definition (* but empty body *)
@@ -25,7 +25,7 @@ type node = node1 * string (* For debugging. Used by print_graph *)
   | WhileHeader   of statement * expression wrap
   | DoHeader      of statement * info
   | DoWhileTail   of expression wrap
-  | ForHeader     of statement * 
+  | ForHeader     of statement *
                  (exprStatement wrap * exprStatement wrap * exprStatement wrap)
                  wrap
   | SwitchHeader  of statement * expression wrap
@@ -53,7 +53,7 @@ type node = node1 * string (* For debugging. Used by print_graph *)
 
   | Include of includ
 
-  | MacroTop of string * argument wrap2 list * il 
+  | MacroTop of string * argument wrap2 list * il
 
   (* ------------------------ *)
   | Case      of statement * expression wrap
@@ -73,10 +73,10 @@ type node = node1 * string (* For debugging. Used by print_graph *)
 
 
   (* ------------------------ *)
-  | Enter 
+  | Enter
   | Exit
   | Fake
-  | CaseNode of int 
+  | CaseNode of int
 
   (* ------------------------ *)
   (* for ctl:  *)

--- a/parsing_c/copyright.txt
+++ b/parsing_c/copyright.txt
@@ -1,12 +1,12 @@
 parsing_c library - Yoann Padioleau
 
-Copyright (C) 2002, 2005, 2006, 2007, 2008, 2009 Yoann Padioleau, 
+Copyright (C) 2002, 2005, 2006, 2007, 2008, 2009 Yoann Padioleau,
 Ecole des Mines de Nantes, University of Urbana Champaign, Université de Rennes.
 
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License (GPL)
   version 2 as published by the Free Software Foundation.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/parsing_c/cpp_ast_c.ml
+++ b/parsing_c/cpp_ast_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2008, 2009 University of Urbana Champaign
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -21,42 +21,42 @@ open Ast_c
 
 (*
  * cpp-include-expander-builtin.
- * 
- * alternative1: parse and call cpp tour a tour. So let cpp work at 
+ *
+ * alternative1: parse and call cpp tour a tour. So let cpp work at
  *  the token level. That's what most tools do.
  * alternative2: apply cpp at the very end. Process that go through ast
- *  and do the stuff such as #include,  macro expand, 
+ *  and do the stuff such as #include,  macro expand,
  *  ifdef but on the ast!
- * 
+ *
  * But need keep those info in ast at least, even bad
- * macro for instance, and for parse error region ? maybe can 
+ * macro for instance, and for parse error region ? maybe can
  * get another chance ?
  * I think it's better to do the cpp-include-expander in a different step
- * rather than embedding it in the parser. The parser is already too complex. 
+ * rather than embedding it in the parser. The parser is already too complex.
  * Also keep with the tradition to try to parse as-is.
- * 
+ *
  * todo? but maybe could discover new info that could help reparse
  * the ParseError in original file. Try again parsing it by
- * putting it in a minifile ? 
- * 
- * 
+ * putting it in a minifile ?
+ *
+ *
  * todo? maybe can do some pass that work at the ifdef level and for instance
  * try to paren them, so have in Ast some stuff that are not
  * present at parsing time but that can then be constructed after
  * some processing (a little bit like my type for expression filler,
  * or position info filler, or include relative position filler).
- * 
+ *
  * ??add such info about what was done somewhere ? could build new
  * ??ast each time but too tedious (maybe need delta-programming!)
  *
  * todo? maybe change cpp_ast_c to go deeper on local "" ?
- * 
- * 
- * TODO: macro expand, 
+ *
+ *
+ * TODO: macro expand,
  * TODO: handle ifdef
- * 
- * 
- * 
+ *
+ *
+ *
  * cpp_ifdef_statementize: again better to separate concern and in parser
  *  just add the directives in a flat way (IfdefStmt) and later do more
  *  processing and transform them in a tree with some IfdefStmt2.
@@ -68,26 +68,26 @@ open Ast_c
 (* Types  *)
 (*****************************************************************************)
 
-type cpp_option = 
+type cpp_option =
   | I of Common.dirname
   | D of string * string option
 
 
 
-let i_of_cpp_options xs = 
+let i_of_cpp_options xs =
   xs +> Common.map_filter (function
   | I f -> Some f
   | D _ -> None
   )
 
-let cpp_option_of_cmdline (xs, ys) = 
+let cpp_option_of_cmdline (xs, ys) =
   (xs +> List.map (fun s -> I s)) @
-  (ys +> List.map (fun s -> 
+  (ys +> List.map (fun s ->
     if s =~ "\\([A-Z][A-Z0-9_]*\\)=\\(.*\\)"
     then
       let (def, value) = matched2 s in
       D (def, Some value)
-    else 
+    else
       D (s, None)
   ))
 
@@ -97,11 +97,11 @@ let cpp_option_of_cmdline (xs, ys) =
 
 let _hcandidates = Hashtbl.create 101
 
-let init_adjust_candidate_header_files dir = 
+let init_adjust_candidate_header_files dir =
   let ext = "[h]" in
   let files = Common2.files_of_dir_or_files ext [dir] in
 
-  files +> List.iter (fun file -> 
+  files +> List.iter (fun file ->
     let base = Filename.basename file in
     pr2 file;
     Hashtbl.add _hcandidates base file;
@@ -113,51 +113,51 @@ let init_adjust_candidate_header_files dir =
 (* may return a list of match ? *)
 let find_header_file1 cppopts dirname inc_file =
   match inc_file with
-  | Local f -> 
-      let finalfile = 
+  | Local f ->
+      let finalfile =
         Filename.concat dirname (Ast_c.s_of_inc_file inc_file) in
-      if Sys.file_exists finalfile 
+      if Sys.file_exists finalfile
       then [finalfile]
       else []
-  | NonLocal f -> 
-      i_of_cpp_options cppopts +> Common.map_filter (fun dirname -> 
-        let finalfile = 
+  | NonLocal f ->
+      i_of_cpp_options cppopts +> Common.map_filter (fun dirname ->
+        let finalfile =
           Filename.concat dirname (Ast_c.s_of_inc_file inc_file) in
-        if Sys.file_exists finalfile 
+        if Sys.file_exists finalfile
         then Some finalfile
         else None
       )
-  | Weird s -> 
+  | Weird s ->
       pr2 ("CPPAST: weird include not handled:" ^ s);
       []
 
 (* todo? can try find most precise ? first just use basename but
  * then maybe look if have also some dir in common ?
  *)
-let find_header_file2 inc_file = 
+let find_header_file2 inc_file =
   match inc_file with
-  | Local f 
-  | NonLocal f -> 
+  | Local f
+  | NonLocal f ->
       let s = (Ast_c.s_of_inc_file inc_file) in
       let base = Filename.basename s in
 
       let res = Hashtbl.find_all _hcandidates base in
       (match res with
-      | [file] -> 
+      | [file] ->
           pr2 ("CPPAST: find header in other dir: " ^ file);
           res
-      | [] -> 
+      | [] ->
           []
       | x::y::xs -> res
       )
-  | Weird s -> 
+  | Weird s ->
       []
 
 
 let find_header_file cppopts dirname inc_file =
   let res1 = find_header_file1 cppopts dirname inc_file in
   match res1 with
-  | [file] -> res1 
+  | [file] -> res1
   | [] -> find_header_file2 inc_file
   | x::y::xs -> res1
 
@@ -166,7 +166,7 @@ let find_header_file cppopts dirname inc_file =
 
 (* ---------------------------------------------------------------------- *)
 let trace_cpp_process depth mark inc_file =
-  pr2 (spf "%s>%s %s" 
+  pr2 (spf "%s>%s %s"
           (Common2.repeat "-" depth +> Common.join "")
           mark
           (s_of_inc_file_bis inc_file));
@@ -174,16 +174,16 @@ let trace_cpp_process depth mark inc_file =
 
 
 (* ---------------------------------------------------------------------- *)
-let _headers_hash = Hashtbl.create 101 
+let _headers_hash = Hashtbl.create 101
 
 (* On freebsd ocaml is trashing, use up to 1.6Go of memory and then
- * building the database_c takes ages. 
- * 
+ * building the database_c takes ages.
+ *
  * So just limit with following threshold to avoid this trashing, simple.
- * 
+ *
  * On netbsd, got a Out_of_memory exn on this file;
  * /home/pad/software-os-src2/netbsd/dev/microcode/cyclades-z/
- * even if the cache is small. That's because huge single 
+ * even if the cache is small. That's because huge single
  * ast element and probably the ast marshalling fail.
  *)
 let threshold_cache_nb_files = ref 200
@@ -192,19 +192,19 @@ let parse_c_and_cpp_cache file =
   if Hashtbl.length _headers_hash > !threshold_cache_nb_files
   then Hashtbl.clear _headers_hash;
 
-  Common.memoized _headers_hash file (fun () -> 
+  Common.memoized _headers_hash file (fun () ->
     Parse_c.parse_c_and_cpp file
   )
 
 
 (* ---------------------------------------------------------------------- *)
-let (show_cpp_i_opts: string list -> unit) = fun xs -> 
-  if not (null xs) then begin 
+let (show_cpp_i_opts: string list -> unit) = fun xs ->
+  if not (null xs) then begin
     pr2 "-I";
     xs +> List.iter pr2
   end
 
-  
+
 let (show_cpp_d_opts: string list -> unit) = fun xs ->
   if not (null xs) then begin
     pr2 "-D";
@@ -216,34 +216,34 @@ let (show_cpp_d_opts: string list -> unit) = fun xs ->
 (*****************************************************************************)
 
 
-let (cpp_expand_include2: 
+let (cpp_expand_include2:
  ?depth_limit:int option ->
  cpp_option list -> Common.dirname -> Ast_c.program -> Ast_c.program) =
- fun ?(depth_limit=None) iops dirname ast -> 
+ fun ?(depth_limit=None) iops dirname ast ->
 
   Common2.pr2_xxxxxxxxxxxxxxxxx();
   let already_included = ref [] in
 
-  let rec aux stack dirname ast = 
+  let rec aux stack dirname ast =
     let depth = List.length stack in
 
     ast +> Visitor_c.vk_program_s { Visitor_c.default_visitor_c_s with
-      Visitor_c.kcppdirective_s = (fun (k, bigf) cpp -> 
-        match cpp with 
+      Visitor_c.kcppdirective_s = (fun (k, bigf) cpp ->
+        match cpp with
         | Include {i_include = (inc_file, ii);
                    i_rel_pos = h_rel_pos;
                    i_is_in_ifdef = b;
                    i_content = copt;
-                   } 
-          -> 
+                   }
+          ->
           (match depth_limit with
           | Some limit when depth >= limit -> cpp
-          | _ -> 
-           
+          | _ ->
+
             (match find_header_file iops dirname inc_file with
-            | [file] -> 
+            | [file] ->
                 if List.mem file !already_included
-                then begin 
+                then begin
                   (* pr2 ("already included: " ^ file); *)
                   trace_cpp_process depth "*" inc_file;
                   k cpp
@@ -251,12 +251,12 @@ let (cpp_expand_include2:
                   trace_cpp_process depth "" inc_file;
                   Common.push file already_included;
                   (* CONFIG *)
-                  Flag_parsing_c.verbose_parsing := false; 
-                  Flag_parsing_c.verbose_lexing := false; 
+                  Flag_parsing_c.verbose_parsing := false;
+                  Flag_parsing_c.verbose_lexing := false;
                   let (ast2, _stat) = parse_c_and_cpp_cache file in
 
                   let ast = Parse_c.program_of_program2 ast2 in
-                  let dirname' = Filename.dirname file in 
+                  let dirname' = Filename.dirname file in
 
                   (* recurse *)
                   let ast' = aux (file::stack) dirname' ast in
@@ -267,11 +267,11 @@ let (cpp_expand_include2:
                            i_content = Some (file, ast');
                   }
                 end
-            | [] -> 
+            | [] ->
                 trace_cpp_process depth "!!" inc_file;
                 pr2 "CPPAST: file not found";
                 k cpp
-            | x::y::zs -> 
+            | x::y::zs ->
                 trace_cpp_process depth "!!" inc_file;
                 pr2 "CPPAST: too much candidates";
                 k cpp
@@ -282,13 +282,13 @@ let (cpp_expand_include2:
     }
   in
   aux [] dirname ast
-    
 
-let cpp_expand_include ?depth_limit a b c = 
+
+let cpp_expand_include ?depth_limit a b c =
   Common.profile_code "cpp_expand_include"
    (fun () -> cpp_expand_include2 ?depth_limit a b c)
 
-(* 
+(*
 let unparse_showing_include_content ?
 *)
 
@@ -298,9 +298,9 @@ let unparse_showing_include_content ?
 (*****************************************************************************)
 
 
-let is_ifdef_and_same_tag tag x = 
+let is_ifdef_and_same_tag tag x =
   match x with
-  | IfdefStmt (IfdefDirective ((_, tag2),_)) -> 
+  | IfdefStmt (IfdefDirective ((_, tag2),_)) ->
       tag =*= tag2
   | StmtElem _ | CppDirectiveStmt _ -> false
   | IfdefStmt2 _ -> raise Impossible
@@ -316,14 +316,14 @@ let is_ifdef_and_same_tag tag x =
  * indice. Or simply count  the number of directives with the same tag and
  * put this information in the tag. Hence the total_with_this_tag below.
  *)
-let should_ifdefize tag ifdefs_directives xxs = 
+let should_ifdefize tag ifdefs_directives xxs =
   let IfdefTag (_tag, total_with_this_tag) = tag in
-  
+
   if total_with_this_tag <> List.length ifdefs_directives
   then begin
     pr2 "CPPASTC: can not ifdefize, some of its directives were passed";
-    false 
-  end else 
+    false
+  end else
     (* todo? put more condition ? dont ifdefize declaration ? *)
     true
 
@@ -331,54 +331,54 @@ let should_ifdefize tag ifdefs_directives xxs =
 
 
 
-(* return a triple, (ifdefs directive * grouped xs * remaining sequencable) 
- * XXX1 XXX2 elsif YYY1 else ZZZ1 endif WWW1 WWW2 
+(* return a triple, (ifdefs directive * grouped xs * remaining sequencable)
+ * XXX1 XXX2 elsif YYY1 else ZZZ1 endif WWW1 WWW2
  * => [elsif, else, endif], [XXX1 XXX2; YYY1; ZZZ1], [WWW1 WWW2]
  *)
-let group_ifdef tag xs = 
+let group_ifdef tag xs =
   let (xxs, xs) = Common2.group_by_post (is_ifdef_and_same_tag tag) xs in
-  
-  xxs +> List.map snd +> List.map (fun x -> 
-    match x with 
+
+  xxs +> List.map snd +> List.map (fun x ->
+    match x with
     | IfdefStmt y -> y
     | StmtElem _ | CppDirectiveStmt _ | IfdefStmt2 _ -> raise Impossible
   ),
-  xxs +> List.map fst, 
+  xxs +> List.map fst,
   xs
 
 
-let rec cpp_ifdef_statementize ast = 
+let rec cpp_ifdef_statementize ast =
   Visitor_c.vk_program_s { Visitor_c.default_visitor_c_s with
-    Visitor_c.kstatementseq_list_s = (fun (k, bigf) xs -> 
-      let rec aux xs = 
+    Visitor_c.kstatementseq_list_s = (fun (k, bigf) xs ->
+      let rec aux xs =
         match xs with
         | [] -> []
         | stseq::xs ->
             (match stseq with
-            | StmtElem st -> 
+            | StmtElem st ->
                 Visitor_c.vk_statement_sequencable_s bigf stseq::aux xs
-            | CppDirectiveStmt directive -> 
+            | CppDirectiveStmt directive ->
                 Visitor_c.vk_statement_sequencable_s bigf stseq::aux xs
             | IfdefStmt ifdef ->
                 (match ifdef with
-                | IfdefDirective ((Ifdef,tag),ii) -> 
+                | IfdefDirective ((Ifdef,tag),ii) ->
 
                     let (restifdefs, xxs, xs') = group_ifdef tag xs in
-                    if should_ifdefize tag (ifdef::restifdefs) xxs 
+                    if should_ifdefize tag (ifdef::restifdefs) xxs
                     then
                       let res = IfdefStmt2 (ifdef::restifdefs, xxs) in
                       Visitor_c.vk_statement_sequencable_s bigf res::aux xs'
                     else
                       Visitor_c.vk_statement_sequencable_s bigf stseq::aux xs
-                      
+
                 | IfdefDirective (((IfdefElseif|IfdefElse|IfdefEndif),b),ii) ->
                     pr2 "weird: first directive is not a ifdef";
-                    (* maybe not weird, just that should_ifdefize 
+                    (* maybe not weird, just that should_ifdefize
                      * returned false *)
                     Visitor_c.vk_statement_sequencable_s bigf stseq::aux xs
                 )
 
-            | IfdefStmt2 (ifdef, xxs) -> 
+            | IfdefStmt2 (ifdef, xxs) ->
                 failwith "already applied cpp_ifdef_statementize"
             )
       in
@@ -391,8 +391,8 @@ let rec cpp_ifdef_statementize ast =
 (* Macro *)
 (*****************************************************************************)
 
-let (cpp_expand_macro_expr: 
-  Ast_c.define_kind -> Ast_c.argument Ast_c.wrap2 list -> 
-  Ast_c.expression option) = 
- fun defkind args -> 
+let (cpp_expand_macro_expr:
+  Ast_c.define_kind -> Ast_c.argument Ast_c.wrap2 list ->
+  Ast_c.expression option) =
+ fun defkind args ->
    raise Todo

--- a/parsing_c/cpp_ast_c.mli
+++ b/parsing_c/cpp_ast_c.mli
@@ -1,8 +1,8 @@
-type cpp_option = 
+type cpp_option =
   | I of Common.dirname
   | D of string * string option
 
-val cpp_option_of_cmdline: 
+val cpp_option_of_cmdline:
   Common.dirname list (* -I *) * string list (* -D *) -> cpp_option list
 val show_cpp_i_opts: string list -> unit
 val show_cpp_d_opts: string list -> unit
@@ -10,16 +10,16 @@ val show_cpp_d_opts: string list -> unit
 
 (* ---------------------------------------------------------------------- *)
 (* cpp_expand_include below must internally use a cache of header files to
- * speedup as programs very often reinclude the same basic set of 
- * header files.  
+ * speedup as programs very often reinclude the same basic set of
+ * header files.
  * note: that also means that the asts of those headers are then shared so take
- * care. 
+ * care.
  *)
-val _headers_hash: 
+val _headers_hash:
   (Common.filename, Parse_c.program2 * Parsing_stat.parsing_stat) Hashtbl.t
 val threshold_cache_nb_files: int ref
 
-(* It can also try to find header files in nested directories if the 
+(* It can also try to find header files in nested directories if the
  * caller use the function below first.
  *)
 val init_adjust_candidate_header_files: Common.dirname -> unit
@@ -27,16 +27,16 @@ val init_adjust_candidate_header_files: Common.dirname -> unit
 (* ---------------------------------------------------------------------- *)
 
 (* include *)
-val cpp_expand_include: 
-  ?depth_limit:int option -> cpp_option list -> 
-  Common.dirname (* start point for relative paths *) -> 
+val cpp_expand_include:
+  ?depth_limit:int option -> cpp_option list ->
+  Common.dirname (* start point for relative paths *) ->
   Ast_c.program -> Ast_c.program
 
 (* ifdef *)
 val cpp_ifdef_statementize: Ast_c.program -> Ast_c.program
 
 (* define *)
-val cpp_expand_macro_expr: 
-  Ast_c.define_kind -> Ast_c.argument Ast_c.wrap2 list -> 
+val cpp_expand_macro_expr:
+  Ast_c.define_kind -> Ast_c.argument Ast_c.wrap2 list ->
   Ast_c.expression option
 

--- a/parsing_c/cpp_token_c.ml
+++ b/parsing_c/cpp_token_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2007, 2008 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -20,7 +20,7 @@ module TH = Token_helpers
 open Parser_c
 open Token_views_c
 
-let assoc_option  k l = 
+let assoc_option  k l =
   Common2.optionise (fun () -> List.assoc k l)
 
 (*****************************************************************************)
@@ -28,36 +28,36 @@ let assoc_option  k l =
 (*****************************************************************************)
 
 (* cpp functions working at the token level. Cf cpp_ast_c for cpp functions
- * working at the AST level (which is very unusual but makes sense in 
+ * working at the AST level (which is very unusual but makes sense in
  * the coccinelle context for instance).
- *  
+ *
  * Note that as I use a single lexer  to work both at the C and cpp level
- * there are some inconveniences. 
- * For instance 'for' is a valid name for a macro parameter and macro 
- * body, but is interpreted in a special way by our single lexer, and 
+ * there are some inconveniences.
+ * For instance 'for' is a valid name for a macro parameter and macro
+ * body, but is interpreted in a special way by our single lexer, and
  * so at some places where I expect a TIdent I need also to
  * handle special cases and accept Tfor, Tif, etc at those places.
- * 
+ *
  * There are multiple issues related to those keywords incorrect tokens.
  * Those keywords can be:
  *   - (1) in the name of the macro as  in  #define inline
  *   - (2) in a parameter of the macro as in #define foo(char)   char x;
  *   - (3) in an argument to a macro call as in   IDENT(if);
  * Case 1 is easy to fix in define_ident.
- * Case 2 is easy to fix in define_parse where detect such toks in 
+ * Case 2 is easy to fix in define_parse where detect such toks in
  * the parameter and then replace their occurence in the body in a Tident.
- * Case 3 is only an issue when the expanded token is not really use 
+ * Case 3 is only an issue when the expanded token is not really use
  * as usual but use for instance in concatenation as in  a ## if
  * when expanded. In the case the grammar this time will not be happy
  * so this is also easy to fix in cpp_engine.
- * 
+ *
  *)
 
 (*****************************************************************************)
 (* Wrappers *)
 (*****************************************************************************)
-let pr2 s = 
-  if !Flag_parsing_c.verbose_parsing 
+let pr2 s =
+  if !Flag_parsing_c.verbose_parsing
   then Common.pr2 s
 
 
@@ -70,15 +70,15 @@ let pr2 s =
 (* mimic standard.h *)
 (* ------------------------------------------------------------------------- *)
 
-type define_def = string * define_param * define_body 
- and define_param = 
+type define_def = string * define_param * define_body
+ and define_param =
    | NoParam
    | Params of string list
- and define_body = 
+ and define_body =
    | DefineBody of Parser_c.token list
    | DefineHint of parsinghack_hint
 
-   and parsinghack_hint = 
+   and parsinghack_hint =
      | HintIterator
      | HintDeclarator
      | HintMacroString
@@ -101,29 +101,29 @@ let assoc_hint_string = [
 ]
 
 
-let (parsinghack_hint_of_string: string -> parsinghack_hint option) = fun s -> 
+let (parsinghack_hint_of_string: string -> parsinghack_hint option) = fun s ->
   assoc_option s assoc_hint_string
 
-let (is_parsinghack_hint: string -> bool) = fun s -> 
+let (is_parsinghack_hint: string -> bool) = fun s ->
   parsinghack_hint_of_string s <> None
 
-let (token_from_parsinghack_hint: 
-     (string * Ast_c.info) -> parsinghack_hint -> Parser_c.token) = 
+let (token_from_parsinghack_hint:
+     (string * Ast_c.info) -> parsinghack_hint -> Parser_c.token) =
  fun (s,ii) hint ->
    match hint with
-   | HintIterator -> 
+   | HintIterator ->
        Parser_c.TMacroIterator (s, ii)
-   | HintDeclarator -> 
+   | HintDeclarator ->
        Parser_c.TMacroDecl (s, ii)
-   | HintMacroString -> 
+   | HintMacroString ->
        Parser_c.TMacroString (s, ii)
-   | HintMacroStatement -> 
+   | HintMacroStatement ->
        Parser_c.TMacroStmt (s, ii)
-   | HintAttribute -> 
+   | HintAttribute ->
        Parser_c.TMacroAttr (s, ii)
-   | HintMacroIdentBuilder -> 
+   | HintMacroIdentBuilder ->
        Parser_c.TMacroIdentBuilder (s, ii)
-  
+
 
 
 
@@ -133,25 +133,25 @@ let (token_from_parsinghack_hint:
 (* Expansion helpers *)
 (*****************************************************************************)
 
-(* In some cases we can have macros like IDENT(if) that expands to some 
- * 'int xxx_if(void)', but as the lexer will currently generate a Tif for 
+(* In some cases we can have macros like IDENT(if) that expands to some
+ * 'int xxx_if(void)', but as the lexer will currently generate a Tif for
  * the expanded code, that may not be accepted as a token after a ##
  * in the grammar. Hence this function to remap some tokens. This is because
  * we should not use a single lexer for both working at the C level and
  * cpp level.
  *)
-let rec remap_keyword_tokens xs = 
+let rec remap_keyword_tokens xs =
   match xs with
   | [] -> []
   | [x] -> [x]
-  | x::y::xs -> 
+  | x::y::xs ->
       (match x, y with
-      | Parser_c.TCppConcatOp _, Parser_c.TIdent _ -> 
+      | Parser_c.TCppConcatOp _, Parser_c.TIdent _ ->
           x::y::remap_keyword_tokens xs
-      | Parser_c.TIdent _, Parser_c.TCppConcatOp _ -> 
+      | Parser_c.TIdent _, Parser_c.TCppConcatOp _ ->
           x::y::remap_keyword_tokens xs
 
-      | Parser_c.TCppConcatOp (i1), _ -> 
+      | Parser_c.TCppConcatOp (i1), _ ->
 
           let s = TH.str_of_tok y in
           let ii = TH.info_of_tok y in
@@ -160,10 +160,10 @@ let rec remap_keyword_tokens xs =
             pr2 (spf "remaping: %s to an ident in expanded code" s);
             x::(Parser_c.TIdent (s, ii))::remap_keyword_tokens xs
           end
-          else 
+          else
             x::y::remap_keyword_tokens xs
 
-      | _, Parser_c.TCppConcatOp (i1) -> 
+      | _, Parser_c.TCppConcatOp (i1) ->
           let s = TH.str_of_tok x in
           let ii = TH.info_of_tok x in
           if s ==~ Common2.regexp_alpha
@@ -171,14 +171,14 @@ let rec remap_keyword_tokens xs =
             pr2 (spf "remaping: %s to an ident in expanded code" s);
             (Parser_c.TIdent (s, ii))::remap_keyword_tokens (y::xs)
           end
-          else 
+          else
             x::y::remap_keyword_tokens xs
 
-      | _, _ -> 
+      | _, _ ->
           x::remap_keyword_tokens (y::xs)
       )
-              
-          
+
+
 
 (* To expand the parameter of the macro. The env corresponds to the actual
  * code that is binded to the parameters of the macro.
@@ -186,27 +186,27 @@ let rec remap_keyword_tokens xs =
  * Or to macro expansion in a strict manner, that is process first
  * the parameters, expands macro in params, and then process enclosing
  * macro call.
- * 
+ *
  * note: do the concatenation job of a##b here ?
  * normally this should be done in the grammar. Here just expand
  * tokens. The only thing we handle here is we may have to remap
  * some tokens.
- * 
+ *
  * todo: handle stringification here ? if #n
- * 
- * todo? but could parsing_hacks then pass over the remapped tokens, 
+ *
+ * todo? but could parsing_hacks then pass over the remapped tokens,
  * for instance transform some of the back into some TypedefIdent
  * so cpp_engine may be fooled?
  *)
-let rec (cpp_engine: (string , Parser_c.token list) assoc -> 
-          Parser_c.token list -> Parser_c.token list) = 
+let rec (cpp_engine: (string , Parser_c.token list) assoc ->
+          Parser_c.token list -> Parser_c.token list) =
  fun env xs ->
-  xs +> List.map (fun tok -> 
+  xs +> List.map (fun tok ->
     (* expand only TIdent ? no cos the parameter of the macro
-     * can actually be some 'register' so may have to look for 
+     * can actually be some 'register' so may have to look for
      * any tokens candidates for the expansion.
      * Only subtelity is maybe dont expand the TDefineIdent.
-     * update: in fact now the caller (define_parse) will have done 
+     * update: in fact now the caller (define_parse) will have done
      * the job right and already replaced the macro parameter with a TIdent.
      *)
     match tok with
@@ -223,83 +223,83 @@ let rec (cpp_engine: (string , Parser_c.token list) assoc ->
 (* ------------------------------------------------------------------------- *)
 
 (* Thanks to this function many stuff are not anymore hardcoded in ocaml code.
- * At some point there were hardcoded in a standard.h file but now I 
+ * At some point there were hardcoded in a standard.h file but now I
  * can even generate them on the fly on demand when there is actually
  * a parsing problem.
- * 
+ *
  * No need to take care to not substitute the macro name itself
  * that occurs in the macro definition because the macro name is
  * after fix_token_define a TDefineIdent, no more a TIdent.
  *)
 
-let rec apply_macro_defs 
- ~msg_apply_known_macro 
- ~msg_apply_known_macro_hint 
- defs xs = 
- let rec apply_macro_defs xs = 
+let rec apply_macro_defs
+ ~msg_apply_known_macro
+ ~msg_apply_known_macro_hint
+ defs xs =
+ let rec apply_macro_defs xs =
   match xs with
   | [] -> ()
 
   (* old: "but could do more, could reuse same original token
    * so that have in the Ast a Dbg, not a MACROSTATEMENT"
-   * 
-   *   | PToken ({tok = TIdent (s,i1)} as id)::xs 
-   *     when s = "MACROSTATEMENT" -> 
-   * 
+   *
+   *   | PToken ({tok = TIdent (s,i1)} as id)::xs
+   *     when s = "MACROSTATEMENT" ->
+   *
    *     msg_macro_statement_hint s;
    *     id.tok <- TMacroStmt(TH.info_of_tok id.tok);
    *     find_macro_paren xs
-   * 
-   *  let msg_macro_statement_hint s = 
+   *
+   *  let msg_macro_statement_hint s =
    *    incr Stat.nMacroHint;
    *   ()
-   * 
+   *
    *)
 
   (* recognized macro of standard.h (or other) *)
-  | PToken ({tok = TIdent (s,i1)} as id)::Parenthised (xxs,info_parens)::xs 
-      when Hashtbl.mem defs s -> 
-      
+  | PToken ({tok = TIdent (s,i1)} as id)::Parenthised (xxs,info_parens)::xs
+      when Hashtbl.mem defs s ->
+
       msg_apply_known_macro s;
       let (s, params, body) = Hashtbl.find defs s in
 
       (match params with
-      | NoParam -> 
+      | NoParam ->
           pr2 ("WEIRD: macro without param used before parenthize: " ^ s);
           (* ex: PRINTP("NCR53C400 card%s detected\n" ANDP(((struct ... *)
 
           (match body with
-          | DefineBody bodymacro -> 
+          | DefineBody bodymacro ->
               set_as_comment (Token_c.CppMacro) id;
               id.new_tokens_before <- bodymacro;
-          | DefineHint hint -> 
+          | DefineHint hint ->
               msg_apply_known_macro_hint s;
               id.tok <- token_from_parsinghack_hint (s,i1) hint;
           )
-      | Params params -> 
+      | Params params ->
           (match body with
-          | DefineBody bodymacro -> 
+          | DefineBody bodymacro ->
 
-              (* bugfix: better to put this that before the match body, 
+              (* bugfix: better to put this that before the match body,
                * cos our macrostatement hint can have variable number of
                * arguments and so it's ok if it does not match exactly
                * the number of arguments. *)
               if List.length params != List.length xxs
-              then begin 
+              then begin
                 pr2_once ("WEIRD: macro with wrong number of arguments: " ^ s);
                 (* old: id.new_tokens_before <- bodymacro; *)
 
                 (* update: if wrong number, then I just pass this macro *)
-                [Parenthised (xxs, info_parens)] +> 
+                [Parenthised (xxs, info_parens)] +>
                   iter_token_paren (set_as_comment Token_c.CppMacro);
                 set_as_comment Token_c.CppMacro id;
 
                 ()
               end
-              else 
+              else
 
-                let xxs' = xxs +> List.map (fun x -> 
-                  (tokens_of_paren_ordered x) +> List.map (fun x -> 
+                let xxs' = xxs +> List.map (fun x ->
+                  (tokens_of_paren_ordered x) +> List.map (fun x ->
                     TH.visitor_info_of_tok Ast_c.make_expanded x.tok
                   )
                 ) in
@@ -311,23 +311,23 @@ let rec apply_macro_defs
                  * will pass as argument to the macro some tokens that
                  * are all TCommentCpp
                  *)
-                [Parenthised (xxs, info_parens)] +> 
+                [Parenthised (xxs, info_parens)] +>
                   iter_token_paren (set_as_comment Token_c.CppMacro);
                 set_as_comment Token_c.CppMacro id;
 
-            | DefineHint (HintMacroStatement as hint) -> 
+            | DefineHint (HintMacroStatement as hint) ->
                 (* important to do that after have apply the macro, otherwise
                  * will pass as argument to the macro some tokens that
                  * are all TCommentCpp
-                 * 
+                 *
                  * note: such macrostatement can have a variable number of
                  * arguments but here we don't care, we just pass all the
                  * parameters.
                  *)
 
                 (match xs with
-                | PToken ({tok = TPtVirg _} as id2)::_ -> 
-                    pr2_once 
+                | PToken ({tok = TPtVirg _} as id2)::_ ->
+                    pr2_once
                       ("macro stmt with trailing ';', passing also ';' for: "^
                        s);
                     (* sometimes still want pass its params ... as in
@@ -336,46 +336,46 @@ let rec apply_macro_defs
 
                     msg_apply_known_macro_hint s;
                     id.tok <- token_from_parsinghack_hint (s,i1) hint;
-                    [Parenthised (xxs, info_parens)] +> 
+                    [Parenthised (xxs, info_parens)] +>
                       iter_token_paren (set_as_comment Token_c.CppMacro);
                     set_as_comment Token_c.CppMacro id2;
 
                 | _ ->
                     msg_apply_known_macro_hint s;
                     id.tok <- token_from_parsinghack_hint (s,i1) hint;
-                    [Parenthised (xxs, info_parens)] +> 
+                    [Parenthised (xxs, info_parens)] +>
                       iter_token_paren (set_as_comment Token_c.CppMacro);
                 )
-                
 
-            | DefineHint hint -> 
+
+            | DefineHint hint ->
                 msg_apply_known_macro_hint s;
                 id.tok <- token_from_parsinghack_hint (s,i1) hint;
             )
       );
       apply_macro_defs xs
 
-  | PToken ({tok = TIdent (s,i1)} as id)::xs 
-      when Hashtbl.mem defs s -> 
+  | PToken ({tok = TIdent (s,i1)} as id)::xs
+      when Hashtbl.mem defs s ->
 
       msg_apply_known_macro s;
       let (_s, params, body) = Hashtbl.find defs s in
 
       (match params with
-      | Params params -> 
+      | Params params ->
           pr2 ("WEIRD: macro with params but no parens found: " ^ s);
           (* dont apply the macro, perhaps a redefinition *)
           ()
-      | NoParam -> 
+      | NoParam ->
           (match body with
-          | DefineBody [newtok] -> 
+          | DefineBody [newtok] ->
              (* special case when 1-1 substitution, we reuse the token *)
-              id.tok <- (newtok +> TH.visitor_info_of_tok (fun _ -> 
+              id.tok <- (newtok +> TH.visitor_info_of_tok (fun _ ->
                 TH.info_of_tok id.tok))
-          | DefineBody bodymacro -> 
+          | DefineBody bodymacro ->
               set_as_comment Token_c.CppMacro id;
               id.new_tokens_before <- bodymacro;
-          | DefineHint hint -> 
+          | DefineHint hint ->
                 msg_apply_known_macro_hint s;
                 id.tok <- token_from_parsinghack_hint (s,i1) hint;
           )
@@ -386,8 +386,8 @@ let rec apply_macro_defs
 
 
   (* recurse *)
-  | (PToken x)::xs -> apply_macro_defs xs 
-  | (Parenthised (xxs, info_parens))::xs -> 
+  | (PToken x)::xs -> apply_macro_defs xs
+  | (Parenthised (xxs, info_parens))::xs ->
       xxs +> List.iter apply_macro_defs;
       apply_macro_defs xs
  in
@@ -400,46 +400,46 @@ let rec apply_macro_defs
 (* The parsing hack for #define *)
 (*****************************************************************************)
 
-(* To parse macro definitions I need to do some tricks 
+(* To parse macro definitions I need to do some tricks
  * as some information can be get only at the lexing level. For instance
  * the space after the name of the macro in '#define foo (x)' is meaningful
  * but the grammar can not get this information. So define_ident below
  * look at such space and generate a special TOpardefine. In a similar
  * way macro definitions can contain some antislash and newlines
- * and the grammar need to know where the macro ends (which is 
- * a line-level and so low token-level information). Hence the 
+ * and the grammar need to know where the macro ends (which is
+ * a line-level and so low token-level information). Hence the
  * function 'define_line' below and the TDefEol.
- * 
- * 
- * ugly hack, a better solution perhaps would be to erase TDefEOL 
- * from the Ast and list of tokens in parse_c. 
- * 
+ *
+ *
+ * ugly hack, a better solution perhaps would be to erase TDefEOL
+ * from the Ast and list of tokens in parse_c.
+ *
  * note: I do a +1 somewhere, it's for the unparsing to correctly sync.
- * 
+ *
  * note: can't replace mark_end_define by simply a fakeInfo(). The reason
  * is where is the \n TCommentSpace. Normally there is always a last token
  * to synchronize on, either EOF or the token of the next toplevel.
- * In the case of the #define we got in list of token 
+ * In the case of the #define we got in list of token
  * [TCommentSpace "\n"; TDefEOL] but if TDefEOL is a fakeinfo then we will
  * not synchronize on it and so we will not print the "\n".
  * A solution would be to put the TDefEOL before the "\n".
- * 
- * todo?: could put a ExpandedTok for that ? 
+ *
+ * todo?: could put a ExpandedTok for that ?
  *)
-let mark_end_define ii = 
-  let ii' = 
-    { Ast_c.pinfo = Ast_c.OriginTok { (Ast_c.parse_info_of_info ii) with 
-        Parse_info.str = ""; 
+let mark_end_define ii =
+  let ii' =
+    { Ast_c.pinfo = Ast_c.OriginTok { (Ast_c.parse_info_of_info ii) with
+        Parse_info.str = "";
         Parse_info.charpos = Ast_c.pos_of_info ii + 1
       };
       cocci_tag = ref Ast_c.emptyAnnot;
       comments_tag = ref Ast_c.emptyComments;
-    } 
+    }
   in
   TDefEOL (ii')
 
 (* put the TDefEOL at the good place *)
-let rec define_line_1 acc xs = 
+let rec define_line_1 acc xs =
   match xs with
   | [] -> List.rev acc
   | TDefine ii::xs ->
@@ -452,44 +452,44 @@ let rec define_line_1 acc xs =
       define_line_1 acc xs
   | x::xs -> define_line_1 (x::acc) xs
 
-and define_line_2 acc line lastinfo xs = 
-  match xs with 
-  | [] -> 
+and define_line_2 acc line lastinfo xs =
+  match xs with
+  | [] ->
       (* should not happened, should meet EOF before *)
-      pr2 "PB: WEIRD";   
+      pr2 "PB: WEIRD";
       List.rev (mark_end_define lastinfo::acc)
-  | x::xs -> 
+  | x::xs ->
       let line' = TH.line_of_tok x in
       let info = TH.info_of_tok x in
 
       (match x with
-      | EOF ii -> 
+      | EOF ii ->
 	  let acc = (mark_end_define lastinfo) :: acc in
 	  let acc = (EOF ii) :: acc in
           define_line_1 acc xs
-      | TCppEscapedNewline ii -> 
+      | TCppEscapedNewline ii ->
           if (line' <> line) then pr2 "PB: WEIRD: not same line number";
 	  let acc = (TCommentSpace ii) :: acc in
           define_line_2 acc (line+1) info xs
-      | x -> 
+      | x ->
           if line' =|= line
-          then define_line_2 (x::acc) line info xs 
+          then define_line_2 (x::acc) line info xs
           else define_line_1 (mark_end_define lastinfo::acc) (x::xs)
       )
 
-let rec define_ident acc xs = 
+let rec define_ident acc xs =
   match xs with
   | [] -> List.rev acc
-  | TDefine ii::xs -> 
+  | TDefine ii::xs ->
       let acc = TDefine ii :: acc in
       (match xs with
-      | TCommentSpace i1::TIdent (s,i2)::TOPar (i3)::xs -> 
+      | TCommentSpace i1::TIdent (s,i2)::TOPar (i3)::xs ->
           (* Change also the kind of TIdent to avoid bad interaction
            * with other parsing_hack tricks. For instant if keep TIdent then
            * the stringication algo can believe the TIdent is a string-macro.
            * So simpler to change the kind of the ident too.
            *)
-          (* if TOParDefine sticked to the ident, then 
+          (* if TOParDefine sticked to the ident, then
            * it's a macro-function. Change token to avoid ambiguity
            * between #define foo(x)  and   #define foo   (x)
            *)
@@ -498,7 +498,7 @@ let rec define_ident acc xs =
 	  let acc = (TOParDefine i3) :: acc in
           define_ident acc xs
 
-      | TCommentSpace i1::TIdent (s,i2)::xs -> 
+      | TCommentSpace i1::TIdent (s,i2)::xs ->
 	  let acc = (TCommentSpace i1) :: acc in
 	  let acc = (TIdentDefine (s,i2)) :: acc in
           define_ident acc xs
@@ -506,11 +506,11 @@ let rec define_ident acc xs =
       (* bugfix: ident of macro (as well as params, cf below) can be tricky
        * note, do we need to subst in the body of the define ? no cos
        * here the issue is the name of the macro, as in #define inline,
-       * so obviously the name of this macro will not be used in its 
+       * so obviously the name of this macro will not be used in its
        * body (it would be a recursive macro, which is forbidden).
        *)
-       
-      | TCommentSpace i1::t::xs -> 
+
+      | TCommentSpace i1::t::xs ->
 
           let s = TH.str_of_tok t in
           let ii = TH.info_of_tok t in
@@ -522,36 +522,36 @@ let rec define_ident acc xs =
             define_ident acc xs
           end
           else begin
-            pr2 "WEIRD: weird #define body"; 
+            pr2 "WEIRD: weird #define body";
             define_ident acc xs
           end
 
-      | _ -> 
-          pr2 "WEIRD: weird #define body"; 
+      | _ ->
+          pr2 "WEIRD: weird #define body";
           define_ident acc xs
       )
   | x::xs ->
       let acc = x :: acc in
       define_ident acc xs
-  
 
 
-let fix_tokens_define2 xs = 
+
+let fix_tokens_define2 xs =
   define_ident [] (define_line_1 [] xs)
 
-let fix_tokens_define a = 
+let fix_tokens_define a =
   Common.profile_code "C parsing.fix_define" (fun () -> fix_tokens_define2 a)
-      
+
 
 
 (*****************************************************************************)
 (* for the cpp-builtin, standard.h, part 0 *)
 (*****************************************************************************)
 
-let macro_body_to_maybe_hint body = 
+let macro_body_to_maybe_hint body =
   match body with
   | [] -> DefineBody body
-  | [TIdent (s,i1)] -> 
+  | [TIdent (s,i1)] ->
       (match parsinghack_hint_of_string s with
       | Some hint -> DefineHint hint
       | None -> DefineBody body
@@ -559,25 +559,25 @@ let macro_body_to_maybe_hint body =
   | xs -> DefineBody body
 
 
-let rec define_parse xs = 
+let rec define_parse xs =
   match xs with
   | [] -> []
-  | TDefine i1::TIdentDefine (s,i2)::TOParDefine i3::xs -> 
-      let (tokparams, _, xs) = 
+  | TDefine i1::TIdentDefine (s,i2)::TOParDefine i3::xs ->
+      let (tokparams, _, xs) =
         xs +> Common2.split_when (function TCPar _ -> true | _ -> false) in
-      let (body, _, xs) = 
+      let (body, _, xs) =
         xs +> Common2.split_when (function TDefEOL _ -> true | _ -> false) in
-      let params = 
+      let params =
         tokparams +> Common.map_filter (function
         | TComma _ -> None
         | TIdent (s, _) -> Some s
 
         (* TODO *)
-        | TDefParamVariadic (s, _) -> Some s 
+        | TDefParamVariadic (s, _) -> Some s
         (* TODO *)
-        | TEllipsis _ -> Some "..." 
+        | TEllipsis _ -> Some "..."
 
-        | x -> 
+        | x ->
             (* bugfix: param of macros can be tricky *)
             let s = TH.str_of_tok x in
             if s ==~ Common2.regexp_alpha
@@ -585,18 +585,18 @@ let rec define_parse xs =
               pr2 (spf "remaping: %s to a macro parameter" s);
               Some s
             end
-            else 
+            else
               error_cant_have x
         ) in
-      (* bugfix: also substitute to ident in body so cpp_engine will 
+      (* bugfix: also substitute to ident in body so cpp_engine will
        * have an easy job.
        *)
-      let body = body +> List.map (fun tok -> 
+      let body = body +> List.map (fun tok ->
         match tok with
         | TIdent _ -> tok
-        | _ -> 
+        | _ ->
             let s = TH.str_of_tok tok in
-            let ii = TH.info_of_tok tok in 
+            let ii = TH.info_of_tok tok in
             if s ==~ Common2.regexp_alpha && List.mem s params
             then begin
               pr2 (spf "remaping: %s to an ident in macro body" s);
@@ -607,27 +607,27 @@ let rec define_parse xs =
       let def = (s, (s, Params params, macro_body_to_maybe_hint body)) in
       def::define_parse xs
 
-  | TDefine i1::TIdentDefine (s,i2)::xs -> 
-      let (body, _, xs) = 
+  | TDefine i1::TIdentDefine (s,i2)::xs ->
+      let (body, _, xs) =
         xs +> Common2.split_when (function TDefEOL _ -> true | _ -> false) in
-      let body = body +> List.map 
+      let body = body +> List.map
         (TH.visitor_info_of_tok Ast_c.make_expanded) in
       let def = (s, (s, NoParam, macro_body_to_maybe_hint body)) in
       def::define_parse xs
 
-  | TDefine i1::_ -> 
+  | TDefine i1::_ ->
       pr2_gen i1;
       raise Impossible
-  | x::xs -> define_parse xs 
-      
+  | x::xs -> define_parse xs
 
 
-let extract_cpp_define xs = 
-  let cleaner = xs +> List.filter (fun x -> 
+
+let extract_cpp_define xs =
+  let cleaner = xs +> List.filter (fun x ->
     not (TH.is_comment x)
   ) in
   define_parse cleaner
-  
+
 
 
 

--- a/parsing_c/cpp_token_c.mli
+++ b/parsing_c/cpp_token_c.mli
@@ -1,22 +1,22 @@
 (*
- * Do stuff involving cpp macros, like expanding some macros, 
+ * Do stuff involving cpp macros, like expanding some macros,
  * or try to parse well the body of the define by finding the end of
  * define virtual end-of-line token.
  *)
 
 (* corresponds to what is in the yacfe configuration file (e.g. standard.h) *)
-type define_def = string * define_param * define_body 
- and define_param = 
+type define_def = string * define_param * define_body
+ and define_param =
    | NoParam
    | Params of string list
- and define_body = 
+ and define_body =
    | DefineBody of Parser_c.token list
    | DefineHint of parsinghack_hint
 
    (* strongly corresponds to the TMacroXxx in the grammar and lexer and the
     * MacroXxx in the ast.
     *)
-   and parsinghack_hint = 
+   and parsinghack_hint =
      | HintIterator
      | HintDeclarator
      | HintMacroString
@@ -26,21 +26,21 @@ type define_def = string * define_param * define_body
 
 (* This function work by side effect and may generate new tokens
  * in the new_tokens_before field of the token_extended in the
- * paren_grouped list. So don't forget to recall 
+ * paren_grouped list. So don't forget to recall
  * Token_views_c.rebuild_tokens_extented after this call, as well
  * as probably parsing_hacks.insert_virtual_positions as new tokens
  * are generated.
  *)
-val apply_macro_defs: 
+val apply_macro_defs:
   msg_apply_known_macro:(string -> unit) ->
   msg_apply_known_macro_hint:(string -> unit) ->
   (string, define_def) Hashtbl.t ->
   Token_views_c.paren_grouped list -> unit
 
 (* generate virtual end-of-line token *)
-val fix_tokens_define : 
+val fix_tokens_define :
   Parser_c.token list -> Parser_c.token list
 
-val extract_cpp_define : 
+val extract_cpp_define :
   Parser_c.token list -> (string, define_def) Common.assoc
 

--- a/parsing_c/flag_parsing_c.ml
+++ b/parsing_c/flag_parsing_c.ml
@@ -1,7 +1,7 @@
 (*****************************************************************************)
 (* convenient globals. *)
 (*****************************************************************************)
-let path = ref 
+let path = ref
   (try (Sys.getenv "YACFE_HOME")
     with Not_found-> "/home/pad/github/yacfe"
   )
@@ -10,9 +10,9 @@ let path = ref
 (* macros *)
 (*****************************************************************************)
 
-let macro_dir = "config/macros/" 
-let mk_macro_path ~cocci_path file = 
-  Filename.concat cocci_path (macro_dir ^ file) 
+let macro_dir = "config/macros/"
+let mk_macro_path ~cocci_path file =
+  Filename.concat cocci_path (macro_dir ^ file)
 
 
 (* to pass to parse_c.init_defs *)
@@ -20,7 +20,7 @@ let std_h   = ref (mk_macro_path ~cocci_path:!path "standard.h")
 let common_h   = ref (mk_macro_path ~cocci_path:!path "common_macros.h")
 
 
-let cmdline_flags_macrofile () = 
+let cmdline_flags_macrofile () =
   [
     "-macro_file_builtins", Arg.Set_string std_h,
     " <file> (default=" ^ !std_h ^ ")";
@@ -45,7 +45,7 @@ let cmdline_flags_cpp () = [
 (*****************************************************************************)
 let std_envir = ref (Filename.concat !path "config/envos/environment_splint.h")
 
-let cmdline_flags_envfile () = 
+let cmdline_flags_envfile () =
   [
     "-env_file", Arg.Set_string std_envir,
     " <file> (default=" ^ !std_envir ^ ")";
@@ -76,7 +76,7 @@ let pretty_print_typedef_value = ref false
 let show_flow_labels = ref true
 
 
-let cmdline_flags_verbose () = 
+let cmdline_flags_verbose () =
   [
     "-no_verbose_parsing", Arg.Clear verbose_parsing , "  ";
     "-no_verbose_lexing", Arg.Clear verbose_lexing , "  ";
@@ -84,9 +84,9 @@ let cmdline_flags_verbose () =
 
     "-no_parse_error_msg", Arg.Clear verbose_parsing, " ";
     "-no_type_error_msg",  Arg.Clear verbose_type, " ";
-    
-    
-    "-filter_msg",      Arg.Set  filter_msg , 
+
+
+    "-filter_msg",      Arg.Set  filter_msg ,
     "  filter some cpp message when the macro is a \"known\" cpp construct";
     "-filter_msg_define_error",Arg.Set filter_msg_define_error,
     "  filter the error msg";
@@ -111,7 +111,7 @@ let debug_unparsing = ref false
 let debug_cfg = ref false
 
 (*   "debug C parsing/unparsing", "" *)
-let cmdline_flags_debugging () = 
+let cmdline_flags_debugging () =
   [
   "-debug_cpp",          Arg.Set  debug_cpp, " ";
   "-debug_lexer",        Arg.Set  debug_lexer , " ";
@@ -127,7 +127,7 @@ let cmdline_flags_debugging () =
 (*****************************************************************************)
 
 let check_annotater = ref true
-let cmdline_flags_checks () = 
+let cmdline_flags_checks () =
   [
   "-disable_check_annotater",          Arg.Clear  check_annotater, " ";
   "-enable_check_annotater",          Arg.Set  check_annotater, " ";
@@ -150,7 +150,7 @@ let cmdline_flags_algos () =
 (*****************************************************************************)
 
 let cpp_directive_passing = ref false
-let ifdef_directive_passing = ref false 
+let ifdef_directive_passing = ref false
 
 let disable_multi_pass = ref false
 let disable_add_typedef = ref false
@@ -160,12 +160,12 @@ let add_typedef_root = ref true
 
 let cmdline_flags_parsing_algos () = [
 
-    "-directive_passing",              Arg.Set cpp_directive_passing, 
+    "-directive_passing",              Arg.Set cpp_directive_passing,
     "   pass most cpp directives, especially when inside function";
-    "-ifdef_passing",              Arg.Set ifdef_directive_passing, 
+    "-ifdef_passing",              Arg.Set ifdef_directive_passing,
     "   pass ifdef directives ";
 
-    "-noif0_passing",   Arg.Clear if0_passing, 
+    "-noif0_passing",   Arg.Clear if0_passing,
     " ";
     "-noadd_typedef_root",   Arg.Clear add_typedef_root, " ";
     "-noadd_typedef",   Arg.Set disable_add_typedef, " ";
@@ -183,12 +183,12 @@ let diff_lines = ref (None : string option) (* number of lines of context *)
 (* for parse_c *)
 let use_cache = ref false
 
-let cmdline_flags_other () = 
+let cmdline_flags_other () =
   [
-    "-U", Arg.Int (fun n -> diff_lines := Some (Common.i_to_s n)), 
+    "-U", Arg.Int (fun n -> diff_lines := Some (Common.i_to_s n)),
     "  set number of diff context lines";
-    
-    "-use_cache", Arg.Set use_cache, 
+
+    "-use_cache", Arg.Set use_cache,
     "   use .ast_raw pre-parsed cached C file";
   ]
 

--- a/parsing_c/lexer_c.mll
+++ b/parsing_c/lexer_c.mll
@@ -1,12 +1,12 @@
 {
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2002, 2006, 2007, 2008, 2009, Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -20,33 +20,33 @@ open Ast_c (* to factorise tokens, OpAssign, ... *)
 
 (*****************************************************************************)
 (*
- * subtil: ocamllex use side effect on lexbuf, so must take care. 
- * For instance must do   
- * 
- *  let info = tokinfo lexbuf in 
- *  TComment (info +> tok_add_s (comment lexbuf)) 
- * 
- * and not 
- * 
- *   TComment (tokinfo lexbuf +> tok_add_s (comment lexbuf)) 
- * 
+ * subtil: ocamllex use side effect on lexbuf, so must take care.
+ * For instance must do
+ *
+ *  let info = tokinfo lexbuf in
+ *  TComment (info +> tok_add_s (comment lexbuf))
+ *
+ * and not
+ *
+ *   TComment (tokinfo lexbuf +> tok_add_s (comment lexbuf))
+ *
  * because of the "wierd" order of evaluation of OCaml.
- * 
- * 
+ *
+ *
  *
  * note: can't use Lexer_parser._lexer_hint here to do different
  * things, because now we call the lexer to get all the tokens
  * (tokens_all), and then we parse. So we can't have the _lexer_hint
  * info here. We can have it only in parse_c. For the same reason, the
- * typedef handling here is now useless. 
+ * typedef handling here is now useless.
  *)
 (*****************************************************************************)
 
 (*****************************************************************************)
 (* Wrappers *)
 (*****************************************************************************)
-let pr2 s = 
-  if !Flag_parsing_c.verbose_lexing 
+let pr2 s =
+  if !Flag_parsing_c.verbose_lexing
   then Common.pr2 s
 
 (*****************************************************************************)
@@ -56,14 +56,14 @@ exception Lexical of string
 
 let tok     lexbuf  = Lexing.lexeme lexbuf
 
-let tokinfo lexbuf  = 
-  { 
+let tokinfo lexbuf  =
+  {
     pinfo = Ast_c.OriginTok {
-      Parse_info.charpos = Lexing.lexeme_start lexbuf; 
+      Parse_info.charpos = Lexing.lexeme_start lexbuf;
       Parse_info.str     = Lexing.lexeme lexbuf;
       (* info filled in a post-lexing phase *)
-      Parse_info.line = -1; 
-      Parse_info.column = -1; 
+      Parse_info.line = -1;
+      Parse_info.column = -1;
       Parse_info.file = "";
     };
    (* must generate a new ref each time, otherwise share *)
@@ -75,50 +75,50 @@ let tokinfo lexbuf  =
 let no_ifdef_mark () = ref (None: (int * int) option)
 
 let tok_add_s s ii = Ast_c.rewrap_str ((Ast_c.str_of_info ii) ^ s) ii
-    
+
 
 (* opti: less convenient, but using a hash is faster than using a match *)
 let keyword_table = Common.hash_of_list [
 
   (* c: *)
-  "void",   (fun ii -> Tvoid ii); 
-  "char",   (fun ii -> Tchar ii);    
-  "short",  (fun ii -> Tshort ii); 
-  "int",    (fun ii -> Tint ii); 
-  "long",   (fun ii -> Tlong ii); 
-  "float",  (fun ii -> Tfloat ii); 
-  "double", (fun ii -> Tdouble ii);  
+  "void",   (fun ii -> Tvoid ii);
+  "char",   (fun ii -> Tchar ii);
+  "short",  (fun ii -> Tshort ii);
+  "int",    (fun ii -> Tint ii);
+  "long",   (fun ii -> Tlong ii);
+  "float",  (fun ii -> Tfloat ii);
+  "double", (fun ii -> Tdouble ii);
 
-  "unsigned", (fun ii -> Tunsigned ii);  
+  "unsigned", (fun ii -> Tunsigned ii);
   "signed",   (fun ii -> Tsigned ii);
-  
-  "auto",     (fun ii -> Tauto ii);    
-  "register", (fun ii -> Tregister ii);  
-  "extern",   (fun ii -> Textern ii); 
+
+  "auto",     (fun ii -> Tauto ii);
+  "register", (fun ii -> Tregister ii);
+  "extern",   (fun ii -> Textern ii);
   "static",   (fun ii -> Tstatic ii);
 
   "const",    (fun ii -> Tconst ii);
-  "volatile", (fun ii -> Tvolatile ii); 
-  
-  "struct",  (fun ii -> Tstruct ii); 
-  "union",   (fun ii -> Tunion ii); 
-  "enum",    (fun ii -> Tenum ii);  
-  "typedef", (fun ii -> Ttypedef ii);  
-  
-  "if",      (fun ii -> Tif ii);      
-  "else",     (fun ii -> Telse ii); 
-  "break",   (fun ii -> Tbreak ii);   
+  "volatile", (fun ii -> Tvolatile ii);
+
+  "struct",  (fun ii -> Tstruct ii);
+  "union",   (fun ii -> Tunion ii);
+  "enum",    (fun ii -> Tenum ii);
+  "typedef", (fun ii -> Ttypedef ii);
+
+  "if",      (fun ii -> Tif ii);
+  "else",     (fun ii -> Telse ii);
+  "break",   (fun ii -> Tbreak ii);
   "continue", (fun ii -> Tcontinue ii);
-  "switch",  (fun ii -> Tswitch ii);  
-  "case",     (fun ii -> Tcase ii);  
-  "default", (fun ii -> Tdefault ii); 
-  "for",     (fun ii -> Tfor ii);  
-  "do",      (fun ii -> Tdo ii);      
-  "while",   (fun ii -> Twhile ii);  
+  "switch",  (fun ii -> Tswitch ii);
+  "case",     (fun ii -> Tcase ii);
+  "default", (fun ii -> Tdefault ii);
+  "for",     (fun ii -> Tfor ii);
+  "do",      (fun ii -> Tdo ii);
+  "while",   (fun ii -> Twhile ii);
   "return",  (fun ii -> Treturn ii);
-  "goto",    (fun ii -> Tgoto ii); 
-  
-  "sizeof", (fun ii -> Tsizeof ii);   
+  "goto",    (fun ii -> Tgoto ii);
+
+  "sizeof", (fun ii -> Tsizeof ii);
 
 
   (* gccext: cppext: linuxext: synonyms *)
@@ -144,20 +144,20 @@ let keyword_table = Common.hash_of_list [
   "__const__",     (fun ii -> Tconst ii);
   "__const",     (fun ii -> Tconst ii);
 
-  "__volatile__",  (fun ii -> Tvolatile ii); 
-  "__volatile",    (fun ii -> Tvolatile ii);  
+  "__volatile__",  (fun ii -> Tvolatile ii);
+  "__volatile",    (fun ii -> Tvolatile ii);
 
 
   (* c99:  *)
-  (* no just "restrict" ? maybe for backward compatibility they avoided 
-   * to use restrict which people may have used in their program already 
+  (* no just "restrict" ? maybe for backward compatibility they avoided
+   * to use restrict which people may have used in their program already
    *)
-  "__restrict",    (fun ii -> Trestrict ii);  
-  "__restrict__",    (fun ii -> Trestrict ii);  
-  
+  "__restrict",    (fun ii -> Trestrict ii);
+  "__restrict__",    (fun ii -> Trestrict ii);
+
  ]
 
-let error_radix s = 
+let error_radix s =
   ("numeric " ^ s ^ " constant contains digits beyond the radix:")
 
 }
@@ -170,12 +170,12 @@ let digit  = ['0'-'9']
 let punctuation = ['!' '"' '#' '%' '&' '\'' '(' ')' '*' '+' ',' '-' '.' '/' ':'
 		   ';' '<' '=' '>' '?' '[' '\\' ']' '^' '{' '|' '}' '~']
 let space = [' ' '\t' '\n' '\r' '\011' '\012' ]
-let additionnal = [ ' ' '\b' '\t' '\011' '\n' '\r' '\007' ] 
-(* 7 = \a = bell in C. this is not the only char allowed !! 
- * ex @ and $ ` are valid too 
+let additionnal = [ ' ' '\b' '\t' '\011' '\n' '\r' '\007' ]
+(* 7 = \a = bell in C. this is not the only char allowed !!
+ * ex @ and $ ` are valid too
  *)
 
-let cchar = (letter | digit | punctuation | additionnal) 
+let cchar = (letter | digit | punctuation | additionnal)
 
 let sp = [' ' '\t']+
 let spopt = [' ' '\t']*
@@ -186,7 +186,7 @@ let hex = ['0'-'9' 'a'-'f' 'A'-'F']
 
 let decimal = ('0' | (['1'-'9'] dec*))
 let octal   = ['0']        oct+
-let hexa    = ("0x" |"0X") hex+ 
+let hexa    = ("0x" |"0X") hex+
 
 
 let pent   = dec+
@@ -204,7 +204,7 @@ rule token = parse
   (* spacing/comments *)
   (* ----------------------------------------------------------------------- *)
 
-  (* note: this lexer generate tokens for comments!! so can not give 
+  (* note: this lexer generate tokens for comments!! so can not give
    * this lexer as-is to the parsing function. Must preprocess it, hence
    * use techniques like cur_tok ref in parse_c.ml
    *)
@@ -212,22 +212,22 @@ rule token = parse
   | ['\n'] [' ' '\t' '\r' '\011' '\012' ]*
       (* starting a new line; the newline character followed by whitespace *)
       { TCommentNewline (tokinfo lexbuf) }
-  | [' ' '\t' '\r' '\011' '\012' ]+  
+  | [' ' '\t' '\r' '\011' '\012' ]+
       { TCommentSpace (tokinfo lexbuf) }
-  | "/*" 
-      { let info = tokinfo lexbuf in 
+  | "/*"
+      { let info = tokinfo lexbuf in
         let com = comment lexbuf in
 
         let info' = info +> tok_add_s com in
         let s = Ast_c.str_of_info info' in
-        (* could be more flexible, use [\t ]* instead of hardcoded 
+        (* could be more flexible, use [\t ]* instead of hardcoded
          * single space. *)
         match s with
-        | "/* {{coccinelle:skip_start}} */" -> 
+        | "/* {{coccinelle:skip_start}} */" ->
             TCommentSkipTagStart (info')
-        | "/* {{coccinelle:skip_end}} */" -> 
+        | "/* {{coccinelle:skip_end}} */" ->
             TCommentSkipTagEnd (info')
-        | _ -> TComment(info') 
+        | _ -> TComment(info')
       }
 
 
@@ -235,20 +235,20 @@ rule token = parse
    * So need this here only when dont call cpp before.
    * note that we don't keep the trailing \n; it will be in another token.
    *)
-  | "//" [^'\r' '\n' '\011']*    { TComment (tokinfo lexbuf) } 
+  | "//" [^'\r' '\n' '\011']*    { TComment (tokinfo lexbuf) }
 
   (* ----------------------------------------------------------------------- *)
   (* cpp *)
   (* ----------------------------------------------------------------------- *)
 
   (* old:
-   *   | '#'		{ endline lexbuf} // should be line, and not endline 
-   *   and endline = parse  | '\n' 	{ token lexbuf}  
-   *                        |	_	{ endline lexbuf} 
+   *   | '#'		{ endline lexbuf} // should be line, and not endline
+   *   and endline = parse  | '\n' 	{ token lexbuf}
+   *                        |	_	{ endline lexbuf}
    *)
 
   (* less?:
-   *  have found a # #else  in "newfile-2.6.c",  legal ?   and also a  #/* ... 
+   *  have found a # #else  in "newfile-2.6.c",  legal ?   and also a  #/* ...
    *    => just "#" -> token {lexbuf} (that is ignore)
    *  il y'a 1 #elif  sans rien  apres
    *  il y'a 1 #error sans rien  apres
@@ -266,21 +266,21 @@ rule token = parse
   (* ---------------------- *)
   (* misc *)
   (* ---------------------- *)
-      
-  (* bugfix: I want now to keep comments for the cComment study 
-   * so cant do:    sp [^'\n']+ '\n' 
+
+  (* bugfix: I want now to keep comments for the cComment study
+   * so cant do:    sp [^'\n']+ '\n'
    * http://gcc.gnu.org/onlinedocs/gcc/Pragmas.html
    *)
 
   | "#" spopt "pragma"  sp  [^'\n']* '\n'
-  | "#" spopt "ident"   sp  [^'\n']* '\n' 
-  | "#" spopt "line"    sp  [^'\n']* '\n' 
-  | "#" spopt "error"   sp  [^'\n']* '\n' 
-  | "#" spopt "warning" sp  [^'\n']* '\n'                     
+  | "#" spopt "ident"   sp  [^'\n']* '\n'
+  | "#" spopt "line"    sp  [^'\n']* '\n'
+  | "#" spopt "error"   sp  [^'\n']* '\n'
+  | "#" spopt "warning" sp  [^'\n']* '\n'
   | "#" spopt "abort"   sp  [^'\n']* '\n'
       { TCppDirectiveOther (tokinfo lexbuf) }
 
-  | "#" [' ' '\t']* '\n' 
+  | "#" [' ' '\t']* '\n'
       { TCppDirectiveOther (tokinfo lexbuf) }
 
   (* only after cpp, ex: # 1 "include/linux/module.h" 1 *)
@@ -293,16 +293,16 @@ rule token = parse
   (* #define, #undef *)
   (* ---------------------- *)
 
-  (* the rest of the lexing/parsing of define is done in fix_tokens_define 
+  (* the rest of the lexing/parsing of define is done in fix_tokens_define
    * where we parse until a TCppEscapedNewline and generate a TDefEol
    *)
-  | "#" [' ' '\t']* "define" { TDefine (tokinfo lexbuf) } 
+  | "#" [' ' '\t']* "define" { TDefine (tokinfo lexbuf) }
 
-  (* note: in some cases can have stuff after the ident as in #undef XXX 50, 
+  (* note: in some cases can have stuff after the ident as in #undef XXX 50,
    * but I currently don't handle it cos I think it's bad code.
    *)
   | (("#" [' ' '\t']* "undef" [' ' '\t']+) as _undef) (id as id)
-      { let info = tokinfo lexbuf in 
+      { let info = tokinfo lexbuf in
         TUndef (id, info)
         (*+> tok_add_s (cpp_eat_until_nl lexbuf))*)
       }
@@ -315,21 +315,21 @@ rule token = parse
   (* The difference between a local "" and standard <> include is computed
    * later in parser_c.mly. So redo a little bit of lexing there; ugly but
    * simpler to generate a single token here.  *)
-  | (("#" [' ''\t']* "include" [' ' '\t']*) as includes) 
-    (('"' ([^ '"']+) '"' | 
-     '<' [^ '>']+ '>' | 
-      ['A'-'Z''_']+ 
+  | (("#" [' ''\t']* "include" [' ' '\t']*) as includes)
+    (('"' ([^ '"']+) '"' |
+     '<' [^ '>']+ '>' |
+      ['A'-'Z''_']+
     ) as filename)
-      { let info = tokinfo lexbuf in 
+      { let info = tokinfo lexbuf in
         TInclude (includes, filename, Ast_c.noInIfdef(), info)
       }
   (* gccext: found in glibc *)
-  | (("#" [' ''\t']* "include_next" [' ' '\t']*) as includes) 
-    (('"' ([^ '"']+) '"' | 
-     '<' [^ '>']+ '>' | 
-      ['A'-'Z''_']+ 
+  | (("#" [' ''\t']* "include_next" [' ' '\t']*) as includes)
+    (('"' ([^ '"']+) '"' |
+     '<' [^ '>']+ '>' |
+      ['A'-'Z''_']+
     ) as filename)
-      { let info = tokinfo lexbuf in 
+      { let info = tokinfo lexbuf in
         TInclude (includes, filename, Ast_c.noInIfdef(), info)
       }
 
@@ -343,35 +343,35 @@ rule token = parse
 
   (* '0'+ because sometimes it is a #if 000 *)
   | "#" [' ' '\t']* "if" [' ' '\t']* '0'+           (* [^'\n']*  '\n' *)
-      { let info = tokinfo lexbuf in 
+      { let info = tokinfo lexbuf in
         TIfdefBool (false, no_ifdef_mark(), info)
-          (* +> tok_add_s (cpp_eat_until_nl lexbuf)*) 
+          (* +> tok_add_s (cpp_eat_until_nl lexbuf)*)
       }
 
   | "#" [' ' '\t']* "if" [' ' '\t']* '1'   (* [^'\n']*  '\n' *)
-      { let info = tokinfo lexbuf in 
-        TIfdefBool (true, no_ifdef_mark(), info) 
+      { let info = tokinfo lexbuf in
+        TIfdefBool (true, no_ifdef_mark(), info)
 
-      } 
-  
+      }
+
  (* DO NOT cherry pick to lexer_cplusplus !!! often used for the extern "C" { *)
   | "#" [' ' '\t']* "if" sp "defined" sp "(" spopt "__cplusplus" spopt ")" [^'\n']* '\n'
-      { let info = tokinfo lexbuf in 
-        TIfdefMisc (false, no_ifdef_mark(), info) 
+      { let info = tokinfo lexbuf in
+        TIfdefMisc (false, no_ifdef_mark(), info)
       }
 
  (* DO NOT cherry pick to lexer_cplusplus !!! *)
   | "#" [' ' '\t']* "ifdef" [' ' '\t']* "__cplusplus"   [^'\n']*  '\n'
-      { let info = tokinfo lexbuf in 
-        TIfdefMisc (false, no_ifdef_mark(), info) 
+      { let info = tokinfo lexbuf in
+        TIfdefMisc (false, no_ifdef_mark(), info)
       }
 
   (* in glibc *)
   | "#" spopt ("ifdef"|"if") sp "__STDC__"
-      { let info = tokinfo lexbuf in 
-        TIfdefVersion (true, no_ifdef_mark(), 
-                      info +> tok_add_s (cpp_eat_until_nl lexbuf)) 
-      } 
+      { let info = tokinfo lexbuf in
+        TIfdefVersion (true, no_ifdef_mark(),
+                      info +> tok_add_s (cpp_eat_until_nl lexbuf))
+      }
 
 
   (* linuxext: different possible variations (we do not manage all of them):
@@ -383,7 +383,7 @@ rule token = parse
     #if LINUX_VERSION_CODE < 0x020600
     #if LINUX_VERSION_CODE >= 0x2051c
     #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,5,0))
-    #if !(LINUX_VERSION_CODE > KERNEL_VERSION(2,5,73)) 
+    #if !(LINUX_VERSION_CODE > KERNEL_VERSION(2,5,73))
     #if STREAMER_IOCTL && (LINUX_VERSION_CODE < KERNEL_VERSION(2,5,0))
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,4,20)  &&  LINUX_VERSION_CODE < KERNEL_VERSION(2,5,0)
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(2,4,20) && \
@@ -397,58 +397,58 @@ rule token = parse
     #if (KERNEL_VERSION(2,4,0) > LINUX_VERSION_CODE)
     #if LINUX_VERSION_CODE >= ASC_LINUX_VERSION(1,3,0)
     # if defined(MODULE) && LINUX_VERSION_CODE >= KERNEL_VERSION(2,1,30)
-    
+
   *)
 
   (* linuxext: must be before the generic rules for if and ifdef *)
   | "#" spopt "if" sp "("?  "LINUX_VERSION_CODE" sp (">=" | ">") sp
-      { let info = tokinfo lexbuf in 
-        TIfdefVersion (true, no_ifdef_mark(), 
-                      info +> tok_add_s (cpp_eat_until_nl lexbuf)) 
-      } 
+      { let info = tokinfo lexbuf in
+        TIfdefVersion (true, no_ifdef_mark(),
+                      info +> tok_add_s (cpp_eat_until_nl lexbuf))
+      }
   (* linuxext: *)
   | "#" spopt "if" sp "!" "("?  "LINUX_VERSION_CODE" sp (">=" | ">") sp
   | "#" spopt "if" sp ['(']?  "LINUX_VERSION_CODE" sp ("<=" | "<") sp
-      
-      { let info = tokinfo lexbuf in 
-        TIfdefVersion (false, no_ifdef_mark(), 
-                      info +> tok_add_s (cpp_eat_until_nl lexbuf)) 
-      } 
+
+      { let info = tokinfo lexbuf in
+        TIfdefVersion (false, no_ifdef_mark(),
+                      info +> tok_add_s (cpp_eat_until_nl lexbuf))
+      }
 
 
 
 
   (* can have some ifdef 0  hence the letter|digit even at beginning of word *)
-  | "#" [' ''\t']* "ifdef"  [' ''\t']+ (letter|digit) ((letter|digit)*) [' ''\t']*  
+  | "#" [' ''\t']* "ifdef"  [' ''\t']+ (letter|digit) ((letter|digit)*) [' ''\t']*
       { TIfdef (no_ifdef_mark(), tokinfo lexbuf) }
-  | "#" [' ''\t']* "ifndef" [' ''\t']+ (letter|digit) ((letter|digit)*) [' ''\t']*  
+  | "#" [' ''\t']* "ifndef" [' ''\t']+ (letter|digit) ((letter|digit)*) [' ''\t']*
       { TIfdef (no_ifdef_mark(), tokinfo lexbuf) }
-  | "#" [' ''\t']* "if" [' ' '\t']+                                           
-      { let info = tokinfo lexbuf in 
-        TIfdef (no_ifdef_mark(), info +> tok_add_s (cpp_eat_until_nl lexbuf)) 
+  | "#" [' ''\t']* "if" [' ' '\t']+
+      { let info = tokinfo lexbuf in
+        TIfdef (no_ifdef_mark(), info +> tok_add_s (cpp_eat_until_nl lexbuf))
       }
-  | "#" [' ' '\t']* "if" '('                
-      { let info = tokinfo lexbuf in 
+  | "#" [' ' '\t']* "if" '('
+      { let info = tokinfo lexbuf in
         TIfdef (no_ifdef_mark(), info +> tok_add_s (cpp_eat_until_nl lexbuf))
       }
 
-  | "#" [' ' '\t']* "elif" [' ' '\t']+ 
-      { let info = tokinfo lexbuf in 
-        TIfdefelif (no_ifdef_mark(), info +> tok_add_s (cpp_eat_until_nl lexbuf)) 
-      } 
+  | "#" [' ' '\t']* "elif" [' ' '\t']+
+      { let info = tokinfo lexbuf in
+        TIfdefelif (no_ifdef_mark(), info +> tok_add_s (cpp_eat_until_nl lexbuf))
+      }
 
 
   (* bugfix: can have #endif LINUX  but at the same time if I eat everything
    * until next line, I may miss some TComment which for some tools
-   * are important such as aComment 
+   * are important such as aComment
    *)
-  | "#" [' ' '\t']* "endif" (*[^'\n']* '\n'*) { 
-      TEndif     (no_ifdef_mark(), tokinfo lexbuf) 
+  | "#" [' ' '\t']* "endif" (*[^'\n']* '\n'*) {
+      TEndif     (no_ifdef_mark(), tokinfo lexbuf)
     }
   (* can be at eof *)
   (*| "#" [' ' '\t']* "endif"                { TEndif     (tokinfo lexbuf) }*)
 
-  | "#" [' ' '\t']* "else" [' ' '\t' '\n']   
+  | "#" [' ' '\t']* "else" [' ' '\t' '\n']
       { TIfdefelse (no_ifdef_mark(), tokinfo lexbuf) }
 
 
@@ -462,7 +462,7 @@ rule token = parse
   | "\\" '\n' { TCppEscapedNewline (tokinfo lexbuf) }
 
   (* We must generate separate tokens for #, ## and extend the grammar.
-   * Note there can be "elaborated" idents in many different places, in 
+   * Note there can be "elaborated" idents in many different places, in
    * expression but also in declaration, in function name. So having 3 tokens
    * for an ident does not work well with how we add info in
    * ast_c. Was easier to generate just one token, just one info,
@@ -472,13 +472,13 @@ rule token = parse
    * (e.g. void METH(foo)(int x)), we need anyway to go from a string
    * to something more. So having also for C something more than just
    * string for ident is natural.
-   * 
+   *
    * todo: our heuristics in parsing_hacks rely on TIdent. So maybe
-   * an easier solution would be to augment the TIdent type such as 
+   * an easier solution would be to augment the TIdent type such as
    *   TIdent of string * info * cpp_ident_additionnal_info
-   * 
+   *
    * old:
-   * |  id   ([' ''\t']* "##" [' ''\t']* id)+ 
+   * |  id   ([' ''\t']* "##" [' ''\t']* id)+
    *   { let info = tokinfo lexbuf in
    *     TIdent (tok lexbuf, info)
    *   }
@@ -486,7 +486,7 @@ rule token = parse
    *   { let info = tokinfo lexbuf in
    *     TIdent (tok lexbuf, info)
    *   }
-   * 
+   *
    *)
   (* cppext: string concatenation of idents, also ##args for variadic macro. *)
   | "##" { TCppConcatOp (tokinfo lexbuf) }
@@ -495,7 +495,7 @@ rule token = parse
    * bugfix: this case must be after the other cases such as #endif
    * otherwise take precedent.
    *)
-  |  "#" spopt id  
+  |  "#" spopt id
       { let info = tokinfo lexbuf in
         TIdent (tok lexbuf, info)
       }
@@ -511,56 +511,56 @@ rule token = parse
   (* C symbols *)
   (* ----------------------------------------------------------------------- *)
    (* stdC:
-    ...   &&   -=   >=   ~   +   ;   ]    
-    <<=   &=   ->   >>   %   ,   <   ^    
-    >>=   *=   /=   ^=   &   -   =   {    
-    !=    ++   <<   |=   (   .   >   |    
-    %=    +=   <=   ||   )   /   ?   }    
-        --   ==   !    *   :   [   
-    recent addition:    <:  :>  <%  %> 
-    only at processing: %:  %:%: # ##  
-   *) 
+    ...   &&   -=   >=   ~   +   ;   ]
+    <<=   &=   ->   >>   %   ,   <   ^
+    >>=   *=   /=   ^=   &   -   =   {
+    !=    ++   <<   |=   (   .   >   |
+    %=    +=   <=   ||   )   /   ?   }
+        --   ==   !    *   :   [
+    recent addition:    <:  :>  <%  %>
+    only at processing: %:  %:%: # ##
+   *)
 
 
   | '[' { TOCro(tokinfo lexbuf) }   | ']' { TCCro(tokinfo lexbuf) }
   | '(' { TOPar(tokinfo lexbuf)   } | ')' { TCPar(tokinfo lexbuf)   }
   | '{' { TOBrace(tokinfo lexbuf) } | '}' { TCBrace(tokinfo lexbuf) }
 
-  | '+' { TPlus(tokinfo lexbuf) }   | '*' { TMul(tokinfo lexbuf) }     
-  | '-' { TMinus(tokinfo lexbuf) }  | '/' { TDiv(tokinfo lexbuf) } 
-  | '%' { TMod(tokinfo lexbuf) } 
+  | '+' { TPlus(tokinfo lexbuf) }   | '*' { TMul(tokinfo lexbuf) }
+  | '-' { TMinus(tokinfo lexbuf) }  | '/' { TDiv(tokinfo lexbuf) }
+  | '%' { TMod(tokinfo lexbuf) }
 
   | "++"{ TInc(tokinfo lexbuf) }    | "--"{ TDec(tokinfo lexbuf) }
 
-  | "="  { TEq(tokinfo lexbuf) } 
+  | "="  { TEq(tokinfo lexbuf) }
 
-  | "-=" { TAssign (OpAssign Minus, (tokinfo lexbuf))} 
-  | "+=" { TAssign (OpAssign Plus, (tokinfo lexbuf))} 
-  | "*=" { TAssign (OpAssign Mul, (tokinfo lexbuf))}   
-  | "/=" { TAssign (OpAssign Div, (tokinfo lexbuf))} 
-  | "%=" { TAssign (OpAssign Mod, (tokinfo lexbuf))} 
-  | "&=" { TAssign (OpAssign And, (tokinfo lexbuf))}  
-  | "|=" { TAssign (OpAssign Or, (tokinfo lexbuf)) } 
-  | "^=" { TAssign (OpAssign Xor, (tokinfo lexbuf))} 
-  | "<<=" {TAssign (OpAssign DecLeft, (tokinfo lexbuf)) } 
+  | "-=" { TAssign (OpAssign Minus, (tokinfo lexbuf))}
+  | "+=" { TAssign (OpAssign Plus, (tokinfo lexbuf))}
+  | "*=" { TAssign (OpAssign Mul, (tokinfo lexbuf))}
+  | "/=" { TAssign (OpAssign Div, (tokinfo lexbuf))}
+  | "%=" { TAssign (OpAssign Mod, (tokinfo lexbuf))}
+  | "&=" { TAssign (OpAssign And, (tokinfo lexbuf))}
+  | "|=" { TAssign (OpAssign Or, (tokinfo lexbuf)) }
+  | "^=" { TAssign (OpAssign Xor, (tokinfo lexbuf))}
+  | "<<=" {TAssign (OpAssign DecLeft, (tokinfo lexbuf)) }
   | ">>=" {TAssign (OpAssign DecRight, (tokinfo lexbuf))}
 
-  | "==" { TEqEq(tokinfo lexbuf) }  | "!=" { TNotEq(tokinfo lexbuf) } 
-  | ">=" { TSupEq(tokinfo lexbuf) } | "<=" { TInfEq(tokinfo lexbuf) } 
+  | "==" { TEqEq(tokinfo lexbuf) }  | "!=" { TNotEq(tokinfo lexbuf) }
+  | ">=" { TSupEq(tokinfo lexbuf) } | "<=" { TInfEq(tokinfo lexbuf) }
   | "<"  { TInf(tokinfo lexbuf) }   | ">"  { TSup(tokinfo lexbuf) }
 
   | "&&" { TAndLog(tokinfo lexbuf) } | "||" { TOrLog(tokinfo lexbuf) }
   | ">>" { TShr(tokinfo lexbuf) }    | "<<" { TShl(tokinfo lexbuf) }
-  | "&"  { TAnd(tokinfo lexbuf) }    | "|" { TOr(tokinfo lexbuf) } 
+  | "&"  { TAnd(tokinfo lexbuf) }    | "|" { TOr(tokinfo lexbuf) }
   | "^"  { TXor(tokinfo lexbuf) }
   | "..." { TEllipsis(tokinfo lexbuf) }
-  | "->"   { TPtrOp(tokinfo lexbuf) }  | '.'  { TDot(tokinfo lexbuf) }  
-  | ','    { TComma(tokinfo lexbuf) }  
+  | "->"   { TPtrOp(tokinfo lexbuf) }  | '.'  { TDot(tokinfo lexbuf) }
+  | ','    { TComma(tokinfo lexbuf) }
   | ";"    { TPtVirg(tokinfo lexbuf) }
-  | "?"    { TWhy(tokinfo lexbuf) }    | ":"   { TDotDot(tokinfo lexbuf) } 
+  | "?"    { TWhy(tokinfo lexbuf) }    | ":"   { TDotDot(tokinfo lexbuf) }
   | "!"    { TBang(tokinfo lexbuf) }   | "~"   { TTilde(tokinfo lexbuf) }
 
-  | "<:" { TOCro(tokinfo lexbuf) } | ":>" { TCCro(tokinfo lexbuf) } 
+  | "<:" { TOCro(tokinfo lexbuf) } | ":>" { TCCro(tokinfo lexbuf) }
   | "<%" { TOBrace(tokinfo lexbuf) } | "%>" { TCBrace(tokinfo lexbuf) }
 
 
@@ -571,21 +571,21 @@ rule token = parse
 
   (* StdC: must handle at least name of length > 509, but can
    * truncate to 31 when compare and truncate to 6 and even lowerise
-   * in the external linkage phase 
+   * in the external linkage phase
    *)
-  | letter (letter | digit) *  
+  | letter (letter | digit) *
       { let info = tokinfo lexbuf in
         let s = tok lexbuf in
-        Common.profile_code "C parsing.lex_ident" (fun () -> 
+        Common.profile_code "C parsing.lex_ident" (fun () ->
           match Common2.optionise (fun () -> Hashtbl.find keyword_table s)
           with
           | Some f -> f info
 
-           (* parse_typedef_fix. 
-            *    if Lexer_parser.is_typedef s 
+           (* parse_typedef_fix.
+            *    if Lexer_parser.is_typedef s
             *    then TypedefIdent (s, info)
             *    else TIdent (s, info)
-            * 
+            *
             * update: now this is no more useful, cos
             * as we use tokens_all, it first parse all as an ident and
             * later transform an indent in a typedef. so the typedef job is
@@ -595,12 +595,12 @@ rule token = parse
           | None -> TIdent (s, info)
         )
       }
-  (* gccext: apparently gcc allows dollar in variable names. found such 
+  (* gccext: apparently gcc allows dollar in variable names. found such
    * thing a few time in linux and in glibc. No need look in keyword_table
    * here.
    *)
-  | (letter | '$') (letter | digit | '$') *  
-      { 
+  | (letter | '$') (letter | digit | '$') *
+      {
         let info = tokinfo lexbuf in
         let s = tok lexbuf in
         pr2 ("LEXER: identifier with dollar: "  ^ s);
@@ -612,39 +612,39 @@ rule token = parse
   (* C constant *)
   (* ----------------------------------------------------------------------- *)
 
-  | "'"     
-      { let info = tokinfo lexbuf in 
-        let s = char lexbuf   in 
-        TChar     ((s,   IsChar),  (info +> tok_add_s (s ^ "'"))) 
-      }
-  | '"'     
+  | "'"
       { let info = tokinfo lexbuf in
-        let s = string lexbuf in 
-        TString   ((s,   IsChar),  (info +> tok_add_s (s ^ "\""))) 
+        let s = char lexbuf   in
+        TChar     ((s,   IsChar),  (info +> tok_add_s (s ^ "'")))
+      }
+  | '"'
+      { let info = tokinfo lexbuf in
+        let s = string lexbuf in
+        TString   ((s,   IsChar),  (info +> tok_add_s (s ^ "\"")))
       }
   (* wide character encoding, TODO L'toto' valid ? what is allowed ? *)
-  | 'L' "'" 
-      { let info = tokinfo lexbuf in 
-        let s = char lexbuf   in 
-        TChar     ((s,   IsWchar),  (info +> tok_add_s (s ^ "'"))) 
-      } 
-  | 'L' '"' 
-      { let info = tokinfo lexbuf in 
-        let s = string lexbuf in 
-        TString   ((s,   IsWchar),  (info +> tok_add_s (s ^ "\""))) 
+  | 'L' "'"
+      { let info = tokinfo lexbuf in
+        let s = char lexbuf   in
+        TChar     ((s,   IsWchar),  (info +> tok_add_s (s ^ "'")))
+      }
+  | 'L' '"'
+      { let info = tokinfo lexbuf in
+        let s = string lexbuf in
+        TString   ((s,   IsWchar),  (info +> tok_add_s (s ^ "\"")))
       }
 
 
   (* Take care of the order ? No because lex try the longest match. The
    * strange diff between decimal and octal constant semantic is not
    * understood too by refman :) refman:11.1.4, and ritchie.
-   * 
+   *
    * todo: attach type info to constant, like for float
    *)
 
-  | (( decimal | hexa | octal) 
-        ( ['u' 'U'] 
-        | ['l' 'L']  
+  | (( decimal | hexa | octal)
+        ( ['u' 'U']
+        | ['l' 'L']
         | (['l' 'L'] ['u' 'U'])
         | (['u' 'U'] ['l' 'L'])
         | (['u' 'U'] ['l' 'L'] ['l' 'L'])
@@ -657,11 +657,11 @@ rule token = parse
   | (real ['l' 'L']) as x { TFloat ((x, CLongDouble), tokinfo lexbuf) }
   | (real as x)           { TFloat ((x, CDouble),     tokinfo lexbuf) }
 
-  | ['0'] ['0'-'9']+  
-      { pr2 ("LEXER: " ^ error_radix "octal" ^ tok lexbuf); 
+  | ['0'] ['0'-'9']+
+      { pr2 ("LEXER: " ^ error_radix "octal" ^ tok lexbuf);
         TUnknown (tokinfo lexbuf)
       }
-  | ("0x" |"0X") ['0'-'9' 'a'-'z' 'A'-'Z']+ 
+  | ("0x" |"0X") ['0'-'9' 'a'-'z' 'A'-'Z']+
       { pr2 ("LEXER: " ^ error_radix "hexa" ^ tok lexbuf);
         TUnknown (tokinfo lexbuf)
       }
@@ -670,24 +670,24 @@ rule token = parse
  (* !!! to put after other rules !!! otherwise 0xff
   * will be parsed as an ident.
   *)
-  | ['0'-'9']+ letter (letter | digit) *  
+  | ['0'-'9']+ letter (letter | digit) *
       { pr2 ("LEXER: ZARB integer_string, certainly a macro:" ^ tok lexbuf);
         TIdent (tok lexbuf, tokinfo lexbuf)
-      } 
+      }
 
 (* gccext: http://gcc.gnu.org/onlinedocs/gcc/Binary-constants.html *)
 (*
- | "0b" ['0'-'1'] { TInt (((tok lexbuf)<!!>(??,??)) +> int_of_stringbits) } 
- | ['0'-'1']+'b' { TInt (((tok lexbuf)<!!>(0,-2)) +> int_of_stringbits) } 
+ | "0b" ['0'-'1'] { TInt (((tok lexbuf)<!!>(??,??)) +> int_of_stringbits) }
+ | ['0'-'1']+'b' { TInt (((tok lexbuf)<!!>(0,-2)) +> int_of_stringbits) }
 *)
 
 
   (*------------------------------------------------------------------------ *)
   | eof { EOF (tokinfo lexbuf +> Ast_c.rewrap_str "") }
 
-  | _ 
-      { 
-        if !Flag_parsing_c.verbose_lexing 
+  | _
+      {
+        if !Flag_parsing_c.verbose_lexing
         then pr2_once ("LEXER:unrecognised symbol, in token rule:"^tok lexbuf);
         TUnknown (tokinfo lexbuf)
       }
@@ -698,24 +698,24 @@ rule token = parse
 and char = parse
   | (_ as x)                                    "'"  { String.make 1 x }
   (* todo?: as for octal, do exception  beyond radix exception ? *)
-  | (("\\" (oct | oct oct | oct oct oct)) as x  "'") { x }  
+  | (("\\" (oct | oct oct | oct oct oct)) as x  "'") { x }
   (* this rule must be after the one with octal, lex try first longest
    * and when \7  we want an octal, not an exn.
    *)
   | (("\\x" ((hex | hex hex))) as x        "'")      { x }
   | (("\\" (_ as v))           as x        "'")
-	{ 
+	{
           (match v with (* Machine specific ? *)
-          | 'n' -> ()  | 't' -> ()   | 'v' -> ()  | 'b' -> () | 'r' -> ()  
+          | 'n' -> ()  | 't' -> ()   | 'v' -> ()  | 'b' -> () | 'r' -> ()
           | 'f' -> () | 'a' -> ()
 	  | '\\' -> () | '?'  -> () | '\'' -> ()  | '"' -> ()
           | 'e' -> () (* linuxext: ? *)
-	  | _ -> 
+	  | _ ->
               pr2 ("LEXER: unrecognised symbol in char:"^tok lexbuf);
 	  );
           x
-	} 
-  | _ 
+	}
+  | _
       { pr2 ("LEXER: unrecognised symbol in char:"^tok lexbuf);
         tok lexbuf
       }
@@ -730,10 +730,10 @@ and string  = parse
   | (_ as x)                                  { Common2.string_of_char x^string lexbuf}
   | ("\\" (oct | oct oct | oct oct oct)) as x { x ^ string lexbuf }
   | ("\\x" (hex | hex hex)) as x              { x ^ string lexbuf }
-  | ("\\" (_ as v)) as x  
-       { 
+  | ("\\" (_ as v)) as x
+       {
          (match v with (* Machine specific ? *)
-         | 'n' -> ()  | 't' -> ()   | 'v' -> ()  | 'b' -> () | 'r' -> ()  
+         | 'n' -> ()  | 't' -> ()   | 'v' -> ()  | 'b' -> () | 'r' -> ()
          | 'f' -> () | 'a' -> ()
 	 | '\\' -> () | '?'  -> () | '\'' -> ()  | '"' -> ()
          | 'e' -> () (* linuxext: ? *)
@@ -741,7 +741,7 @@ and string  = parse
          (* old: "x" -> 10 gccext ? todo ugly, I put a fake value *)
 
          (* cppext:  can have   \ for multiline in string too *)
-         | '\n' -> () 
+         | '\n' -> ()
          | _ -> pr2 ("LEXER: unrecognised symbol in string:"^tok lexbuf);
 	 );
           x ^ string lexbuf
@@ -753,9 +753,9 @@ and string  = parse
   * to finish the string, and so go until end of file.
   *)
  (*
-  | [^ '\\']+ 
+  | [^ '\\']+
     { let cs = lexbuf +> tok +> list_of_string +> List.map Char.code in
-      cs ++ string lexbuf  
+      cs ++ string lexbuf
     }
   *)
 
@@ -769,7 +769,7 @@ and comment = parse
   (* noteopti: *)
   | [^ '*']+ { let s = tok lexbuf in s ^ comment lexbuf }
   | [ '*']   { let s = tok lexbuf in s ^ comment lexbuf }
-  | _  
+  | _
       { let s = tok lexbuf in
         pr2 ("LEXER: unrecognised symbol in comment:"^s);
         s ^ comment lexbuf
@@ -788,19 +788,19 @@ and comment = parse
 
 and cpp_eat_until_nl = parse
   (* bugfix: *)
-  | "/*"          
-      { let s = tok lexbuf in 
-        let s2 = comment lexbuf in 
-        let s3 = cpp_eat_until_nl lexbuf in 
-        s ^ s2 ^ s3  
-      } 
+  | "/*"
+      { let s = tok lexbuf in
+        let s2 = comment lexbuf in
+        let s3 = cpp_eat_until_nl lexbuf in
+        s ^ s2 ^ s3
+      }
   | '\\' "\n" { let s = tok lexbuf in s ^ cpp_eat_until_nl lexbuf }
 
-  | "\n"      { tok lexbuf } 
-  (* noteopti: 
-   * update: need also deal with comments chars now 
+  | "\n"      { tok lexbuf }
+  (* noteopti:
+   * update: need also deal with comments chars now
    *)
-  | [^ '\n' '\\'      '/' '*'  ]+ 
-     { let s = tok lexbuf in s ^ cpp_eat_until_nl lexbuf } 
+  | [^ '\n' '\\'      '/' '*'  ]+
+     { let s = tok lexbuf in s ^ cpp_eat_until_nl lexbuf }
   | eof { pr2 "LEXER: end of file in cpp_eat_until_nl"; ""}
-  | _   { let s = tok lexbuf in s ^ cpp_eat_until_nl lexbuf }  
+  | _   { let s = tok lexbuf in s ^ cpp_eat_until_nl lexbuf }

--- a/parsing_c/lexer_parser.ml
+++ b/parsing_c/lexer_parser.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2002, 2006 Yoann Padioleau
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -15,16 +15,16 @@ open Common
 
 (* Tricks used to handle the ambiguity in the grammar with the typedef
  * which impose a cooperation between the lexer and the parser.
- * 
+ *
  * An example by hughes casse: "in the symbol table, local
  * definition must replace type definition in order to correctly parse
  * local variable in functions body. This is the only way to correctly
  * handle this kind of exception, that is,
- * 
+ *
  * typedef ... ID; int f(int *p) {int ID; return (ID) * *p;} If ID
  * isn't overload, last expression is parsed as a type cast, if it
  * isn't, this a multiplication."
- * 
+ *
  * Why parse_typedef_fix2 ? Cos when introduce new variable, for
  * instance when declare parameters for a function such as int var_t,
  * then the var_t must not be lexed as a typedef, so we must disable
@@ -48,14 +48,14 @@ let is_enabled_typedef () = !_handle_typedef
 type identkind = TypeDefI | IdentI
 
 (* Ca marche ce code ? on peut avoir un typedef puis un ident puis
- * un typedef nested ? oui car Hashtbl (dans scoped_h_env) gere l'historique. 
- * 
- * oldsimple:  but slow,  take 2 secondes on some C files 
+ * un typedef nested ? oui car Hashtbl (dans scoped_h_env) gere l'historique.
+ *
+ * oldsimple:  but slow,  take 2 secondes on some C files
  *    let (typedef: typedef list list ref) = ref [[]]
  *)
-let (_typedef : (string, identkind) Common2.scoped_h_env ref) = 
+let (_typedef : (string, identkind) Common2.scoped_h_env ref) =
   ref (Common2.empty_scoped_h_env ())
-   
+
 let is_typedef s  = if !_handle_typedef || !_always_look_typedef then
   (match (Common2.optionise (fun () -> Common2.lookup_h_env s !_typedef)) with
   | Some TypeDefI -> true
@@ -70,9 +70,9 @@ let del_scope() = Common2.del_scope_h _typedef
 let add_typedef  s = Common2.add_in_scope_h _typedef (s, TypeDefI)
 let add_ident s    = Common2.add_in_scope_h _typedef (s, IdentI)
 
-let add_typedef_root s = 
+let add_typedef_root s =
   if !Flag_parsing_c.add_typedef_root
-  then 
+  then
     Hashtbl.add !_typedef.Common2.scoped_h s TypeDefI
   else add_typedef s (* have far more .failed without this *)
 
@@ -82,51 +82,51 @@ let add_typedef_root s =
  *)
 let _old_state = ref (Common2.clone_scoped_h_env !_typedef)
 
-let save_typedef_state () = 
+let save_typedef_state () =
   _old_state := Common2.clone_scoped_h_env !_typedef
 
-let restore_typedef_state () = 
+let restore_typedef_state () =
   _typedef := !_old_state
-  
 
 
 
-type context = 
+
+type context =
   | InTopLevel
   | InFunction
   | InStruct
   | InParameter
   | InInitializer
   | InEnum
-(* InExpr ? but then orthogonal to InFunction. Could assign InExpr for 
- * instance after a '=' as in 'a = (irq_t) b;' 
+(* InExpr ? but then orthogonal to InFunction. Could assign InExpr for
+ * instance after a '=' as in 'a = (irq_t) b;'
  *)
 
 let is_top_or_struct = function
   | InTopLevel
-  | InStruct 
+  | InStruct
       -> true
   | _ -> false
 
-type lexer_hint = { 
+type lexer_hint = {
   mutable context_stack: context Common.stack;
  }
 
-let default_hint () = { 
+let default_hint () = {
   context_stack = [InTopLevel];
 }
 
 let _lexer_hint = ref (default_hint())
 
-let current_context () = List.hd !_lexer_hint.context_stack 
-let push_context ctx = 
+let current_context () = List.hd !_lexer_hint.context_stack
+let push_context ctx =
   !_lexer_hint.context_stack <- ctx::!_lexer_hint.context_stack
-let pop_context () = 
+let pop_context () =
   !_lexer_hint.context_stack <- List.tl !_lexer_hint.context_stack
 
 
 
-let lexer_reset_typedef () = 
+let lexer_reset_typedef () =
   begin
   _handle_typedef := true;
   _typedef := Common2.empty_scoped_h_env ();

--- a/parsing_c/lexer_parser.mli
+++ b/parsing_c/lexer_parser.mli
@@ -27,7 +27,7 @@ val save_typedef_state : unit -> unit
 val restore_typedef_state : unit -> unit
 
 
-type context = 
+type context =
   | InTopLevel
   | InFunction
   | InStruct
@@ -37,7 +37,7 @@ type context =
 
 val is_top_or_struct : context -> bool
 
-type lexer_hint = { 
+type lexer_hint = {
   mutable context_stack: context Common.stack;
  }
 

--- a/parsing_c/lib_parsing_c.ml
+++ b/parsing_c/lib_parsing_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2007, 2008, 2009 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -18,35 +18,35 @@ open Common
 (*****************************************************************************)
 
 (* todo?: al_expr doit enlever les infos de type ? et doit remettre en
- *  emptyAnnot ? 
+ *  emptyAnnot ?
  *)
 
 (* drop all info information *)
 
-let strip_info_visitor _ = 
+let strip_info_visitor _ =
   { Visitor_c.default_visitor_c_s with
     Visitor_c.kinfo_s =
     (* traversal should be deterministic... *)
-    (let ctr = ref 0 in 
+    (let ctr = ref 0 in
     (function (k,_) ->
     function i -> ctr := !ctr + 1; Ast_c.al_info_cpp !ctr i));
 
-    Visitor_c.kexpr_s = (fun (k,_) e -> 
+    Visitor_c.kexpr_s = (fun (k,_) e ->
       let (e', ty),ii' = k e in
       (e', Ast_c.noType()(*ref !ty*)), ii' (* keep type - jll *)
     );
 
 (*
-    Visitor_c.ktype_s = (fun (k,_) ft -> 
+    Visitor_c.ktype_s = (fun (k,_) ft ->
       let ft' = k ft in
       match Ast_c.unwrap_typeC ft' with
-      | Ast_c.TypeName (s,_typ) -> 
+      | Ast_c.TypeName (s,_typ) ->
           Ast_c.TypeName (s, Ast_c.noTypedefDef()) +> Ast_c.rewrap_typeC ft'
       | _ -> ft'
 
     );
 *)
-    
+
   }
 
 let al_expr      x = Visitor_c.vk_expr_s      (strip_info_visitor()) x
@@ -72,14 +72,14 @@ let semi_strip_info_visitor = (* keep position information *)
   { Visitor_c.default_visitor_c_s with
     Visitor_c.kinfo_s = (fun (k,_) i -> Ast_c.semi_al_info_cpp i);
 
-    Visitor_c.kexpr_s = (fun (k,_) e -> 
+    Visitor_c.kexpr_s = (fun (k,_) e ->
       let (e', ty),ii' = k e in
       (e', Ast_c.noType()(*ref !ty*)), ii' (* keep type - jll *)
     );
-    
+
   }
 
-let semi_al_expr      = Visitor_c.vk_expr_s      semi_strip_info_visitor 
+let semi_al_expr      = Visitor_c.vk_expr_s      semi_strip_info_visitor
 let semi_al_statement = Visitor_c.vk_statement_s semi_strip_info_visitor
 let semi_al_type      = Visitor_c.vk_type_s      semi_strip_info_visitor
 let semi_al_init      = Visitor_c.vk_ini_s       semi_strip_info_visitor
@@ -95,28 +95,28 @@ let semi_al_program =
 
 (* really strip, do not keep position nor anything specificities, true
  * abstracted form. *)
-let real_strip_info_visitor _ = 
+let real_strip_info_visitor _ =
   { Visitor_c.default_visitor_c_s with
     Visitor_c.kinfo_s = (fun (k,_) i ->
       Ast_c.real_al_info_cpp i
     );
 
-    Visitor_c.kexpr_s = (fun (k,_) e -> 
+    Visitor_c.kexpr_s = (fun (k,_) e ->
       let (e', ty),ii' = k e in
       (e', Ast_c.noType()), ii'
     );
 
 (*
-    Visitor_c.ktype_s = (fun (k,_) ft -> 
+    Visitor_c.ktype_s = (fun (k,_) ft ->
       let ft' = k ft in
       match Ast_c.unwrap_typeC ft' with
-      | Ast_c.TypeName (s,_typ) -> 
+      | Ast_c.TypeName (s,_typ) ->
           Ast_c.TypeName (s, Ast_c.noTypedefDef()) +> Ast_c.rewrap_typeC ft'
       | _ -> ft'
 
     );
 *)
-    
+
   }
 
 let real_al_expr      x = Visitor_c.vk_expr_s   (real_strip_info_visitor()) x
@@ -128,9 +128,9 @@ let real_al_type      x = Visitor_c.vk_type_s   (real_strip_info_visitor()) x
 (* Extract infos *)
 (*****************************************************************************)
 
-let extract_info_visitor recursor x = 
+let extract_info_visitor recursor x =
   let globals = ref [] in
-  let visitor = 
+  let visitor =
     {
       Visitor_c.default_visitor_c with
         Visitor_c.kinfo = (fun (k, _) i -> Common.push i globals)
@@ -153,20 +153,20 @@ let ii_of_struct_fields = extract_info_visitor Visitor_c.vk_struct_fields
 (*let ii_of_struct_field = extract_info_visitor Visitor_c.vk_struct_field*)
 let ii_of_struct_fieldkinds = extract_info_visitor Visitor_c.vk_struct_fieldkinds
 let ii_of_cst = extract_info_visitor Visitor_c.vk_cst
-let ii_of_define_params = 
+let ii_of_define_params =
   extract_info_visitor Visitor_c.vk_define_params_splitted
 let ii_of_toplevel = extract_info_visitor Visitor_c.vk_toplevel
 
 (*****************************************************************************)
 (* Max min, range *)
 (*****************************************************************************)
-let max_min_ii_by_pos xs = 
+let max_min_ii_by_pos xs =
   match xs with
   | [] -> failwith "empty list, max_min_ii_by_pos"
   | [x] -> (x, x)
-  | x::xs -> 
+  | x::xs ->
       let pos_leq p1 p2 = (Ast_c.compare_pos p1 p2) =|= (-1) in
-      xs +> List.fold_left (fun (maxii,minii) e -> 
+      xs +> List.fold_left (fun (maxii,minii) e ->
         let maxii' = if pos_leq maxii e then e else maxii in
         let minii' = if pos_leq e minii then e else minii in
         maxii', minii'
@@ -180,15 +180,15 @@ let info_to_fixpos ii =
   | Ast_c.FakeTok (_,(pi,offset)) ->
       Ast_cocci.Virt (pi.Parse_info.charpos,offset)
   | Ast_c.AbstractLineTok pi -> failwith "unexpected abstract"
-  
-let max_min_by_pos xs = 
+
+let max_min_by_pos xs =
   let (i1, i2) = max_min_ii_by_pos xs in
   (info_to_fixpos i1, info_to_fixpos i2)
 
 (* yacfe addon, is in flag.ml in cocci: *)
 let current_element = ref ""
 
-let lin_col_by_pos xs = 
+let lin_col_by_pos xs =
   (* put min before max; no idea why they are backwards above *)
   let (i2, i1) = max_min_ii_by_pos xs in
   let posf x = Ast_c.col_of_info x in
@@ -200,23 +200,23 @@ let lin_col_by_pos xs =
 
 
 
-let min_pinfo_of_node node = 
+let min_pinfo_of_node node =
   let ii = ii_of_node node in
   let (maxii, minii) = max_min_ii_by_pos ii in
   Ast_c.parse_info_of_info minii
 
 
-let (range_of_origin_ii: Ast_c.info list -> (int * int) option) = 
- fun ii -> 
+let (range_of_origin_ii: Ast_c.info list -> (int * int) option) =
+ fun ii ->
   let ii = List.filter Ast_c.is_origintok ii in
-  try 
+  try
     let (max, min) = max_min_ii_by_pos ii in
     assert(Ast_c.is_origintok max);
     assert(Ast_c.is_origintok min);
     let strmax = Ast_c.str_of_info max in
-    Some 
+    Some
       (Ast_c.pos_of_info min, Ast_c.pos_of_info max + String.length strmax)
-  with _ -> 
+  with _ ->
     None
 
 
@@ -224,20 +224,20 @@ let (range_of_origin_ii: Ast_c.info list -> (int * int) option) =
 (* Ast getters *)
 (*****************************************************************************)
 
-let names_of_parameters_in_def def = 
+let names_of_parameters_in_def def =
   match def.Ast_c.f_old_c_style with
-  | Some _ -> 
+  | Some _ ->
       pr2_once "names_of_parameters_in_def: f_old_c_style not handled";
       []
-  | None -> 
+  | None ->
       let ftyp = def.Ast_c.f_type in
       let (ret, (params, bwrap)) = ftyp in
-      params +> Common.map_filter (fun (param,ii) -> 
+      params +> Common.map_filter (fun (param,ii) ->
         Ast_c.name_of_parameter param
       )
 
-let names_of_parameters_in_macro xs = 
-  xs +> List.map (fun (xx, ii) -> 
+let names_of_parameters_in_macro xs =
+  xs +> List.map (fun (xx, ii) ->
     let (s, ii2) = xx in
     s
   )

--- a/parsing_c/meta_ast_c.ml
+++ b/parsing_c/meta_ast_c.ml
@@ -24,12 +24,12 @@ let vof_posl (v1, v2) =
   let v1 = Ocaml.vof_int v1
   and v2 = Ocaml.vof_int v2
   in Ocaml.VTuple [ v1; v2 ]
-  
+
 let vof_virtual_position (v1, v2) =
   let v1 = Parse_info.vof_t v1
   and v2 = Ocaml.vof_int v2
   in Ocaml.VTuple [ v1; v2 ]
-  
+
 let vof_parse_info =
   function
   | OriginTok v1 ->
@@ -46,12 +46,12 @@ let vof_parse_info =
       let v1 = Parse_info.vof_t v1
       in Ocaml.VSum (("AbstractLineTok", [ v1 ]))
 
-let rec vof_info x = 
+let rec vof_info x =
 (*
   if !_current_precision.M.full_info
   then Parse_info.vof_info x
   else if !_current_precision.M.token_info
-       then 
+       then
         Ocaml.VDict [
           "line", Ocaml.VInt (Parse_info.line_of_info x);
           "col", Ocaml.VInt (Parse_info.col_of_info x);
@@ -59,7 +59,7 @@ let rec vof_info x =
       else Ocaml.VUnit
 *)
   Ocaml.VUnit
-  
+
 let vof_il v = Ocaml.vof_list vof_info v
 
 let vof_wrap _of_a (v1, v2) =
@@ -891,4 +891,4 @@ and vof_comment_and_relative_pos { minfo = v_minfo; mpos = v_mpos } =
   let bnd = ("minfo", arg) in let bnds = bnd :: bnds in Ocaml.VDict bnds
 and vof_comment v = Parse_info.vof_t v
 and vof_com v = Ocaml.vof_ref (Ocaml.vof_list vof_comment) v
-  
+

--- a/parsing_c/orig.mly
+++ b/parsing_c/orig.mly
@@ -1,6 +1,6 @@
 %{
-(* src: ocamlyaccified from 
- *  http://www.lysator.liu.se/c/ANSI-C-grammar-y.html 
+(* src: ocamlyaccified from
+ *  http://www.lysator.liu.se/c/ANSI-C-grammar-y.html
  *)
 open Common
 open AbstractSyntax
@@ -15,23 +15,23 @@ exception Parsing of string
 /*(* conflicts *)*/
 %token <string> TypedefIdent
 
-%token TOPar TCPar TOBrace TCBrace TOCro TCCro 
-%token TDot TComma TPtrOp 
+%token TOPar TCPar TOBrace TCBrace TOCro TCCro
+%token TDot TComma TPtrOp
 %token TInc TDec
-%token <AbstractSyntax.assignOp> TAssign 
+%token <AbstractSyntax.assignOp> TAssign
 %token TEq
 %token TWhy TDotDot TPtVirg TTilde TBang
 %token TEllipsis
 
-%token TOrLog TAndLog TOrIncl TOrExcl TAnd  TEqEq TNotEq TInf TSup TInfEq TSupEq  TShl TShr 
-       TPlus TMinus TMul TDiv TMod 
+%token TOrLog TAndLog TOrIncl TOrExcl TAnd  TEqEq TNotEq TInf TSup TInfEq TSupEq  TShl TShr
+       TPlus TMinus TMul TDiv TMod
 
 %token Tchar Tshort Tint Tdouble Tfloat Tlong Tunsigned Tsigned Tvoid
-       Tauto Tregister Textern Tstatic 
+       Tauto Tregister Textern Tstatic
        Tconst Tvolatile
        Tstruct Tenum Ttypedef Tunion
        Tbreak Telse Tswitch Tcase Tcontinue Tfor Tdo Tif  Twhile Treturn Tgoto Tdefault
-       Tsizeof  
+       Tsizeof
 
 %token EOF
 
@@ -40,12 +40,12 @@ exception Parsing of string
 %left TAndLog
 %left TOrIncl
 %left TOrExcl
-%left TAnd 
+%left TAnd
 %left TEqEq TNotEq
-%left TInf TSup TInfEq TSupEq 
+%left TInf TSup TInfEq TSupEq
 %left TShl TShr
 %left TPlus TMinus
-%left TMul TDiv TMod 
+%left TMul TDiv TMod
 
 %start main
 %type <int list> main
@@ -165,10 +165,10 @@ iteration: Twhile TOPar expr TCPar statement {}
 	 | Tfor TOPar expr_statement expr_statement TCPar statement {}
 	 | Tfor TOPar expr_statement expr_statement expr TCPar statement {}
 
-jump: Tgoto TIdent {} 
+jump: Tgoto TIdent {}
     | Tcontinue {}
     | Tbreak {}
-    | Treturn {} 
+    | Treturn {}
     | Treturn expr {}
 
 /********************************************************************************/
@@ -202,7 +202,7 @@ type_spec: Tvoid {}
 	 | struct_or_union_spec {}
 	 | enum_spec {}
 /*TODO	 | TIdent {} */
-         | TypedefIdent {} 
+         | TypedefIdent {}
 
 type_qualif: Tconst {}
 	   | Tvolatile {}
@@ -241,7 +241,7 @@ enumerator_list: enumerator {}
 enumerator: TIdent {}
           | TIdent TEq const_expr {}
 /*------------------------------------------------------------------------------*/
- 	     
+
 init_declarator_list: init_declarator {}
 	            | init_declarator_list TComma init_declarator {}
 
@@ -297,7 +297,7 @@ direct_abstract_declarator: TOPar abstract_declarator TCPar {}
 			  | TOPar parameter_type_list TCPar {}
 			  | direct_abstract_declarator TOPar TCPar {}
 			  | direct_abstract_declarator TOPar parameter_type_list TCPar {}
-			  
+
 /*------------------------------------------------------------------------------*/
 initialize: assign_expr {}
           | TOBrace initialize_list TCBrace {}

--- a/parsing_c/pad.doc
+++ b/parsing_c/pad.doc
@@ -1,12 +1,12 @@
 I started coding it while at IRISA, during 2 weeks in march 2002?, during
 a period of depression in my PhD :). I continued working on it
-during 2005-2007 for the Coccinelle project. I continued working 
+during 2005-2007 for the Coccinelle project. I continued working
 on it in 2008 for aComment.
 
-So copyright holder = ? 
- - irisa  ? 
+So copyright holder = ?
+ - irisa  ?
  - lande ? (but not really work related)
- - emn ? 
+ - emn ?
  - uiuc ?
 
 well, make it simpler, pad is the copyright holder :)

--- a/parsing_c/parse_c.ml
+++ b/parsing_c/parse_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2006, 2007, 2008 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,7 +14,7 @@
 open Common
 open Common2
 
-module TH = Token_helpers 
+module TH = Token_helpers
 module LP = Lexer_parser
 
 module Stat = Parsing_stat
@@ -22,71 +22,71 @@ module Stat = Parsing_stat
 (*****************************************************************************)
 (* Wrappers *)
 (*****************************************************************************)
-let pr2_err s = 
-  if !Flag_parsing_c.verbose_parsing 
+let pr2_err s =
+  if !Flag_parsing_c.verbose_parsing
   then Common.pr2 s
 
-let pr2_once s = 
-  if !Flag_parsing_c.verbose_parsing 
+let pr2_once s =
+  if !Flag_parsing_c.verbose_parsing
   then Common.pr2_once s
-    
+
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
 
-let lexbuf_to_strpos lexbuf     = 
-  (Lexing.lexeme lexbuf, Lexing.lexeme_start lexbuf)    
+let lexbuf_to_strpos lexbuf     =
+  (Lexing.lexeme lexbuf, Lexing.lexeme_start lexbuf)
 
-let token_to_strpos tok = 
+let token_to_strpos tok =
   (TH.str_of_tok tok, TH.pos_of_tok tok)
 
 
-let error_msg_tok tok = 
+let error_msg_tok tok =
   let file = TH.file_of_tok tok in
   if !Flag_parsing_c.verbose_parsing
-  then Parse_info.error_message file (token_to_strpos tok) 
+  then Parse_info.error_message file (token_to_strpos tok)
   else ("error in " ^ file  ^ "; set verbose_parsing for more info")
 
 
-let print_bad line_error (start_line, end_line) filelines  = 
+let print_bad line_error (start_line, end_line) filelines  =
   begin
     pr2 ("badcount: " ^ i_to_s (end_line - start_line));
 
-    for i = start_line to end_line do 
-      let line = filelines.(i) in 
+    for i = start_line to end_line do
+      let line = filelines.(i) in
 
-      if i =|= line_error 
-      then  pr2 ("BAD:!!!!!" ^ " " ^ line) 
-      else  pr2 ("bad:" ^ " " ^      line) 
+      if i =|= line_error
+      then  pr2 ("BAD:!!!!!" ^ " " ^ line)
+      else  pr2 ("bad:" ^ " " ^      line)
     done
   end
 
 
 
-let mk_info_item2 filename toks = 
+let mk_info_item2 filename toks =
   let buf = Buffer.create 100 in
-  let s = 
+  let s =
     (* old: get_slice_file filename (line1, line2) *)
     begin
-      toks +> List.iter (fun tok -> 
+      toks +> List.iter (fun tok ->
         match TH.pinfo_of_tok tok with
-        | Ast_c.OriginTok _ -> 
+        | Ast_c.OriginTok _ ->
             Buffer.add_string buf (TH.str_of_tok tok)
-        | Ast_c.AbstractLineTok _ -> 
+        | Ast_c.AbstractLineTok _ ->
             raise Impossible
         | _ -> ()
       );
       Buffer.contents buf
     end
   in
-  (s, toks) 
+  (s, toks)
 
-let mk_info_item a b = 
-  Common.profile_code "C parsing.mk_info_item" 
+let mk_info_item a b =
+  Common.profile_code "C parsing.mk_info_item"
     (fun () -> mk_info_item2 a b)
 
 
-let info_same_line line xs = 
+let info_same_line line xs =
   xs +> List.filter (fun info -> Ast_c.line_of_info info =|= line)
 
 
@@ -95,32 +95,32 @@ let info_same_line line xs =
 (*****************************************************************************)
 
 let commentized xs = xs +> Common.map_filter (function
-  | Parser_c.TCommentCpp (cppkind, ii) -> 
+  | Parser_c.TCommentCpp (cppkind, ii) ->
       let s = Ast_c.str_of_info ii in
-      let legal_passing = 
-        match !Flag_parsing_c.filter_passed_level with 
+      let legal_passing =
+        match !Flag_parsing_c.filter_passed_level with
         | 0 -> false
-        | 1 -> 
+        | 1 ->
             List.mem cppkind [Token_c.CppAttr]
-            || 
+            ||
             (s =~ "__.*")
-        | 2 -> 
+        | 2 ->
             List.mem cppkind [Token_c.CppAttr;Token_c.CppPassingNormal]
-            || 
+            ||
             (s =~ "__.*")
-        | 3 -> 
+        | 3 ->
             List.mem cppkind [Token_c.CppAttr;Token_c.CppPassingNormal;Token_c.CppDirective]
-            || 
+            ||
             (s =~ "__.*")
-        | 4 -> 
+        | 4 ->
             List.mem cppkind [Token_c.CppAttr;Token_c.CppPassingNormal;Token_c.CppMacro]
-            || 
+            ||
             (s =~ "__.*")
 
 
-        | 5 -> 
+        | 5 ->
             List.mem cppkind [Token_c.CppAttr;Token_c.CppPassingNormal;Token_c.CppDirective;Token_c.CppMacro]
-            || 
+            ||
             (s =~ "__.*")
 
 
@@ -131,32 +131,32 @@ let commentized xs = xs +> Common.map_filter (function
       if legal_passing then None else Some (ii.Ast_c.pinfo)
 
         (*
-        | Ast_c.CppOther -> 
+        | Ast_c.CppOther ->
             (match s with
             | s when s =~ "KERN_.*" -> None
             | s when s =~ "__.*" -> None
-            | _ -> 
+            | _ ->
                 Some (ii.Ast_c.pinfo)
             )
         *)
 
-      
+
   | Parser_c.TCommentMisc ii
-  | Parser_c.TAction ii 
+  | Parser_c.TAction ii
     ->
       Some (ii.Ast_c.pinfo)
-  | _ -> 
+  | _ ->
       None
  )
-  
-let count_lines_commentized xs = 
+
+let count_lines_commentized xs =
   let line = ref (-1) in
   let count = ref 0 in
   begin
     commentized xs +>
     List.iter
       (function
-	  Ast_c.OriginTok pinfo | Ast_c.ExpandedTok (_,(pinfo,_)) -> 
+	  Ast_c.OriginTok pinfo | Ast_c.ExpandedTok (_,(pinfo,_)) ->
 	    let newline = pinfo.Parse_info.line in
 	    if newline <> !line
 	    then begin
@@ -169,24 +169,24 @@ let count_lines_commentized xs =
 
 
 
-let print_commentized xs = 
+let print_commentized xs =
   let line = ref (-1) in
   begin
     let ys = commentized xs in
     ys +>
     List.iter
       (function
-	  Ast_c.OriginTok pinfo | Ast_c.ExpandedTok (_,(pinfo,_)) -> 
+	  Ast_c.OriginTok pinfo | Ast_c.ExpandedTok (_,(pinfo,_)) ->
 	    let newline = pinfo.Parse_info.line in
 	    let s = pinfo.Parse_info.str in
-	    let s = Str.global_substitute 
-		(Str.regexp "\n") (fun s -> "") s 
+	    let s = Str.global_substitute
+		(Str.regexp "\n") (fun s -> "") s
 	    in
 	    if newline =|= !line
 	    then prerr_string (s ^ " ")
 	    else begin
-              if !line =|= -1 
-              then Common2.pr2_no_nl "passed:" 
+              if !line =|= -1
+              then Common2.pr2_no_nl "passed:"
               else Common2.pr2_no_nl "\npassed:";
               line := newline;
               Common2.pr2_no_nl (s ^ " ");
@@ -194,7 +194,7 @@ let print_commentized xs =
 	| _ -> ());
     if not (null ys) then pr2 "";
   end
-      
+
 
 
 
@@ -203,16 +203,16 @@ let print_commentized xs =
 (*****************************************************************************)
 
 (* called by parse_print_error_heuristic *)
-let tokens2 file = 
+let tokens2 file =
  let table     = Parse_info.full_charpos_to_pos_large file in
 
- Common.with_open_infile file (fun chan -> 
+ Common.with_open_infile file (fun chan ->
   let lexbuf = Lexing.from_channel chan in
-  try 
-    let rec tokens_aux acc = 
+  try
+    let rec tokens_aux acc =
       let tok = Lexer_c.token lexbuf in
       (* fill in the line and col information *)
-      let tok = tok +> TH.visitor_info_of_tok (fun ii -> 
+      let tok = tok +> TH.visitor_info_of_tok (fun ii ->
         { ii with Ast_c.pinfo=
           (* could assert pinfo.filename = file ? *)
 	  match Ast_c.pinfo_of_info ii with
@@ -231,24 +231,24 @@ let tokens2 file =
     in
     tokens_aux []
   with
-    | Lexer_c.Lexical s -> 
-        failwith ("lexical error " ^ s ^ "\n =" ^ 
+    | Lexer_c.Lexical s ->
+        failwith ("lexical error " ^ s ^ "\n =" ^
                   (Parse_info.error_message file (lexbuf_to_strpos lexbuf)))
     | e -> raise e
  )
 
-let time_lexing ?(profile=true) a = 
-  if profile 
+let time_lexing ?(profile=true) a =
+  if profile
   then Common.profile_code_exclusif "LEXING" (fun () -> tokens2 a)
-  else tokens2 a 
-let tokens ?profile a = 
+  else tokens2 a
+let tokens ?profile a =
   Common.profile_code "C parsing.tokens" (fun () -> time_lexing ?profile a)
 
 
-let tokens_of_string string = 
+let tokens_of_string string =
   let lexbuf = Lexing.from_string string in
-  try 
-    let rec tokens_s_aux () = 
+  try
+    let rec tokens_s_aux () =
       let tok = Lexer_c.token lexbuf in
       if TH.is_eof tok
       then [tok]
@@ -267,30 +267,30 @@ let tokens_of_string string =
 (*
  * !!!Those function use refs, and are not reentrant !!! so take care.
  * It use globals defined in Lexer_parser.
- * 
+ *
  * update: because now lexer return comments tokens, those functions
  * may not work anymore.
  *)
 
-let parse file = 
+let parse file =
   let lexbuf = Lexing.from_channel (open_in file) in
   let result = Parser_c.main Lexer_c.token lexbuf in
   result
 
 
-let parse_print_error file = 
+let parse_print_error file =
   let chan = (open_in file) in
   let lexbuf = Lexing.from_channel chan in
 
   let error_msg () = Parse_info.error_message file (lexbuf_to_strpos lexbuf) in
-  try 
+  try
     lexbuf +> Parser_c.main Lexer_c.token
-  with 
-  | Lexer_c.Lexical s ->   
+  with
+  | Lexer_c.Lexical s ->
       failwith ("lexical error " ^s^ "\n =" ^  error_msg ())
-  | Parsing.Parse_error -> 
+  | Parsing.Parse_error ->
       failwith ("parse error \n = " ^ error_msg ())
-  | Semantic_c.Semantic (s, i) -> 
+  | Semantic_c.Semantic (s, i) ->
       failwith ("semantic error " ^ s ^ "\n =" ^ error_msg ())
   | e -> raise e
 
@@ -307,34 +307,34 @@ let parse_print_error file =
  *)
 
 
-(* old: 
- *   let parse_gen parsefunc s = 
+(* old:
+ *   let parse_gen parsefunc s =
  *     let lexbuf = Lexing.from_string s in
  *     let result = parsefunc Lexer_c.token lexbuf in
  *     result
  *)
 
-let parse_gen parsefunc s = 
+let parse_gen parsefunc s =
   let toks = tokens_of_string s +> List.filter TH.is_not_comment in
 
 
   (* Why use this lexing scheme ? Why not classically give lexer func
-   * to parser ? Because I now keep comments in lexer. Could 
+   * to parser ? Because I now keep comments in lexer. Could
    * just do a simple wrapper that when comment ask again for a token,
    * but maybe simpler to use cur_tok technique.
    *)
   let all_tokens = ref toks in
   let cur_tok    = ref (List.hd !all_tokens) in
 
-  let lexer_function = 
-    (fun _ -> 
+  let lexer_function =
+    (fun _ ->
       if TH.is_eof !cur_tok
       then (pr2_err "LEXER: ALREADY AT END"; !cur_tok)
       else
         let v = Common2.pop2 all_tokens in
         cur_tok := v;
         !cur_tok
-    ) 
+    )
   in
   let lexbuf_fake = Lexing.from_function (fun buf n -> raise Impossible) in
   let result = parsefunc lexer_function lexbuf_fake in
@@ -357,11 +357,11 @@ let expression_of_string = parse_gen Parser_c.expr
 
 (* todo:
  *  could check that an ident has always the same class, be it a typedef
- *  (but sometimes do 'acpi_val acpi_val;'), an ident, a TMacroStatement, 
+ *  (but sometimes do 'acpi_val acpi_val;'), an ident, a TMacroStatement,
  *  etc.
  *)
 
-type class_ident = 
+type class_ident =
   | CIdent (* can be var, func, field, tag, enum constant *)
   | CTypedef
 
@@ -379,10 +379,10 @@ let str_of_class_ident = function
 
 (* but take care that must still be able to use '=' *)
 type context = InFunction | InEnum | InStruct | InInitializer | InParams
-type class_token = 
+type class_token =
   | CIdent of class_ident
 
-  | CComment 
+  | CComment
   | CSpace
   | CCommentCpp of cppkind
   | CCommentMisc
@@ -399,13 +399,13 @@ type class_token =
 
 let ident_to_typename ident =
   (Ast_c.nQ, (Ast_c.TypeName  (ident, Ast_c.noTypedefDef()), Ast_c.noii))
-                  
+
 
 (* parse_typedef_fix4 *)
-let consistency_checking2 xs = 
+let consistency_checking2 xs =
 
   (* first phase, gather data *)
-  let stat = Hashtbl.create 101 in 
+  let stat = Hashtbl.create 101 in
 
   (* default value for hash *)
   let v1 () = Hashtbl.create 101 in
@@ -413,41 +413,41 @@ let consistency_checking2 xs =
 
   let bigf = { Visitor_c.default_visitor_c with
 
-    Visitor_c.kexpr = (fun (k,bigf) x -> 
+    Visitor_c.kexpr = (fun (k,bigf) x ->
       match Ast_c.unwrap_expr x with
-      | Ast_c.Ident (id) -> 
+      | Ast_c.Ident (id) ->
           let s = Ast_c.str_of_name id in
-          stat +> 
-            Common2.hfind_default s v1 +> Common2.hfind_default CIdent v2 +> 
+          stat +>
+            Common2.hfind_default s v1 +> Common2.hfind_default CIdent v2 +>
             (fun aref -> incr aref)
 
       | _ -> k x
     );
-    Visitor_c.ktype = (fun (k,bigf) t -> 
+    Visitor_c.ktype = (fun (k,bigf) t ->
       match Ast_c.unwrap_typeC t with
-      | Ast_c.TypeName (name,_typ) -> 
+      | Ast_c.TypeName (name,_typ) ->
           let s = Ast_c.str_of_name name in
-          stat +> 
-            Common2.hfind_default s v1 +> Common2.hfind_default CTypedef v2 +> 
+          stat +>
+            Common2.hfind_default s v1 +> Common2.hfind_default CTypedef v2 +>
             (fun aref -> incr aref)
 
       | _ -> k t
     );
-  } 
+  }
   in
   xs +> List.iter (fun (p, info_item) -> Visitor_c.vk_toplevel bigf p);
 
 
   let ident_to_type = ref [] in
-  
+
 
   (* second phase, analyze data *)
-  stat +> Hashtbl.iter (fun k v -> 
+  stat +> Hashtbl.iter (fun k v ->
     let xs = Common.hash_to_list v in
     if List.length xs >= 2
-    then begin 
+    then begin
       pr2_err ("CONFLICT:" ^ k);
-      let sorted = xs +> List.sort (fun (ka,va) (kb,vb) -> 
+      let sorted = xs +> List.sort (fun (ka,va) (kb,vb) ->
         if !va =|= !vb then
           (match ka, kb with
           | CTypedef, _ -> 1 (* first is smaller *)
@@ -458,30 +458,30 @@ let consistency_checking2 xs =
       ) in
       let sorted = List.rev sorted in
       match sorted with
-      | [CTypedef, i1;CIdent, i2] -> 
+      | [CTypedef, i1;CIdent, i2] ->
           pr2_err ("transforming some ident in typedef");
           Common.push k ident_to_type;
-      | _ -> 
+      | _ ->
           pr2_err ("TODO:other transforming?");
-      
+
     end
   );
 
-  (* third phase, update ast. 
+  (* third phase, update ast.
    * todo? but normally should try to handle correctly scope ? maybe sometime
-   * sizeof(id) and even if id was for a long time an identifier, maybe 
+   * sizeof(id) and even if id was for a long time an identifier, maybe
    * a few time, because of the scope it's actually really a type.
    *)
   if (null !ident_to_type)
-  then xs 
-  else 
+  then xs
+  else
     let bigf = { Visitor_c.default_visitor_c_s with
-      Visitor_c.kdefineval_s = (fun (k,bigf) x -> 
+      Visitor_c.kdefineval_s = (fun (k,bigf) x ->
         match x with
-        | Ast_c.DefineExpr e -> 
+        | Ast_c.DefineExpr e ->
             (match e with
-            | (Ast_c.Ident (ident), _), _ii  -> 
-                let s = Ast_c.str_of_name ident in 
+            | (Ast_c.Ident (ident), _), _ii  ->
+                let s = Ast_c.str_of_name ident in
                 if List.mem s !ident_to_type
                 then
                   let t = ident_to_typename ident in
@@ -491,16 +491,16 @@ let consistency_checking2 xs =
             )
         | _ -> k x
       );
-      Visitor_c.kexpr_s = (fun (k, bigf) x -> 
+      Visitor_c.kexpr_s = (fun (k, bigf) x ->
         match x with
-        | (Ast_c.SizeOfExpr e, tref), isizeof -> 
+        | (Ast_c.SizeOfExpr e, tref), isizeof ->
             let i1 = Common2.tuple_of_list1 isizeof in
             (match e with
-            | (Ast_c.ParenExpr e, _), iiparen -> 
+            | (Ast_c.ParenExpr e, _), iiparen ->
                 (match e with
-                | (Ast_c.Ident (ident), _), _ii  -> 
+                | (Ast_c.Ident (ident), _), _ii  ->
 
-                    let s = Ast_c.str_of_name ident in 
+                    let s = Ast_c.str_of_name ident in
                     if List.mem s !ident_to_type
                     then
                       let t = ident_to_typename ident in
@@ -514,12 +514,12 @@ let consistency_checking2 xs =
         | _ -> k x
       );
     } in
-    xs +> List.map (fun (p, info_item) -> 
+    xs +> List.map (fun (p, info_item) ->
       Visitor_c.vk_toplevel_s bigf p, info_item
     )
 
 
-let consistency_checking a  = 
+let consistency_checking a  =
   Common.profile_code "C consistencycheck" (fun () -> consistency_checking2 a)
 
 
@@ -530,19 +530,19 @@ let consistency_checking a  =
 
 let is_define_passed passed =
   let xs = passed +> List.rev +> List.filter TH.is_not_comment in
-  if List.length xs >= 2 
-  then 
+  if List.length xs >= 2
+  then
     (match Common2.head_middle_tail xs with
-    | Parser_c.TDefine _, _, Parser_c.TDefEOL _ -> 
+    | Parser_c.TDefine _, _, Parser_c.TDefEOL _ ->
         true
     | _ -> false
     )
   else begin
     pr2_err "WEIRD: length list of error recovery tokens < 2 ";
-    false 
+    false
   end
 
-let is_defined_passed_bis last_round = 
+let is_defined_passed_bis last_round =
   let xs = last_round +> List.filter TH.is_not_comment in
   match xs with
   | Parser_c.TDefine _::_ -> true
@@ -560,101 +560,101 @@ let rec find_next_synchro next already_passed =
    * looking for next synchro point starting from next may not be the
    * best. So maybe we can find synchro point inside already_passed
    * instead of looking in next.
-   * 
+   *
    * But take care! must progress. We must not stay in infinite loop!
-   * For instance now I have as a error recovery to look for 
+   * For instance now I have as a error recovery to look for
    * a "start of something", corresponding to start of function,
    * but must go beyond this start otherwise will loop.
    * So look at premier(external_declaration2) in parser.output and
    * pass at least those first tokens.
-   * 
+   *
    * I have chosen to start search for next synchro point after the
    * first { I found, so quite sure we will not loop. *)
 
   let last_round = List.rev already_passed in
-  if is_defined_passed_bis last_round 
+  if is_defined_passed_bis last_round
   then find_next_synchro_define (last_round @ next) []
-  else 
+  else
 
-  let (before, after) = 
-    last_round +> Common.span (fun tok -> 
+  let (before, after) =
+    last_round +> Common.span (fun tok ->
       match tok with
       (* by looking at TOBrace we are sure that the "start of something"
-       * will not arrive too early 
+       * will not arrive too early
        *)
       | Parser_c.TOBrace _ -> false
       | Parser_c.TDefine _ -> false
       | _ -> true
-    ) 
+    )
   in
   find_next_synchro_orig (after @ next)  (List.rev before)
 
-    
+
 
 and find_next_synchro_define next already_passed =
   match next with
-  | [] ->  
-      pr2_err "ERROR-RECOV: end of file while in recovery mode"; 
+  | [] ->
+      pr2_err "ERROR-RECOV: end of file while in recovery mode";
       already_passed, []
-  | (Parser_c.TDefEOL i as v)::xs  -> 
+  | (Parser_c.TDefEOL i as v)::xs  ->
       pr2_err ("ERROR-RECOV: found sync end of #define, line "^i_to_s(TH.line_of_tok v));
       v::already_passed, xs
-  | v::xs -> 
+  | v::xs ->
       find_next_synchro_define xs (v::already_passed)
 
 
-    
+
 
 and find_next_synchro_orig next already_passed =
   match next with
-  | [] ->  
-      pr2_err "ERROR-RECOV: end of file while in recovery mode"; 
+  | [] ->
+      pr2_err "ERROR-RECOV: end of file while in recovery mode";
       already_passed, []
 
-  | (Parser_c.TCBrace i as v)::xs when TH.col_of_tok v =|= 0 -> 
+  | (Parser_c.TCBrace i as v)::xs when TH.col_of_tok v =|= 0 ->
       pr2_err ("ERROR-RECOV: found sync '}' at line "^i_to_s (TH.line_of_tok v));
 
       (match xs with
       | [] -> raise Impossible (* there is a EOF token normally *)
 
       (* still useful: now parser.mly allow empty ';' so normally no pb *)
-      | Parser_c.TPtVirg iptvirg::xs -> 
+      | Parser_c.TPtVirg iptvirg::xs ->
           pr2_err "ERROR-RECOV: found sync bis, eating } and ;";
           (Parser_c.TPtVirg iptvirg)::v::already_passed, xs
 
-      | Parser_c.TIdent x::Parser_c.TPtVirg iptvirg::xs -> 
+      | Parser_c.TIdent x::Parser_c.TPtVirg iptvirg::xs ->
           pr2_err "ERROR-RECOV: found sync bis, eating ident, }, and ;";
-          (Parser_c.TPtVirg iptvirg)::(Parser_c.TIdent x)::v::already_passed, 
+          (Parser_c.TPtVirg iptvirg)::(Parser_c.TIdent x)::v::already_passed,
           xs
-            
+
       | Parser_c.TCommentSpace sp::Parser_c.TIdent x::Parser_c.TPtVirg iptvirg
-        ::xs -> 
+        ::xs ->
           pr2_err "ERROR-RECOV: found sync bis, eating ident, }, and ;";
           (Parser_c.TCommentSpace sp)::
             (Parser_c.TPtVirg iptvirg)::
             (Parser_c.TIdent x)::
             v::
-            already_passed, 
+            already_passed,
           xs
-            
+
       | Parser_c.TCommentNewline sp::Parser_c.TIdent x::Parser_c.TPtVirg iptvirg
-        ::xs -> 
+        ::xs ->
           pr2_err "ERROR-RECOV: found sync bis, eating ident, }, and ;";
           (Parser_c.TCommentNewline sp)::
             (Parser_c.TPtVirg iptvirg)::
             (Parser_c.TIdent x)::
             v::
-            already_passed, 
+            already_passed,
           xs
-            
-      | _ -> 
+
+      | _ ->
           v::already_passed, xs
       )
-  | v::xs when TH.col_of_tok v =|= 0 && TH.is_start_of_something v  -> 
+  | v::xs when TH.col_of_tok v =|= 0 && TH.is_start_of_something v  ->
       pr2_err ("ERROR-RECOV: found sync col 0 at line "^ i_to_s(TH.line_of_tok v));
       already_passed, v::xs
-        
-  | v::xs -> 
+
+  | v::xs ->
       find_next_synchro_orig xs (v::already_passed)
 
 
@@ -663,7 +663,7 @@ and find_next_synchro_orig next already_passed =
 (*****************************************************************************)
 module TV = Token_views_c
 
-let candidate_macros_in_passed2 passed defs_optional = 
+let candidate_macros_in_passed2 passed defs_optional =
   let res = ref [] in
   let res2 = ref [] in
 
@@ -672,28 +672,28 @@ let candidate_macros_in_passed2 passed defs_optional =
    (* bugfix: may have to undo some infered things *)
   | Parser_c.TMacroIterator (s,_)
   | Parser_c.TypedefIdent (s,_)
-    -> 
+    ->
       (match Common2.hfind_option s defs_optional with
-      | Some def -> 
-          if s ==~ Parsing_hacks.regexp_macro 
+      | Some def ->
+          if s ==~ Parsing_hacks.regexp_macro
           then
             (* pr2 (spf "candidate: %s" s); *)
-            Common.push (s, def) res 
-          else 
+            Common.push (s, def) res
+          else
             Common.push (s, def) res2
         | None -> ()
         )
 
   | _ -> ()
   );
-  if null !res 
-  then !res2 
+  if null !res
+  then !res2
   else !res
 
-let candidate_macros_in_passed a b = 
-  Common.profile_code "MACRO managment" (fun () -> 
+let candidate_macros_in_passed a b =
+  Common.profile_code "MACRO managment" (fun () ->
     candidate_macros_in_passed2 a b)
-  
+
 
 
 let find_optional_macro_to_expand2 ~defs toks =
@@ -703,12 +703,12 @@ let find_optional_macro_to_expand2 ~defs toks =
   let toks = toks +> List.map (function
 
     (* special cases to undo *)
-    | Parser_c.TMacroIterator (s, ii) -> 
+    | Parser_c.TMacroIterator (s, ii) ->
         if Hashtbl.mem defs s
         then Parser_c.TIdent (s, ii)
         else Parser_c.TMacroIterator (s, ii)
 
-    | Parser_c.TypedefIdent (s, ii) -> 
+    | Parser_c.TypedefIdent (s, ii) ->
         if Hashtbl.mem defs s
         then Parser_c.TIdent (s, ii)
         else Parser_c.TypedefIdent (s, ii)
@@ -720,10 +720,10 @@ let find_optional_macro_to_expand2 ~defs toks =
   Parsing_hacks.fix_tokens_cpp ~macro_defs:defs tokens
 
   (* just calling apply_macro_defs and having a specialized version
-   * of the code in fix_tokens_cpp is not enough as some work such 
+   * of the code in fix_tokens_cpp is not enough as some work such
    * as the passing of the body of attribute in Parsing_hacks.find_macro_paren
    * will not get the chance to be run on the new expanded tokens.
-   * Hence even if it's expensive, it's currently better to 
+   * Hence even if it's expensive, it's currently better to
    * just call directly fix_tokens_cpp again here.
 
   let tokens2 = ref (tokens +> Common.acc_map TV.mk_token_extended) in
@@ -734,14 +734,14 @@ let find_optional_macro_to_expand2 ~defs toks =
     ~msg_apply_known_macro_hint:(fun s -> pr2 "hint")
     defs paren_grouped;
   (* because the before field is used by apply_macro_defs *)
-  tokens2 := TV.rebuild_tokens_extented !tokens2; 
-  Parsing_hacks.insert_virtual_positions 
+  tokens2 := TV.rebuild_tokens_extented !tokens2;
+  Parsing_hacks.insert_virtual_positions
     (!tokens2 +> Common.acc_map (fun x -> x.TV.tok))
   *)
-let find_optional_macro_to_expand ~defs a = 
-    Common.profile_code "MACRO managment" (fun () -> 
+let find_optional_macro_to_expand ~defs a =
+    Common.profile_code "MACRO managment" (fun () ->
       find_optional_macro_to_expand2 ~defs a)
-  
+
 
 
 (*****************************************************************************)
@@ -750,15 +750,15 @@ let find_optional_macro_to_expand ~defs a =
 
 (* Sometimes I prefer to generate a single token for a list of things in the
  * lexer so that if I have to passed them, like for passing TInclude then
- * it's easy. Also if I don't do a single token, then I need to 
- * parse the rest which may not need special stuff, like detecting 
+ * it's easy. Also if I don't do a single token, then I need to
+ * parse the rest which may not need special stuff, like detecting
  * end of line which the parser is not really ready for. So for instance
  * could I parse a #include <a/b/c/xxx.h> as 2 or more tokens ? just
- * lex #include ? so then need recognize <a/b/c/xxx.h> as one token ? 
+ * lex #include ? so then need recognize <a/b/c/xxx.h> as one token ?
  * but this kind of token is valid only after a #include and the
  * lexing and parsing rules are different for such tokens so not that
  * easy to parse such things in parser_c.mly. Hence the following hacks.
- * 
+ *
  * less?: maybe could get rid of this like I get rid of some of fix_define.
  *)
 
@@ -768,8 +768,8 @@ let find_optional_macro_to_expand ~defs a =
 
 (* used to generate new token from existing one *)
 let new_info posadd str ii =
-  { Ast_c.pinfo = 
-      Ast_c.OriginTok { (Ast_c.parse_info_of_info ii) with 
+  { Ast_c.pinfo =
+      Ast_c.OriginTok { (Ast_c.parse_info_of_info ii) with
         Parse_info.charpos = Ast_c.pos_of_info ii + posadd;
         str     = str;
         column = Ast_c.col_of_info ii + posadd;
@@ -780,16 +780,16 @@ let new_info posadd str ii =
    }
 
 
-let rec comment_until_defeol xs = 
+let rec comment_until_defeol xs =
   match xs with
   | [] -> failwith "cant find end of define token TDefEOL"
-  | x::xs -> 
+  | x::xs ->
       (match x with
-      | Parser_c.TDefEOL i -> 
+      | Parser_c.TDefEOL i ->
           Parser_c.TCommentCpp (Token_c.CppDirective, TH.info_of_tok x)
           ::xs
-      | _ -> 
-          let x' = 
+      | _ ->
+          let x' =
             (* bugfix: otherwise may lose a TComment token *)
             if TH.is_real_comment x
             then x
@@ -798,8 +798,8 @@ let rec comment_until_defeol xs =
           x'::comment_until_defeol xs
       )
 
-let drop_until_defeol xs = 
-  List.tl 
+let drop_until_defeol xs =
+  List.tl
     (Common2.drop_until (function Parser_c.TDefEOL _ -> true | _ -> false) xs)
 
 
@@ -808,9 +808,9 @@ let drop_until_defeol xs =
 (* returns a pair (replaced token, list of next tokens) *)
 (* ------------------------------------------------------------------------- *)
 
-let tokens_include (info, includes, filename, inifdef) = 
-  Parser_c.TIncludeStart (Ast_c.rewrap_str includes info, inifdef), 
-  [Parser_c.TIncludeFilename 
+let tokens_include (info, includes, filename, inifdef) =
+  Parser_c.TIncludeStart (Ast_c.rewrap_str includes info, inifdef),
+  [Parser_c.TIncludeFilename
       (filename, (new_info (String.length includes) filename info))
   ]
 
@@ -818,36 +818,36 @@ let tokens_include (info, includes, filename, inifdef) =
 (* Parsing default define macros, usually in a standard.h file *)
 (*****************************************************************************)
 
-let save_excursion reference f = 
+let save_excursion reference f =
   let old = !reference in
   let res = f() in
   reference := old;
   res
 
-let parse_cpp_define_file2 file = 
-  save_excursion Flag_parsing_c.verbose_lexing (fun () -> 
+let parse_cpp_define_file2 file =
+  save_excursion Flag_parsing_c.verbose_lexing (fun () ->
     Flag_parsing_c.verbose_lexing := false;
     let toks = tokens ~profile:false file in
     let toks = Cpp_token_c.fix_tokens_define toks in
     Cpp_token_c.extract_cpp_define toks
   )
 
-let parse_cpp_define_file a = 
+let parse_cpp_define_file a =
   Common.profile_code_exclusif "HACK" (fun () -> parse_cpp_define_file2 a)
 
 
 
-let (_defs : (string, Cpp_token_c.define_def) Hashtbl.t ref)  = 
+let (_defs : (string, Cpp_token_c.define_def) Hashtbl.t ref)  =
   ref (Hashtbl.create 101)
 
-let (_defs_builtins : (string, Cpp_token_c.define_def) Hashtbl.t ref)  = 
+let (_defs_builtins : (string, Cpp_token_c.define_def) Hashtbl.t ref)  =
   ref (Hashtbl.create 101)
 
 
 (* can not be put in parsing_hack, cos then mutually recursive problem as
  * we also want to parse the standard.h file.
  *)
-let init_defs std_h =     
+let init_defs std_h =
   if not (Common2.lfile_exists std_h)
   then pr2 ("warning: Can't find default macro file: " ^ std_h)
   else begin
@@ -855,12 +855,12 @@ let init_defs std_h =
     _defs := Common.hash_of_list (parse_cpp_define_file std_h);
   end
 
-let init_defs_builtins file_h =     
+let init_defs_builtins file_h =
   if not (Common2.lfile_exists file_h)
   then pr2 ("warning: Can't find macro file: " ^ file_h)
   else begin
     pr2 ("init_defs_builtins: " ^ file_h);
-    _defs_builtins := 
+    _defs_builtins :=
       Common.hash_of_list (parse_cpp_define_file file_h);
   end
 
@@ -874,13 +874,13 @@ type info_item =  string * Parser_c.token list
 type program2 = toplevel2 list
      and toplevel2 = Ast_c.toplevel * info_item
 
-let program_of_program2 xs = 
+let program_of_program2 xs =
   xs +> List.map fst
 
-let with_program2 f program2 = 
-  program2 
-  +> Common2.unzip 
-  +> (fun (program, infos) -> 
+let with_program2 f program2 =
+  program2
+  +> Common2.unzip
+  +> (fun (program, infos) ->
     f program, infos
   )
   +> Common2.uncurry Common2.zip
@@ -892,36 +892,36 @@ let with_program2 f program2 =
  * still be able to call again the ocamlyacc parser. It is ugly code
  * because we cant modify ocamllex and ocamlyacc. As we want some
  * extended lexing tricks, we have to use such refs.
- * 
+ *
  * Those refs are now also used for my lalr(k) technique. Indeed They
  * store the futur and previous tokens that were parsed, and so
  * provide enough context information for powerful lex trick.
- * 
+ *
  * - passed_tokens_last_ckp stores the passed tokens since last
  *   checkpoint. Used for NotParsedCorrectly and also to build the
  *   info_item attached to each program_element.
  * - passed_tokens_clean is used for lookahead, in fact for lookback.
  * - remaining_tokens_clean is used for lookahead. Now remaining_tokens
  *   contain some comments and so would make pattern matching difficult
- *   in lookahead. Hence this variable. We would like also to get rid 
+ *   in lookahead. Hence this variable. We would like also to get rid
  *   of cpp instruction because sometimes a cpp instruction is between
  *   two tokens and makes a pattern matching fail. But lookahead also
  *   transform some cpp instruction (in comment) so can't remove them.
- * 
+ *
  * So remaining_tokens, passed_tokens_last_ckp contain comment-tokens,
  * whereas passed_tokens_clean and remaining_tokens_clean does not contain
  * comment-tokens.
- * 
+ *
  * Normally we have:
- * toks = (reverse passed_tok) ++ cur_tok ++ remaining_tokens   
+ * toks = (reverse passed_tok) ++ cur_tok ++ remaining_tokens
  *    after the call to pop2.
- * toks = (reverse passed_tok) ++ remaining_tokens   
+ * toks = (reverse passed_tok) ++ remaining_tokens
  *     at the and of the lexer_function call.
  * At the very beginning, cur_tok and remaining_tokens overlap, but not after.
  * At the end of lexer_function call,  cur_tok  overlap  with passed_tok.
- * 
+ *
  * convention: I use "tr"  for "tokens refs"
- * 
+ *
  * I now also need this lexing trick because the lexer return comment
  * tokens.
  *)
@@ -935,25 +935,25 @@ type tokens_state = {
   mutable passed_clean : Parser_c.token list;
 }
 
-let mk_tokens_state toks = 
-  { 
+let mk_tokens_state toks =
+  {
     rest       = toks;
     rest_clean = (toks +> List.filter TH.is_not_comment);
     current    = (List.hd toks);
-    passed = []; 
+    passed = [];
     passed_clean = [];
   }
 
 
 
-let clone_tokens_state tr = 
+let clone_tokens_state tr =
   { rest = tr.rest;
     rest_clean = tr.rest_clean;
     current = tr.current;
     passed = tr.passed;
     passed_clean = tr.passed_clean;
   }
-let copy_tokens_state ~src ~dst = 
+let copy_tokens_state ~src ~dst =
   dst.rest <- src.rest;
   dst.rest_clean <- src.rest_clean;
   dst.current <- src.current;
@@ -966,30 +966,30 @@ let rec filter_noise n xs =
   match n, xs with
   | _, [] -> []
   | 0, xs -> xs
-  | n, x::xs -> 
+  | n, x::xs ->
       (match x with
-      | Parser_c.TMacroAttr _ -> 
+      | Parser_c.TMacroAttr _ ->
           filter_noise (n-1) xs
-      | _ -> 
+      | _ ->
           x::filter_noise (n-1) xs
       )
 
-let clean_for_lookahead xs = 
+let clean_for_lookahead xs =
   match xs with
   | [] -> []
   | [x] -> [x]
-  | x::xs -> 
+  | x::xs ->
       x::filter_noise 10 xs
 
 
 
-(* Hacked lex. This function use refs passed by parse_print_error_heuristic 
+(* Hacked lex. This function use refs passed by parse_print_error_heuristic
  * tr means token refs.
  *)
-let rec lexer_function ~pass tr = fun lexbuf -> 
+let rec lexer_function ~pass tr = fun lexbuf ->
   match tr.rest with
   | [] -> pr2_err "ALREADY AT END"; tr.current
-  | v::xs -> 
+  | v::xs ->
     tr.rest <- xs;
     tr.current <- v;
 
@@ -1004,18 +1004,18 @@ let rec lexer_function ~pass tr = fun lexbuf ->
       let x = List.hd tr.rest_clean  in
       tr.rest_clean <- List.tl tr.rest_clean;
       assert (x =*= v);
-      
+
       (match v with
 
-      (* fix_define1. 
+      (* fix_define1.
        *
        * Why not in parsing_hacks lookahead and do passing like
-       * I do for some ifdef directives ? Because here I also need to 
-       * generate some tokens sometimes and so I need access to the 
+       * I do for some ifdef directives ? Because here I also need to
+       * generate some tokens sometimes and so I need access to the
        * tr.passed, tr.rest, etc.
        *)
-      | Parser_c.TDefine (tok) -> 
-          if not (LP.current_context () =*= LP.InTopLevel) && 
+      | Parser_c.TDefine (tok) ->
+          if not (LP.current_context () =*= LP.InTopLevel) &&
             (!Flag_parsing_c.cpp_directive_passing || (pass >= 2))
           then begin
             incr Stat.nDefinePassing;
@@ -1032,8 +1032,8 @@ let rec lexer_function ~pass tr = fun lexbuf ->
             tr.passed_clean <- v::tr.passed_clean;
             v
           end
-            
-      | Parser_c.TInclude (includes, filename, inifdef, info) -> 
+
+      | Parser_c.TInclude (includes, filename, inifdef, info) ->
           if not (LP.current_context () =*= LP.InTopLevel)  &&
             (!Flag_parsing_c.cpp_directive_passing || (pass >= 2))
           then begin
@@ -1044,9 +1044,9 @@ let rec lexer_function ~pass tr = fun lexbuf ->
             lexer_function ~pass tr lexbuf
           end
           else begin
-            let (v,new_tokens) = 
+            let (v,new_tokens) =
               tokens_include (info, includes, filename, inifdef) in
-            let new_tokens_clean = 
+            let new_tokens_clean =
               new_tokens +> List.filter TH.is_not_comment  in
 
             tr.passed <- v::tr.passed;
@@ -1055,33 +1055,33 @@ let rec lexer_function ~pass tr = fun lexbuf ->
             tr.rest_clean <- new_tokens_clean ++ tr.rest_clean;
             v
           end
-            
-      | _ -> 
-          
+
+      | _ ->
+
           (* typedef_fix1 *)
           let v = match v with
-            | Parser_c.TIdent (s, ii) -> 
-                if 
-                  LP.is_typedef s && 
+            | Parser_c.TIdent (s, ii) ->
+                if
+                  LP.is_typedef s &&
                     not (!Flag_parsing_c.disable_add_typedef) &&
                     pass =|= 1
                 then Parser_c.TypedefIdent (s, ii)
                 else Parser_c.TIdent (s, ii)
             | x -> x
           in
-          
+
           let v = Parsing_hacks.lookahead ~pass
             (clean_for_lookahead (v::tr.rest_clean))
             tr.passed_clean in
 
           tr.passed <- v::tr.passed;
-          
+
           (* the lookahead may have changed the status of the token and
            * consider it as a comment, for instance some #include are
            * turned into comments, hence this code. *)
           match v with
           | Parser_c.TCommentCpp _ -> lexer_function ~pass tr lexbuf
-          | v -> 
+          | v ->
               tr.passed_clean <- v::tr.passed_clean;
               v
       )
@@ -1091,32 +1091,32 @@ let rec lexer_function ~pass tr = fun lexbuf ->
 let max_pass = 4
 
 
-let get_one_elem ~pass tr (file, filelines) = 
+let get_one_elem ~pass tr (file, filelines) =
 
   if not (LP.is_enabled_typedef()) && !Flag_parsing_c.debug_typedef
   then pr2_err "TYPEDEF:_handle_typedef=false. Not normal if dont come from exn";
 
   (* normally have to do that only when come from an exception in which
-   * case the dt() may not have been done 
+   * case the dt() may not have been done
    * TODO but if was in scoped scope ? have to let only the last scope
    * so need do a LP.lexer_reset_typedef ();
    *)
-  LP.enable_typedef();  
+  LP.enable_typedef();
   LP._lexer_hint := (LP.default_hint ());
   LP.save_typedef_state();
 
   tr.passed <- [];
 
   let lexbuf_fake = Lexing.from_function (fun buf n -> raise Impossible) in
-  
-  (try 
+
+  (try
       (* -------------------------------------------------- *)
       (* Call parser *)
       (* -------------------------------------------------- *)
-      Common.profile_code_exclusif "YACC" (fun () -> 
+      Common.profile_code_exclusif "YACC" (fun () ->
         Left (Parser_c.celem (lexer_function ~pass tr) lexbuf_fake)
       )
-    with e -> 
+    with e ->
       LP.restore_typedef_state();
 
       (* must keep here, before the code that adjusts the tr fields *)
@@ -1124,21 +1124,21 @@ let get_one_elem ~pass tr (file, filelines) =
 
       let passed_before_error = tr.passed in
       let current = tr.current in
-        
+
       (*  error recovery, go to next synchro point *)
       let (passed', rest') = find_next_synchro tr.rest tr.passed in
       tr.rest <- rest';
       tr.passed <- passed';
-      
+
       tr.current <- List.hd passed';
       tr.passed_clean <- [];           (* enough ? *)
       (* with error recovery, rest and rest_clean may not be in sync *)
       tr.rest_clean <- (tr.rest +> List.filter TH.is_not_comment);
-      
-      
-      let info_of_bads = Common2.map_eff_rev TH.info_of_tok tr.passed in 
-      Right (info_of_bads,  line_error, 
-            tr.passed, passed_before_error, 
+
+
+      let info_of_bads = Common2.map_eff_rev TH.info_of_tok tr.passed in
+      Right (info_of_bads,  line_error,
+            tr.passed, passed_before_error,
             current, e)
   )
 
@@ -1148,16 +1148,16 @@ let get_one_elem ~pass tr (file, filelines) =
 (* note: as now we go in 2 passes, there is first all the error message of
  * the lexer, and then the error of the parser. It is not anymore
  * interwinded.
- * 
+ *
  * !!!This function use refs, and is not reentrant !!! so take care.
  * It use globals defined in Lexer_parser and also the _defs global
- * in parsing_hack.ml. 
- * 
+ * in parsing_hack.ml.
+ *
  * This function uses internally some semi globals in the
  * tokens_stat record and parsing_stat record.
  *)
 
-let parse_print_error_heuristic2 file = 
+let parse_print_error_heuristic2 file =
 
   let filelines = Common2.cat_array file in
   let stat = Parsing_stat.default_stat file in
@@ -1165,7 +1165,7 @@ let parse_print_error_heuristic2 file =
   (* -------------------------------------------------- *)
   (* call lexer and get all the tokens *)
   (* -------------------------------------------------- *)
-  LP.lexer_reset_typedef(); 
+  LP.lexer_reset_typedef();
   Parsing_hacks.ifdef_paren_cnt := 0;
 
   let toks_orig = tokens file in
@@ -1175,21 +1175,21 @@ let parse_print_error_heuristic2 file =
   let toks = Parsing_hacks.fix_tokens_cpp ~macro_defs:!_defs_builtins toks in
 
   (* expand macros on demand trick, preparation phase *)
-  let macros = 
-    Common.profile_code "MACRO mgmt prep 1" (fun () -> 
+  let macros =
+    Common.profile_code "MACRO mgmt prep 1" (fun () ->
       let macros = Hashtbl.copy !_defs in
       (* include also builtins as some macros may generate some builtins too
        * like __decl_spec or __stdcall
        *)
-      !_defs_builtins +> Hashtbl.iter (fun s def -> 
+      !_defs_builtins +> Hashtbl.iter (fun s def ->
         Hashtbl.replace macros   s def;
       );
       macros
     )
   in
-  Common.profile_code "MACRO mgmt prep 2" (fun () -> 
+  Common.profile_code "MACRO mgmt prep 2" (fun () ->
     let local_macros = parse_cpp_define_file file in
-    local_macros +> List.iter (fun (s, def) -> 
+    local_macros +> List.iter (fun (s, def) ->
       Hashtbl.replace macros   s def;
     );
   );
@@ -1212,18 +1212,18 @@ let parse_print_error_heuristic2 file =
     let checkpoint_file = TH.file_of_tok tr.current in
 
     (* call the parser *)
-    let elem = 
-      let pass1 = 
-        Common.profile_code "Parsing: 1st pass" (fun () -> 
+    let elem =
+      let pass1 =
+        Common.profile_code "Parsing: 1st pass" (fun () ->
           get_one_elem ~pass:1 tr (file, filelines)
         ) in
       match pass1 with
       | Left e -> Left e
-      | Right (info,line_err, passed, passed_before_error, cur, exn) -> 
+      | Right (info,line_err, passed, passed_before_error, cur, exn) ->
           if !Flag_parsing_c.disable_multi_pass
           then pass1
           else begin
-            Common.profile_code "Parsing: multi pass" (fun () -> 
+            Common.profile_code "Parsing: multi pass" (fun () ->
 
             pr2_err "parsing pass2: try again";
             let toks = List.rev passed ++ tr.rest in
@@ -1233,9 +1233,9 @@ let parse_print_error_heuristic2 file =
 
             (match passx with
             | Left e -> passx
-            | Right (info,line_err,passed,passed_before_error,cur,exn) -> 
-                let candidates = 
-                  candidate_macros_in_passed passed macros 
+            | Right (info,line_err,passed,passed_before_error,cur,exn) ->
+                let candidates =
+                  candidate_macros_in_passed passed macros
                 in
                 if is_define_passed passed || null candidates
                 then passx
@@ -1244,7 +1244,7 @@ let parse_print_error_heuristic2 file =
 
                   pr2_err "parsing pass3: try again";
                   let toks = List.rev passed ++ tr.rest in
-                  let toks' = 
+                  let toks' =
                     find_optional_macro_to_expand ~defs:candidates toks in
                   let new_tr = mk_tokens_state toks' in
                   copy_tokens_state ~src:new_tr ~dst:tr;
@@ -1252,14 +1252,14 @@ let parse_print_error_heuristic2 file =
 
                   (match passx with
                   | Left e -> passx
-                  | Right (info,line_err,passed,passed_before_error,cur,exn) -> 
+                  | Right (info,line_err,passed,passed_before_error,cur,exn) ->
                       pr2_err "parsing pass4: try again";
 
-                      let candidates = 
+                      let candidates =
                         candidate_macros_in_passed passed macros in
 
                       let toks = List.rev passed ++ tr.rest in
-                      let toks' = 
+                      let toks' =
                       find_optional_macro_to_expand ~defs:candidates toks in
                       let new_tr = mk_tokens_state toks' in
                       copy_tokens_state ~src:new_tr ~dst:tr;
@@ -1277,9 +1277,9 @@ let parse_print_error_heuristic2 file =
     let checkpoint2 = TH.line_of_tok tr.current in (* <> line_error *)
     let checkpoint2_file = TH.file_of_tok tr.current in
 
-    let diffline = 
+    let diffline =
       if (checkpoint_file =$= checkpoint2_file) && (checkpoint_file =$= file)
-      then (checkpoint2 - checkpoint) 
+      then (checkpoint2 - checkpoint)
       else 0
         (* TODO? so if error come in middle of something ? where the
          * start token was from original file but synchro found in body
@@ -1288,49 +1288,49 @@ let parse_print_error_heuristic2 file =
          * the lines in the token from the correct file ?
          *)
     in
-    let info = mk_info_item file (List.rev tr.passed) in 
+    let info = mk_info_item file (List.rev tr.passed) in
 
     (* some stat updates *)
-    stat.Stat.commentized <- 
+    stat.Stat.commentized <-
       stat.Stat.commentized + count_lines_commentized (snd info);
 
-    let elem = 
+    let elem =
       match elem with
-      | Left e -> 
+      | Left e ->
           stat.Stat.correct <- stat.Stat.correct + diffline;
           e
-      | Right (info_of_bads, line_error, toks_of_bads, 
-              _passed_before_error, cur, exn) -> 
+      | Right (info_of_bads, line_error, toks_of_bads,
+              _passed_before_error, cur, exn) ->
 
           let was_define = is_define_passed tr.passed in
-          
+
           if was_define && !Flag_parsing_c.filter_msg_define_error
           then ()
           else begin
             (match exn with
             (* Lexical is not anymore launched I think *)
-            | Lexer_c.Lexical s -> 
+            | Lexer_c.Lexical s ->
                 pr2 ("lexical error " ^s^ "\n =" ^ error_msg_tok cur)
-            | Parsing.Parse_error -> 
+            | Parsing.Parse_error ->
                 pr2 ("parse error \n = " ^ error_msg_tok cur)
-            | Semantic_c.Semantic (s, i) -> 
+            | Semantic_c.Semantic (s, i) ->
                 pr2 ("semantic error " ^s^ "\n ="^ error_msg_tok cur)
             | e -> raise e
             );
-            
-            let pbline = 
-              toks_of_bads 
+
+            let pbline =
+              toks_of_bads
               +> Common2.filter (TH.is_same_line_or_close line_error)
-              +> Common2.filter TH.is_ident_like 
+              +> Common2.filter TH.is_ident_like
             in
-            let error_info = 
+            let error_info =
               (pbline +> List.map TH.str_of_tok), line_error
             in
-            stat.Stat.problematic_lines <- 
+            stat.Stat.problematic_lines <-
               error_info::stat.Stat.problematic_lines;
 
             (* bugfix: *)
-            if (checkpoint_file =$= checkpoint2_file) && 
+            if (checkpoint_file =$= checkpoint2_file) &&
                 checkpoint_file =$= file
             then print_bad line_error (checkpoint, checkpoint2) filelines
             else pr2 "PB: bad: but on tokens not from original file"
@@ -1353,10 +1353,10 @@ let parse_print_error_heuristic2 file =
   (v, stat)
 
 
-let time_total_parsing a  = 
+let time_total_parsing a  =
   Common.profile_code "TOTAL" (fun () -> parse_print_error_heuristic2 a)
 
-let parse_print_error_heuristic a  = 
+let parse_print_error_heuristic a  =
   Common.profile_code "C parsing" (fun () -> time_total_parsing a)
 
 
@@ -1366,31 +1366,31 @@ let parse_c_and_cpp a = parse_print_error_heuristic a
 (*****************************************************************************)
 (* Same but faster cos memoize stuff *)
 (*****************************************************************************)
-let parse_cache file = 
-  if not !Flag_parsing_c.use_cache then parse_print_error_heuristic file 
-  else 
+let parse_cache file =
+  if not !Flag_parsing_c.use_cache then parse_print_error_heuristic file
+  else
   let _ = pr2 "TOFIX" in
-  let need_no_changed_files = 
+  let need_no_changed_files =
     (* should use Sys.argv.(0), would be safer. *)
 
     [
       (* TOFIX
       Config.path ^ "/parsing_c/c_parser.cma";
-      (* we may also depend now on the semantic patch because 
+      (* we may also depend now on the semantic patch because
          the SP may use macro and so we will disable some of the
-         macro expansions from standard.h. 
+         macro expansions from standard.h.
       *)
       !Config.std_h;
       *)
-    ] 
+    ]
   in
-  let need_no_changed_variables = 
+  let need_no_changed_variables =
     (* could add some of the flags of flag_parsing_c.ml *)
-    [] 
+    []
   in
-  Common2.cache_computation_robust 
-    file ".ast_raw" 
-    (need_no_changed_files, need_no_changed_variables) ".depend_raw" 
+  Common2.cache_computation_robust
+    file ".ast_raw"
+    (need_no_changed_files, need_no_changed_variables) ".depend_raw"
     (fun () -> parse_print_error_heuristic file)
 
 
@@ -1402,7 +1402,7 @@ let parse_cache file =
 let (cstatement_of_string: string -> Ast_c.statement) = fun s ->
   Common.write_file ("/tmp/__cocci.c") ("void main() { \n" ^ s ^ "\n}");
   let program = parse_c_and_cpp ("/tmp/__cocci.c") +> fst in
-  program +> Common.find_some (fun (e,_) -> 
+  program +> Common.find_some (fun (e,_) ->
     match e with
     | Ast_c.Definition ({Ast_c.f_body = [Ast_c.StmtElem st]},_) -> Some st
     | _ -> None
@@ -1411,9 +1411,9 @@ let (cstatement_of_string: string -> Ast_c.statement) = fun s ->
 let (cexpression_of_string: string -> Ast_c.expression) = fun s ->
   Common.write_file ("/tmp/__cocci.c") ("void main() { \n" ^ s ^ ";\n}");
   let program = parse_c_and_cpp ("/tmp/__cocci.c") +> fst in
-  program +> Common.find_some (fun (e,_) -> 
+  program +> Common.find_some (fun (e,_) ->
     match e with
-    | Ast_c.Definition ({Ast_c.f_body = compound},_) -> 
+    | Ast_c.Definition ({Ast_c.f_body = compound},_) ->
         (match compound with
         | [Ast_c.StmtElem (Ast_c.ExprStatement (Some e),ii)] -> Some e
         | _ -> None

--- a/parsing_c/parse_c.mli
+++ b/parsing_c/parse_c.mli
@@ -1,6 +1,6 @@
 open Common
 
-(* The main function is parse_c_and_cpp. It uses globals in Lexer_Parser and 
+(* The main function is parse_c_and_cpp. It uses globals in Lexer_Parser and
  * Parsing_hacks. Especially Parsing_hacks._defs which often comes
  * from a standard.h macro file. Cf also init_defs below.
  *)
@@ -14,7 +14,7 @@ type program2 = toplevel2 list
 
 (* ---------------------------------------------------------------------- *)
 (* a few globals *)
-val parse_cpp_define_file : 
+val parse_cpp_define_file :
   filename -> (string, Cpp_token_c.define_def) assoc
 
 (* usually correspond to what is inside your macros.h *)
@@ -28,10 +28,10 @@ val init_defs_builtins : filename -> unit
 
 (* ---------------------------------------------------------------------- *)
 (* This is the main function *)
-val parse_print_error_heuristic:  
+val parse_print_error_heuristic:
   filename (*cfile*) -> (program2 * Parsing_stat.parsing_stat)
 (* alias of previous func *)
-val parse_c_and_cpp : 
+val parse_c_and_cpp :
   filename (*cfile*) -> (program2 * Parsing_stat.parsing_stat)
 
 (* use some .ast_raw memoized version, and take care if obsolete *)
@@ -45,14 +45,14 @@ val tokens_of_string: string -> Parser_c.token list
 
 val parse:                        filename -> Ast_c.program
 val parse_print_error:            filename -> Ast_c.program
-val parse_gen: 
+val parse_gen:
     ((Lexing.lexbuf -> Parser_c.token) -> Lexing.lexbuf -> 'a) -> string -> 'a
 
 
 
 (* ---------------------------------------------------------------------- *)
 (* Easy way to build complex Ast elements from simple strings.
- * Can also be useful when called from the ocaml toplevel to test. 
+ * Can also be useful when called from the ocaml toplevel to test.
  *)
 val type_of_string      : string -> Ast_c.fullType
 val statement_of_string : string -> Ast_c.statement

--- a/parsing_c/parser_c.mly
+++ b/parsing_c/parser_c.mly
@@ -1,12 +1,12 @@
 %{
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2002, 2006, 2007, 2008, 2009 Yoann Padioleau
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -28,14 +28,14 @@ let (++) = (@)
 (*****************************************************************************)
 (* Wrappers *)
 (*****************************************************************************)
-let warning s v = 
-  if !Flag_parsing_c.verbose_parsing 
+let warning s v =
+  if !Flag_parsing_c.verbose_parsing
   then Common2.warning ("PARSING: " ^ s) v
   else v
 
 
-let pr2 s = 
-  if !Flag_parsing_c.verbose_parsing 
+let pr2 s =
+  if !Flag_parsing_c.verbose_parsing
   then Common.pr2 s
 
 (*****************************************************************************)
@@ -48,7 +48,7 @@ let pr2 s =
 
 type shortLong      = Short  | Long | LongLong
 
-type decl = { 
+type decl = {
   storageD: storagebis wrap;
   typeD: ((sign option) * (shortLong option) * (typeCbis option)) wrap;
   qualifD: typeQualifierbis wrap;
@@ -56,7 +56,7 @@ type decl = {
   (* note: have a full_info: parse_info list; to remember ordering
    * between storage, qualifier, type ? well this info is already in
    * the Ast_c.info, just have to sort them to get good order *)
-} 
+}
 
 let nullDecl = {
   storageD = NoSto, [];
@@ -66,47 +66,47 @@ let nullDecl = {
 }
 let fake_pi = Parse_info.fake_parse_info
 
-let addStorageD  = function 
+let addStorageD  = function
   | ((x,ii), ({storageD = (NoSto,[])} as v)) -> { v with storageD = (x, [ii]) }
-  | ((x,ii), ({storageD = (y, ii2)} as v)) ->  
+  | ((x,ii), ({storageD = (y, ii2)} as v)) ->
       if x =*= y then warning "duplicate storage classes" v
       else raise (Semantic ("multiple storage classes", fake_pi))
 
-let addInlineD  = function 
+let addInlineD  = function
   | ((true,ii), ({inlineD = (false,[])} as v)) -> { v with inlineD=(true,[ii])}
   | ((true,ii), ({inlineD = (true, ii2)} as v)) -> warning "duplicate inline" v
   | _ -> raise Impossible
 
 
-let addTypeD     = function 
-  | ((Left3 Signed,ii)   ,({typeD = ((Some Signed,  b,c),ii2)} as v)) -> 
+let addTypeD     = function
+  | ((Left3 Signed,ii)   ,({typeD = ((Some Signed,  b,c),ii2)} as v)) ->
       warning "duplicate 'signed'"   v
-  | ((Left3 UnSigned,ii) ,({typeD = ((Some UnSigned,b,c),ii2)} as v)) -> 
+  | ((Left3 UnSigned,ii) ,({typeD = ((Some UnSigned,b,c),ii2)} as v)) ->
       warning "duplicate 'unsigned'" v
-  | ((Left3 _,ii),        ({typeD = ((Some _,b,c),ii2)} as _v)) -> 
+  | ((Left3 _,ii),        ({typeD = ((Some _,b,c),ii2)} as _v)) ->
       raise (Semantic ("both signed and unsigned specified", fake_pi))
-  | ((Left3 x,ii),        ({typeD = ((None,b,c),ii2)} as v))   -> 
+  | ((Left3 x,ii),        ({typeD = ((None,b,c),ii2)} as v))   ->
       {v with typeD = (Some x,b,c),ii @ ii2}
 
-  | ((Middle3 Short,ii),  ({typeD = ((a,Some Short,c),ii2)} as v)) -> 
+  | ((Middle3 Short,ii),  ({typeD = ((a,Some Short,c),ii2)} as v)) ->
       warning "duplicate 'short'" v
 
-      
+
   (* gccext: long long allowed *)
-  | ((Middle3 Long,ii),   ({typeD = ((a,Some Long ,c),ii2)} as v)) -> 
+  | ((Middle3 Long,ii),   ({typeD = ((a,Some Long ,c),ii2)} as v)) ->
       { v with typeD = (a, Some LongLong, c),ii++ii2 }
-  | ((Middle3 Long,ii),   ({typeD = ((a,Some LongLong ,c),ii2)} as v)) -> 
+  | ((Middle3 Long,ii),   ({typeD = ((a,Some LongLong ,c),ii2)} as v)) ->
       warning "triplicate 'long'" v
 
 
-  | ((Middle3 _,ii),      ({typeD = ((a,Some _,c),ii2)} as _v)) -> 
+  | ((Middle3 _,ii),      ({typeD = ((a,Some _,c),ii2)} as _v)) ->
       raise (Semantic ("both long and short specified", fake_pi))
-  | ((Middle3 x,ii),      ({typeD = ((a,None,c),ii2)} as v))  -> 
+  | ((Middle3 x,ii),      ({typeD = ((a,None,c),ii2)} as v))  ->
       {v with typeD = (a, Some x,c),ii++ii2}
 
-  | ((Right3 t,ii),       ({typeD = ((a,b,Some _),ii2)} as _v)) -> 
+  | ((Right3 t,ii),       ({typeD = ((a,b,Some _),ii2)} as _v)) ->
       raise (Semantic ("two or more data types", fake_pi))
-  | ((Right3 t,ii),       ({typeD = ((a,b,None),ii2)} as v))   -> 
+  | ((Right3 t,ii),       ({typeD = ((a,b,None),ii2)} as v))   ->
       {v with typeD = (a,b, Some t),ii++ii2}
 
 
@@ -115,7 +115,7 @@ let addQualif = function
   | ({volatile=true},({volatile=true} as x))-> warning "duplicate 'volatile'" x
   | ({const=true},    v) -> {v with const=true}
   | ({volatile=true}, v) -> {v with volatile=true}
-  | _ -> 
+  | _ ->
       Common2.internal_error "there is no noconst or novolatile keyword"
 
 let addQualifD ((qu,ii), ({qualifD = (v,ii2)} as x)) =
@@ -128,45 +128,45 @@ let addQualifD ((qu,ii), ({qualifD = (v,ii2)} as x)) =
 
 
 (* stdC: type section, basic integer types (and ritchie)
- * To understand the code, just look at the result (right part of the PM) 
+ * To understand the code, just look at the result (right part of the PM)
  * and go back.
  *)
 let (fixDeclSpecForDecl: decl -> (fullType * (storage wrap)))  = function
- {storageD = (st,iist); 
-  qualifD = (qu,iiq); 
-  typeD = (ty,iit); 
+ {storageD = (st,iist);
+  qualifD = (qu,iiq);
+  typeD = (ty,iit);
   inlineD = (inline,iinl);
-  } -> 
+  } ->
   (
    ((qu, iiq),
-   (match ty with 
- | (None,None,None)       -> 
-     (* generate fake_info, otherwise type_annotater can crash in 
+   (match ty with
+ | (None,None,None)       ->
+     (* generate fake_info, otherwise type_annotater can crash in
       * offset.
       *)
      warning "type defaults to 'int'" (defaultInt, [fakeInfo fake_pi])
  | (None, None, Some t)   -> (t, iit)
-	 
- | (Some sign,   None, (None| Some (BaseType (IntType (Si (_,CInt))))))  -> 
+
+ | (Some sign,   None, (None| Some (BaseType (IntType (Si (_,CInt))))))  ->
      BaseType(IntType (Si (sign, CInt))), iit
- | ((None|Some Signed),Some x,(None|Some(BaseType(IntType (Si (_,CInt)))))) -> 
+ | ((None|Some Signed),Some x,(None|Some(BaseType(IntType (Si (_,CInt)))))) ->
      BaseType(IntType (Si (Signed, [Short,CShort; Long, CLong; LongLong, CLongLong] +> List.assoc x))), iit
- | (Some UnSigned, Some x, (None| Some (BaseType (IntType (Si (_,CInt))))))-> 
+ | (Some UnSigned, Some x, (None| Some (BaseType (IntType (Si (_,CInt))))))->
      BaseType(IntType (Si (UnSigned, [Short,CShort; Long, CLong; LongLong, CLongLong] +> List.assoc x))), iit
  | (Some sign,   None, (Some (BaseType (IntType CChar))))   -> BaseType(IntType (Si (sign, CChar2))), iit
  | (None, Some Long,(Some(BaseType(FloatType CDouble))))    -> BaseType (FloatType (CLongDouble)), iit
 
- | (Some _,_, Some _) ->  
+ | (Some _,_, Some _) ->
      (*mine*)
      raise (Semantic ("signed, unsigned valid only for char and int", fake_pi))
- | (_,Some _,(Some(BaseType(FloatType (CFloat|CLongDouble))))) -> 
+ | (_,Some _,(Some(BaseType(FloatType (CFloat|CLongDouble))))) ->
      raise (Semantic ("long or short specified with floatint type", fake_pi))
  | (_,Some Short,(Some(BaseType(FloatType CDouble)))) ->
      raise (Semantic ("the only valid combination is long double", fake_pi))
-       
- | (_, Some _, Some _) -> 
+
+ | (_, Some _, Some _) ->
      (* mine *)
-     raise (Semantic ("long, short valid only for int or float", fake_pi)) 
+     raise (Semantic ("long, short valid only for int or float", fake_pi))
 
      (* if do short uint i, then gcc say parse error, strange ? it is
       * not a parse error, it is just that we dont allow with typedef
@@ -180,34 +180,34 @@ let (fixDeclSpecForDecl: decl -> (fullType * (storage wrap)))  = function
      ,((st, inline),iist++iinl)
   )
 
-let fixDeclSpecForParam = function ({storageD = (st,iist)} as r) -> 
+let fixDeclSpecForParam = function ({storageD = (st,iist)} as r) ->
   let ((qu,ty) as v,_st) = fixDeclSpecForDecl r in
   match st with
   | (Sto Register) -> (v, true), iist
   | NoSto -> (v, false), iist
-  | _ -> 
-      raise 
-        (Semantic ("storage class specified for parameter of function", 
+  | _ ->
+      raise
+        (Semantic ("storage class specified for parameter of function",
                   fake_pi))
 
-let fixDeclSpecForMacro = function ({storageD = (st,iist)} as r) -> 
+let fixDeclSpecForMacro = function ({storageD = (st,iist)} as r) ->
   let ((qu,ty) as v,_st) = fixDeclSpecForDecl r in
   match st with
   | NoSto -> v
-  | _ -> 
-      raise 
-        (Semantic ("storage class specified for macro type decl", 
+  | _ ->
+      raise
+        (Semantic ("storage class specified for macro type decl",
                   fake_pi))
 
 
 let fixDeclSpecForFuncDef x =
   let (returnType,storage) = fixDeclSpecForDecl x in
   (match fst (unwrap storage) with
-  | StoTypedef -> 
+  | StoTypedef ->
       raise (Semantic ("function definition declared 'typedef'", fake_pi))
   | _ -> (returnType, storage)
   )
-  
+
 
 (* parameter: (this is the context where we give parameter only when
  * in func DEFINITION not in funct DECLARATION) We must have a name.
@@ -220,69 +220,69 @@ let fixDeclSpecForFuncDef x =
  *)
 let (fixOldCDecl: fullType -> fullType) = fun ty ->
   match snd ty with
-  | ((FunctionType (fullt, (params, (b, iib)))),iifunc) -> 
+  | ((FunctionType (fullt, (params, (b, iib)))),iifunc) ->
 
       (* stdC: If the prototype declaration declares a parameter for a
        * function that you are defining (it is part of a function
        * definition), then you must write a name within the declarator.
        * Otherwise, you can omit the name. *)
       (match params with
-      | [{p_namei = None; p_type = ((_qua, (BaseType Void,_)))},_] ->  
+      | [{p_namei = None; p_type = ((_qua, (BaseType Void,_)))},_] ->
           ty
-      | params -> 
+      | params ->
           (params +> List.iter (fun (param,_) ->
             match param with
-            | {p_namei = None} -> 
+            | {p_namei = None} ->
               (* if majuscule, then certainly macro-parameter *)
-              pr2 ("SEMANTIC:parameter name omitted, but I continue"); 
+              pr2 ("SEMANTIC:parameter name omitted, but I continue");
 	    | _ -> ()
           ));
            ty)
-      
+
         (* todo? can we declare prototype in the decl or structdef,
            ... => length <> but good kan meme *)
-  | _ -> 
+  | _ ->
       (* gcc say parse error but dont see why *)
-      raise (Semantic ("seems this is not a function", fake_pi)) 
+      raise (Semantic ("seems this is not a function", fake_pi))
 
 
-let fixFunc (typ, compound, old_style_opt) = 
+let fixFunc (typ, compound, old_style_opt) =
   let (cp,iicp) = compound in
 
   match typ with
-  | (name, 
-    (nQ, (FunctionType (fullt, (params,bool)),iifunc)), 
+  | (name,
+    (nQ, (FunctionType (fullt, (params,bool)),iifunc)),
     (st,iist),
     attrs)
-    -> 
+    ->
       let iistart = Ast_c.fakeInfo () in
       assert (nQ =*= nullQualif);
       (match params with
       | [{p_namei= None; p_type =((_qua, (BaseType Void,_)))}, _] ->  ()
-      | params -> 
-          params +> List.iter (function 
+      | params ->
+          params +> List.iter (function
           | ({p_namei = Some s}, _) -> ()
 	  | _ -> ()
                 (* failwith "internal errror: fixOldCDecl not good" *)
           )
       );
-      (* bugfix: cf tests_c/function_pointer4.c. 
+      (* bugfix: cf tests_c/function_pointer4.c.
        * Apparemment en C on peut syntaxiquement ecrire ca:
-       * 
+       *
        *   void a(int)(int x);
        * mais apres gcc gueule au niveau semantique avec:
        *   xxx.c:1: error: 'a' declared as function returning a function
-       * Je ne faisais pas cette verif. Sur du code comme 
-       *   void METH(foo)(int x) { ...} , le parser croit (a tort) que foo 
-       * est un typedef, et donc c'est parsé comme l'exemple precedent, 
+       * Je ne faisais pas cette verif. Sur du code comme
+       *   void METH(foo)(int x) { ...} , le parser croit (a tort) que foo
+       * est un typedef, et donc c'est parsé comme l'exemple precedent,
        * ce qui ensuite confuse l'unparser qui n'est pas habitué
        * a avoir dans le returnType un FunctionType et qui donc
        * pr_elem les ii dans le mauvais sens ce qui genere au final
-       * une exception. Hence this fix to at least detect the error 
+       * une exception. Hence this fix to at least detect the error
        * at parsing time (not unparsing time).
        *)
-      (match Ast_c.unwrap_typeC fullt with 
-      | FunctionType _ -> 
+      (match Ast_c.unwrap_typeC fullt with
+      | FunctionType _ ->
           let s = Ast_c.str_of_name name in
           let iis = Ast_c.info_of_name name in
           pr2 (spf "WEIRD: %s declared as function returning a function." s);
@@ -298,11 +298,11 @@ let fixFunc (typ, compound, old_style_opt) =
        f_body = cp;
        f_attr = attrs;
        f_old_c_style = old_style_opt;
-      }, 
-      (iifunc++iicp++[iistart]++iist) 
-  | _ -> 
-      raise 
-        (Semantic 
+      },
+      (iifunc++iicp++[iistart]++iist)
+  | _ ->
+      raise
+        (Semantic
             ("you are trying to do a function definition but you dont give " ^
              "any parameter", fake_pi))
 
@@ -311,29 +311,29 @@ let fixFunc (typ, compound, old_style_opt) =
 (* parse_typedef_fix2 *)
 (*-------------------------------------------------------------------------- *)
 
-let dt s () = 
-  if !Flag_parsing_c.debug_etdt then pr2 ("<" ^ s); 
+let dt s () =
+  if !Flag_parsing_c.debug_etdt then pr2 ("<" ^ s);
   LP.disable_typedef ()
 
-let et s () = 
-  if !Flag_parsing_c.debug_etdt then pr2 (">" ^ s);  
+let et s () =
+  if !Flag_parsing_c.debug_etdt then pr2 (">" ^ s);
   LP.enable_typedef ()
 
 
 let fix_add_params_ident = function
-  | ((s, (nQ, (FunctionType (fullt, (params, bool)),_)), st, _attrs)) ->  
+  | ((s, (nQ, (FunctionType (fullt, (params, bool)),_)), st, _attrs)) ->
 
       (match params with
       | [{p_namei=None; p_type=((_qua, (BaseType Void,_)))}, _] ->  ()
-      | params -> 
-          params +> List.iter (function 
-          | ({p_namei= Some name}, _) -> 
+      | params ->
+          params +> List.iter (function
+          | ({p_namei= Some name}, _) ->
               LP.add_ident (Ast_c.str_of_name s)
-	  | _ -> 
+	  | _ ->
               ()
                 (* failwith "internal errror: fixOldCDecl not good" *)
           )
-      ) 
+      )
   | _ -> ()
 
 
@@ -345,7 +345,7 @@ let fix_add_params_ident = function
 let mk_e e ii = ((e, Ast_c.noType()), ii)
 
 let mk_string_wrap (s,info) = (s, [info])
-    
+
 %}
 
 /*(*****************************************************************************)*/
@@ -353,7 +353,7 @@ let mk_string_wrap (s,info) = (s, [info])
 /*(*************************************************************************)*/
 
 /*
-(* 
+(*
  * Some tokens are not even used in this file because they are filtered
  * in some intermediate phase. But they still must be declared because
  * ocamllex may generate them, or some intermediate phase may also
@@ -375,42 +375,42 @@ let mk_string_wrap (s,info) = (s, [info])
 %token <(string * Ast_c.isWchar) * Ast_c.info>   TChar
 %token <(string * Ast_c.isWchar) * Ast_c.info>   TString
 
-%token <string * Ast_c.info> TIdent 
+%token <string * Ast_c.info> TIdent
 /*(* appears mostly after some fix_xxx in parsing_hack *)*/
 %token <string * Ast_c.info> TypedefIdent
 
 
 /*
-(* Some tokens like TOPar and TCPar are used as synchronisation stuff, 
+(* Some tokens like TOPar and TCPar are used as synchronisation stuff,
  * in parsing_hack.ml. So if define special tokens like TOParDefine and
  * TCParEOL, then take care to also modify in Token_helpers.
  *)
 */
-  
-%token <Ast_c.info> TOPar TCPar TOBrace TCBrace TOCro TCCro 
-%token <Ast_c.info> TDot TComma TPtrOp 
+
+%token <Ast_c.info> TOPar TCPar TOBrace TCBrace TOCro TCCro
+%token <Ast_c.info> TDot TComma TPtrOp
 %token <Ast_c.info> TInc TDec
-%token <Ast_c.assignOp * Ast_c.info> TAssign 
+%token <Ast_c.assignOp * Ast_c.info> TAssign
 %token <Ast_c.info> TEq
 %token <Ast_c.info> TWhy  TTilde TBang
 %token <Ast_c.info> TEllipsis
 %token <Ast_c.info> TDotDot
 
 %token <Ast_c.info> TPtVirg
-%token <Ast_c.info> 
+%token <Ast_c.info>
        TOrLog TAndLog TOr TXor TAnd  TEqEq TNotEq TInf TSup TInfEq TSupEq
-       TShl TShr 
-       TPlus TMinus TMul TDiv TMod 
+       TShl TShr
+       TPlus TMinus TMul TDiv TMod
 
 %token <Ast_c.info>
        Tchar Tshort Tint Tdouble Tfloat Tlong Tunsigned Tsigned Tvoid
-       Tauto Tregister Textern Tstatic 
-       Ttypedef 
+       Tauto Tregister Textern Tstatic
+       Ttypedef
        Tconst Tvolatile
-       Tstruct Tunion Tenum 
+       Tstruct Tunion Tenum
        Tbreak Telse Tswitch Tcase Tcontinue Tfor Tdo Tif  Twhile Treturn
        Tgoto Tdefault
-       Tsizeof  
+       Tsizeof
 
 /*(* C99 *)*/
 %token <Ast_c.info>
@@ -438,12 +438,12 @@ let mk_string_wrap (s,info) = (s, [info])
 %token <(string * Ast_c.info)> TDefParamVariadic
 
 /*(* disappear after fix_tokens_define *)*/
-%token <Ast_c.info> TCppEscapedNewline 
+%token <Ast_c.info> TCppEscapedNewline
 
 %token <Ast_c.info> TCppConcatOp
 
 /*(* appear    after fix_tokens_define *)*/
-%token <Ast_c.info> TOParDefine        
+%token <Ast_c.info> TOParDefine
 %token <Ast_c.info> TOBraceDefineInit
 
 %token <(string * Ast_c.info)> TIdentDefine /*(* same *)*/
@@ -468,9 +468,9 @@ let mk_string_wrap (s,info) = (s, [info])
 /*(*---------------*)*/
 
 /*(* coupling: Token_helpers.is_cpp_instruction *)*/
-%token <((int * int) option ref * Ast_c.info)> 
+%token <((int * int) option ref * Ast_c.info)>
   TIfdef TIfdefelse TIfdefelif TEndif
-%token <(bool * (int * int) option ref * Ast_c.info)> 
+%token <(bool * (int * int) option ref * Ast_c.info)>
   TIfdefBool TIfdefMisc TIfdefVersion
 
 /*(*---------------*)*/
@@ -492,13 +492,13 @@ let mk_string_wrap (s,info) = (s, [info])
 %token <(string * Ast_c.info)>            TMacroStmt
 %token <(string * Ast_c.info)> TMacroIdentBuilder
 /*(* no need value for the moment *)*/
-%token <(string * Ast_c.info)>            TMacroString 
+%token <(string * Ast_c.info)>            TMacroString
 %token <(string * Ast_c.info)> TMacroDecl
-%token <Ast_c.info>            TMacroDeclConst 
+%token <Ast_c.info>            TMacroDeclConst
 
 %token <(string * Ast_c.info)> TMacroIterator
-/*(* 
-%token <(string * Ast_c.info)> TMacroTop 
+/*(*
+%token <(string * Ast_c.info)> TMacroTop
 %token <(string * Ast_c.info)> TMacroStructDecl
 *)*/
 
@@ -515,7 +515,7 @@ let mk_string_wrap (s,info) = (s, [info])
 
 
 /*(* appear after parsing_hack *)*/
-%token <Ast_c.info> TCParEOL   
+%token <Ast_c.info> TCParEOL
 
 %token <Ast_c.info> TAction
 
@@ -539,12 +539,12 @@ let mk_string_wrap (s,info) = (s, [info])
 %left TAndLog
 %left TOr
 %left TXor
-%left TAnd 
+%left TAnd
 %left TEqEq TNotEq
-%left TInf TSup TInfEq TSupEq 
+%left TInf TSup TInfEq TSupEq
 %left TShl TShr
 %left TPlus TMinus
-%left TMul TDiv TMod 
+%left TMul TDiv TMod
 
 /*(*************************************************************************)*/
 /*(* Rules type declaration *)*/
@@ -563,12 +563,12 @@ let mk_string_wrap (s,info) = (s, [info])
 /*
 (* TOC:
  * toplevel (obsolete)
- * 
+ *
  * ident
  * expression
  * statement
- * types with 
- *   - left part (type_spec, qualif), 
+ * types with
+ *   - left part (type_spec, qualif),
  *   - right part (declarator, abstract declarator)
  *   - aux part (parameters)
  * declaration, storage, initializers
@@ -576,7 +576,7 @@ let mk_string_wrap (s,info) = (s, [info])
  * enum
  * cpp directives
  * celem (=~ main)
- * 
+ *
  * generic workarounds (obrace, cbrace for context setting)
  * xxx_list, xxx_opt
  *)
@@ -590,8 +590,8 @@ let mk_string_wrap (s,info) = (s, [info])
 
 main:  translation_unit EOF     { $1 }
 
-translation_unit: 
- | external_declaration                  
+translation_unit:
+ | external_declaration
      { !LP._lexer_hint.context_stack <- [LP.InTopLevel];   [$1] }
  | translation_unit external_declaration
      { !LP._lexer_hint.context_stack <- [LP.InTopLevel]; $1 ++ [$2] }
@@ -602,11 +602,11 @@ translation_unit:
 /*(* ident *)*/
 /*(*************************************************************************)*/
 
-/*(* Why this ? Why not s/ident/TIdent ? cos there is multiple namespaces in C, 
+/*(* Why this ? Why not s/ident/TIdent ? cos there is multiple namespaces in C,
    * so a label can have the same name that a typedef, same for field and tags
    * hence sometimes the use of ident  instead of TIdent.
    *)*/
-ident: 
+ident:
  | TIdent       { $1 }
  | TypedefIdent { $1 }
 
@@ -615,70 +615,70 @@ identifier:
  | TIdent       { $1 }
 
 /*
-(* cppext: string concatenation of idents 
+(* cppext: string concatenation of idents
  * also cppext: gccext: ##args for variadic macro
  *)
 */
 identifier_cpp:
- | TIdent       
+ | TIdent
      { RegularName (mk_string_wrap $1) }
  | ident_extra_cpp { $1 }
 
 ident_cpp:
  | TIdent
      { RegularName (mk_string_wrap $1) }
- | TypedefIdent       
+ | TypedefIdent
      { RegularName (mk_string_wrap $1) }
  | ident_extra_cpp { $1 }
 
 ident_extra_cpp:
- | TIdent TCppConcatOp identifier_cpp_list 
-     {  
+ | TIdent TCppConcatOp identifier_cpp_list
+     {
        CppConcatenatedName (
          match $3 with
          | [] -> raise Impossible
-         | (x,concatnull)::xs -> 
+         | (x,concatnull)::xs ->
              assert(null concatnull);
              (mk_string_wrap $1, [])::(x,[$2])::xs
        )
    }
- | TCppConcatOp TIdent 
+ | TCppConcatOp TIdent
      { CppVariadicName (fst $2, [$1; snd $2]) }
  | TMacroIdentBuilder TOPar param_define_list TCPar
-     { CppIdentBuilder ((fst $1, [snd $1;$2;$4]), $3) } 
+     { CppIdentBuilder ((fst $1, [snd $1;$2;$4]), $3) }
 
 identifier_cpp_list:
- | TIdent { [mk_string_wrap $1, []] } 
+ | TIdent { [mk_string_wrap $1, []] }
  | identifier_cpp_list TCppConcatOp TIdent { $1 ++ [mk_string_wrap $3, [$2]] }
 
 /*(*************************************************************************)*/
 /*(* expr *)*/
 /*(*************************************************************************)*/
 
-expr: 
+expr:
  | assign_expr             { $1 }
  | expr TComma assign_expr { mk_e (Sequence ($1,$3)) [$2] }
 
-/*(* bugfix: in C grammar they put unary_expr, but in fact it must be 
+/*(* bugfix: in C grammar they put unary_expr, but in fact it must be
    * cast_expr, otherwise (int * ) xxx = &yy; is not allowed
    *)*/
-assign_expr: 
+assign_expr:
  | cond_expr                     { $1 }
  | cast_expr TAssign assign_expr { mk_e(Assignment ($1,fst $2,$3)) [snd $2]}
  | cast_expr TEq     assign_expr { mk_e(Assignment ($1,SimpleAssign,$3)) [$2]}
 
-/*(* gccext: allow optional then part hence gcc_opt_expr 
+/*(* gccext: allow optional then part hence gcc_opt_expr
    * bugfix: in C grammar they put TDotDot cond_expr, but in fact it must be
    * assign_expr, otherwise   pnp ? x : x = 0x388  is not allowed
    *)*/
-cond_expr: 
- | arith_expr                                     
+cond_expr:
+ | arith_expr
      { $1 }
- | arith_expr TWhy gcc_opt_expr TDotDot assign_expr 
-     { mk_e (CondExpr ($1,$3,$5)) [$2;$4] } 
+ | arith_expr TWhy gcc_opt_expr TDotDot assign_expr
+     { mk_e (CondExpr ($1,$3,$5)) [$2;$4] }
 
 
-arith_expr: 
+arith_expr:
  | cast_expr                     { $1 }
  | arith_expr TMul    arith_expr { mk_e(Binary ($1, Arith Mul,      $3)) [$2] }
  | arith_expr TDiv    arith_expr { mk_e(Binary ($1, Arith Div,      $3)) [$2] }
@@ -699,11 +699,11 @@ arith_expr:
  | arith_expr TAndLog arith_expr { mk_e(Binary ($1, Logical AndLog, $3)) [$2] }
  | arith_expr TOrLog  arith_expr { mk_e(Binary ($1, Logical OrLog,  $3)) [$2] }
 
-cast_expr: 
+cast_expr:
  | unary_expr                        { $1 }
  | topar2 type_name tcpar2 cast_expr { mk_e(Cast ($2, $4)) [$1;$3] }
 
-unary_expr: 
+unary_expr:
  | postfix_expr                    { $1 }
  | TInc unary_expr                 { mk_e(Infix ($2, Inc))    [$1] }
  | TDec unary_expr                 { mk_e(Infix ($2, Dec))    [$1] }
@@ -711,7 +711,7 @@ unary_expr:
  | Tsizeof unary_expr              { mk_e(SizeOfExpr ($2))    [$1] }
  | Tsizeof topar2 type_name tcpar2 { mk_e(SizeOfType ($3))    [$1;$2;$4] }
 
-unary_op: 
+unary_op:
  | TAnd   { GetRef,     $1 }
  | TMul   { DeRef,      $1 }
  | TPlus  { UnPlus,     $1 }
@@ -725,11 +725,11 @@ unary_op:
 
 
 
-postfix_expr: 
+postfix_expr:
  | primary_expr               { $1 }
- | postfix_expr TOCro expr TCCro                
+ | postfix_expr TOCro expr TCCro
      { mk_e(ArrayAccess ($1, $3)) [$2;$4] }
- | postfix_expr TOPar argument_list_ne TCPar  
+ | postfix_expr TOPar argument_list_ne TCPar
      { mk_e(FunCall ($1, $3)) [$2;$4] }
  | postfix_expr TOPar  TCPar  { mk_e(FunCall ($1, [])) [$2;$3] }
  | postfix_expr TDot   ident_cpp { mk_e(RecordAccess   ($1,$3)) [$2] }
@@ -773,22 +773,22 @@ argument_ne:
  | action_higherordermacro_ne { Right (ArgAction $1) }
 
 
-argument: 
+argument:
  | assign_expr { Left $1 }
  | parameter_decl { Right (ArgType $1)  }
  /*(* had conflicts before, but julia fixed them *)*/
  | action_higherordermacro { Right (ArgAction $1) }
 
-action_higherordermacro_ne: 
- | taction_list_ne 
+action_higherordermacro_ne:
+ | taction_list_ne
      { if null $1
        then ActMisc [Ast_c.fakeInfo()]
        else ActMisc $1
      }
 
 
-action_higherordermacro: 
- | taction_list 
+action_higherordermacro:
+ | taction_list
      { if null $1
        then ActMisc [Ast_c.fakeInfo()]
        else ActMisc $1
@@ -804,7 +804,7 @@ const_expr: cond_expr { $1  }
 
 
 topar2: TOPar { et "topar2" (); $1  }
-tcpar2: TCPar { et "tcpar2" (); $1 (*TODO? et ? sure ? c pas dt plutot ? *) } 
+tcpar2: TCPar { et "tcpar2" (); $1 (*TODO? et ? sure ? c pas dt plutot ? *) }
 
 
 
@@ -812,7 +812,7 @@ tcpar2: TCPar { et "tcpar2" (); $1 (*TODO? et ? sure ? c pas dt plutot ? *) }
 /*(* statement *)*/
 /*(*************************************************************************)*/
 
-statement: 
+statement:
  | labeled         { Labeled      (fst $1), snd $1 }
  | compound        { Compound     (fst $1), snd $1 }
  | expr_statement  { ExprStatement(fst $1), snd $1 }
@@ -830,27 +830,27 @@ statement:
 
 
 
-/*(* note that case 1: case 2: i++;    would be correctly parsed, but with 
-   * a Case  (1, (Case (2, i++)))  :(  
+/*(* note that case 1: case 2: i++;    would be correctly parsed, but with
+   * a Case  (1, (Case (2, i++)))  :(
    *)*/
-labeled: 
+labeled:
  | ident_cpp        TDotDot statement   { Label ($1, $3),  [$2] }
  | Tcase const_expr TDotDot statement   { Case ($2, $4),       [$1; $3] }
- | Tcase const_expr TEllipsis const_expr TDotDot statement 
+ | Tcase const_expr TEllipsis const_expr TDotDot statement
      { CaseRange ($2, $4, $6), [$1;$3;$5] } /*(* gccext: allow range *)*/
- | Tdefault         TDotDot statement   { Default $3,             [$1; $2] } 
+ | Tdefault         TDotDot statement   { Default $3,             [$1; $2] }
 
-end_labeled: 
+end_labeled:
  /*(* gccext:  allow toto: }
     * was generating each 30 shift/Reduce conflicts,
     * mais ca va, ca fait ce qu'il faut.
-    * update: julia fixed the problem by introducing end_labeled 
+    * update: julia fixed the problem by introducing end_labeled
     * and modifying below stat_or_decl_list
     *)*/
- | ident_cpp            TDotDot 
+ | ident_cpp            TDotDot
      { Label ($1, (ExprStatement None, [])), [$2] }
- | Tcase const_expr TDotDot { Case ($2, (ExprStatement None, [])), [$1;$3] }   
- | Tdefault         TDotDot { Default (ExprStatement None, []),    [$1; $2] }  
+ | Tcase const_expr TDotDot { Case ($2, (ExprStatement None, [])), [$1;$3] }
+ | Tdefault         TDotDot { Default (ExprStatement None, []),    [$1; $2] }
 
 
 
@@ -867,19 +867,19 @@ compound: tobrace compound2 tcbrace { $2, [$1; $3]  }
  * Moreover it helps to not make such a difference between decl and
  * statement for further coccinelle phases to factorize code.
 *)*/
-compound2:  
+compound2:
  |                   { ([]) }
  | stat_or_decl_list { $1 }
 
 
-stat_or_decl_list: 
- | stat_or_decl                   { [$1] }                          
+stat_or_decl_list:
+ | stat_or_decl                   { [$1] }
  /*(* gccext: to avoid conflicts, cf end_labeled above *)*/
  | end_labeled  { [StmtElem (Labeled      (fst $1), snd $1)] }
  /*(* old: conflicts | stat_or_decl_list stat_or_decl { $1 ++ [$2] } *)*/
  | stat_or_decl stat_or_decl_list { $1 :: $2 }
 
-stat_or_decl: 
+stat_or_decl:
  | decl      { StmtElem (Decl ($1 Ast_c.LocalDecl), []) }
  | statement { StmtElem $1 }
 
@@ -887,31 +887,31 @@ stat_or_decl:
  | function_definition { StmtElem (NestedFunc $1, []) }
 
  /* (* cppext: *)*/
- | cpp_directive 
+ | cpp_directive
      { CppDirectiveStmt $1 }
- | cpp_ifdef_directive/*(* stat_or_decl_list ...*)*/  
+ | cpp_ifdef_directive/*(* stat_or_decl_list ...*)*/
      { IfdefStmt $1 }
 
 
 
 
 
-expr_statement: 
+expr_statement:
  | TPtVirg      { None,    [$1] }
  | expr TPtVirg { Some $1, [$2] }
 
-selection: 
+selection:
  | Tif TOPar expr TCPar statement              %prec SHIFTHERE
      { If ($3, $5, (ExprStatement None, [])),   [$1;$2;$4] }
- | Tif TOPar expr TCPar statement Telse statement 
+ | Tif TOPar expr TCPar statement Telse statement
      { If ($3, $5, $7),  [$1;$2;$4;$6] }
- | Tswitch TOPar expr TCPar statement             
+ | Tswitch TOPar expr TCPar statement
      { Switch ($3,$5),   [$1;$2;$4]  }
 
-iteration: 
- | Twhile TOPar expr TCPar statement                             
+iteration:
+ | Twhile TOPar expr TCPar statement
      { While ($3,$5),                [$1;$2;$4] }
- | Tdo statement Twhile TOPar expr TCPar TPtVirg                 
+ | Tdo statement Twhile TOPar expr TCPar TPtVirg
      { DoWhile ($2,$5),              [$1;$3;$4;$6;$7] }
  | Tfor TOPar expr_statement expr_statement TCPar statement
      { For ($3,$4,(None, []),$6),    [$1;$2;$5]}
@@ -919,7 +919,7 @@ iteration:
      { For ($3,$4,(Some $5, []),$7), [$1;$2;$6] }
  /*(* c++ext: for(int i = 0; i < n; i++)*)*/
  | Tfor TOPar decl expr_statement expr_opt TCPar statement
-     { 
+     {
        (* pr2 "DECL in for"; *)
        MacroIteration ("toto", [], $7),[$1;$2;$6] (* TODOfake ast, TODO need decl2 ? *)
      }
@@ -930,11 +930,11 @@ iteration:
      { MacroIteration (fst $1, [], $4), [snd $1;$2;$3] }
 
 /*(* the ';' in the caller grammar rule will be appended to the infos *)*/
-jump: 
- | Tgoto ident_cpp  { Goto ($2),  [$1] } 
+jump:
+ | Tgoto ident_cpp  { Goto ($2),  [$1] }
  | Tcontinue    { Continue,       [$1] }
  | Tbreak       { Break,          [$1] }
- | Treturn      { Return,         [$1] } 
+ | Treturn      { Return,         [$1] }
  | Treturn expr { ReturnExpr $2,  [$1] }
  | Tgoto TMul expr { GotoComputed $3, [$1;$2] }
 
@@ -949,16 +949,16 @@ string_elem:
  | TMacroString { [snd $1] }
 
 
-asmbody: 
+asmbody:
  | string_list colon_asm_list  { $1, $2 }
  | string_list { $1, [] } /*(* in old kernel *)*/
 
 
 colon_asm: TDotDot colon_option_list { Colon $2, [$1]   }
 
-colon_option: 
+colon_option:
  | TString                      { ColonMisc, [snd $1] }
- | TString TOPar asm_expr TCPar { ColonExpr $3, [snd $1; $2;$4] } 
+ | TString TOPar asm_expr TCPar { ColonExpr $3, [snd $1; $2;$4] }
  /*(* cppext: certainly a macro *)*/
  | TOCro identifier TCCro TString TOPar asm_expr TCPar
      { ColonExpr $6, [$1;snd $2;$3;snd $4; $5; $7 ] }
@@ -970,12 +970,12 @@ asm_expr: assign_expr { $1 }
 /*(*************************************************************************)*/
 /*(* types *)*/
 /*(*************************************************************************)*/
-       
+
 
 /*(*-----------------------------------------------------------------------*)*/
 /*(* Type spec, left part of a type *)*/
 /*(*-----------------------------------------------------------------------*)*/
-type_spec2: 
+type_spec2:
  | Tvoid                { Right3 (BaseType Void),            [$1] }
  | Tchar                { Right3 (BaseType (IntType CChar)), [$1]}
  | Tint                 { Right3 (BaseType (IntType (Si (Signed,CInt)))), [$1]}
@@ -989,19 +989,19 @@ type_spec2:
  | enum_spec            { Right3 (fst $1), snd $1 }
 
  /*
- (* parse_typedef_fix1: cant put: TIdent {} cos it make the grammar 
-  * ambiguous, generates lots of conflicts => we must 
+ (* parse_typedef_fix1: cant put: TIdent {} cos it make the grammar
+  * ambiguous, generates lots of conflicts => we must
   * use some tricks: we make the lexer and parser cooperate, cf lexerParser.ml.
-  * 
-  * parse_typedef_fix2: this is not enough, and you must use 
+  *
+  * parse_typedef_fix2: this is not enough, and you must use
   * parse_typedef_fix2 to fully manage typedef problems in grammar.
-  * 
+  *
   * parse_typedef_fix3:
-  * 
+  *
   * parse_typedef_fix4: try also to do now some consistency checking in
   * Parse_c
-  *)*/                            
- | TypedefIdent   
+  *)*/
+ | TypedefIdent
      { let name = RegularName (mk_string_wrap $1) in
        Right3 (TypeName (name, Ast_c.noTypedefDef())),[] }
 
@@ -1018,7 +1018,7 @@ type_spec: type_spec2    { dt "type" (); $1   }
 /*(* Qualifiers *)*/
 /*(*-----------------------------------------------------------------------*)*/
 
-type_qualif: 
+type_qualif:
  | Tconst    { {const=true  ; volatile=false}, $1 }
  | Tvolatile { {const=false ; volatile=true},  $1 }
  /*(* C99 *)*/
@@ -1048,37 +1048,37 @@ type_qualif_attr:
 /*(*-----------------------------------------------------------------------*)*/
 
 /*
-(* declarator return a couple: 
- *  (name, partial type (a function to be applied to return type)) 
+(* declarator return a couple:
+ *  (name, partial type (a function to be applied to return type))
  *
  * when int* f(int) we must return Func(Pointer int,int) and not
- * Pointer (Func(int,int) 
+ * Pointer (Func(int,int)
  *)*/
 
-declarator: 
+declarator:
  | pointer direct_d { (fst $2, fun x -> x +> $1 +> (snd $2)  ) }
  | direct_d         { $1  }
 
 /*(* so must do  int * const p; if the pointer is constant, not the pointee *)*/
-pointer: 
+pointer:
  | TMul                          { fun x ->(nQ,         (Pointer x,     [$1]))}
  | TMul type_qualif_list         { fun x ->($2.qualifD, (Pointer x,     [$1]))}
  | TMul pointer                  { fun x ->(nQ,         (Pointer ($2 x),[$1]))}
  | TMul type_qualif_list pointer { fun x ->($2.qualifD, (Pointer ($3 x),[$1]))}
 
 
-direct_d: 
+direct_d:
  | identifier_cpp
      { ($1, fun x -> x) }
- | TOPar declarator TCPar      /*(* forunparser: old: $2 *)*/ 
+ | TOPar declarator TCPar      /*(* forunparser: old: $2 *)*/
      { (fst $2, fun x -> (nQ, (ParenType ((snd $2) x), [$1;$3]))) }
- | direct_d tocro            tccro         
+ | direct_d tocro            tccro
      { (fst $1,fun x->(snd $1) (nQ,(Array (None,x),         [$2;$3]))) }
  | direct_d tocro const_expr tccro
      { (fst $1,fun x->(snd $1) (nQ,(Array (Some $3,x),      [$2;$4])))}
  | direct_d topar            tcpar
      { (fst $1,
-       fun x->(snd $1) 
+       fun x->(snd $1)
          (nQ,(FunctionType (x,(([],(false, [])))),[$2;$3])))
      }
  | direct_d topar parameter_type_list tcpar
@@ -1093,33 +1093,33 @@ tocro: TOCro { et "tocro" ();$1 }
 tccro: TCCro { dt "tccro" ();$1 }
 
 /*(*-----------------------------------------------------------------------*)*/
-abstract_declarator: 
+abstract_declarator:
  | pointer                            { $1 }
  |         direct_abstract_declarator { $1 }
  | pointer direct_abstract_declarator { fun x -> x +> $2 +> $1 }
 
-direct_abstract_declarator: 
+direct_abstract_declarator:
  | TOPar abstract_declarator TCPar /*(* forunparser: old: $2 *)*/
      { (fun x -> (nQ, (ParenType ($2 x), [$1;$3]))) }
 
- | TOCro            TCCro                            
+ | TOCro            TCCro
      { fun x ->   (nQ, (Array (None, x),      [$1;$2]))}
- | TOCro const_expr TCCro                            
+ | TOCro const_expr TCCro
      { fun x ->   (nQ, (Array (Some $2, x),   [$1;$3]))}
- | direct_abstract_declarator TOCro            TCCro 
+ | direct_abstract_declarator TOCro            TCCro
      { fun x ->$1 (nQ, (Array (None, x),      [$2;$3])) }
  | direct_abstract_declarator TOCro const_expr TCCro
      { fun x ->$1 (nQ, (Array (Some $3,x),    [$2;$4])) }
- | TOPar TCPar                                       
+ | TOPar TCPar
      { fun x ->   (nQ, (FunctionType (x, ([], (false,  []))),   [$1;$2])) }
  | topar parameter_type_list tcpar
      { fun x ->   (nQ, (FunctionType (x, $2),           [$1;$3]))}
 /*(* subtle: here must also use topar, not TOPar, otherwise if have for
    * instance   (xxx ( * )(xxx)) cast, then the second xxx may still be a Tident
-   * but we want to reduce topar, to set the InParameter so that 
+   * but we want to reduce topar, to set the InParameter so that
    * parsing_hack can get a chance to change the type of xxx into a typedef.
    * That's an example where parsing_hack and the lookahead of ocamlyacc does
-   * not go very well together ... we got the info too late. We got 
+   * not go very well together ... we got the info too late. We got
    * a similar pb with xxx xxx; declaration, cf parsing_hack.ml and the
    * "disable typedef cos special case ..." message.
 *)*/
@@ -1131,12 +1131,12 @@ direct_abstract_declarator:
 /*(*-----------------------------------------------------------------------*)*/
 /*(* Parameters (use decl_spec not type_spec just for 'register') *)*/
 /*(*-----------------------------------------------------------------------*)*/
-parameter_type_list: 
+parameter_type_list:
  | parameter_list                  { ($1, (false, []))}
  | parameter_list TComma TEllipsis { ($1, (true,  [$2;$3])) }
 
 
-parameter_decl2: 
+parameter_decl2:
  | decl_spec declaratorp
      { let ((returnType,hasreg),iihasreg) = fixDeclSpecForParam $1 in
        let (name, ftyp) = $2 in
@@ -1146,11 +1146,11 @@ parameter_decl2:
        }
      }
  | decl_spec abstract_declaratorp
-     { let ((returnType,hasreg), iihasreg) = fixDeclSpecForParam $1 in 
+     { let ((returnType,hasreg), iihasreg) = fixDeclSpecForParam $1 in
        { p_namei = None;
          p_type = $2 returnType;
          p_register = hasreg, iihasreg;
-       } 
+       }
      }
  | decl_spec
      { let ((returnType,hasreg), iihasreg) = fixDeclSpecForParam $1 in
@@ -1168,7 +1168,7 @@ parameter_decl2:
 parameter_decl: parameter_decl2 { et "param" ();  $1 }
  | attributes parameter_decl2 { et "param" (); $2 }
 
-declaratorp: 
+declaratorp:
  | declarator  { LP.add_ident (str_of_name (fst $1)); $1 }
  /*(* gccext: *)*/
  | attributes declarator   { LP.add_ident (str_of_name (fst $2)); $2 }
@@ -1185,7 +1185,7 @@ abstract_declaratorp:
 
 /*(* for struct and also typename *)*/
 /*(* cant put decl_spec cos no storage is allowed for field struct *)*/
-spec_qualif_list2: 
+spec_qualif_list2:
  | type_spec                    { addTypeD ($1, nullDecl) }
  | type_qualif                  { {nullDecl with qualifD = (fst $1,[snd $1])}}
  | type_spec   spec_qualif_list { addTypeD ($1,$2)   }
@@ -1195,28 +1195,28 @@ spec_qualif_list: spec_qualif_list2            {  dt "spec_qualif" (); $1 }
 
 
 /*(* for pointers in direct_declarator and abstract_declarator *)*/
-type_qualif_list: 
+type_qualif_list:
  | type_qualif_attr                  { {nullDecl with qualifD = (fst $1,[snd $1])} }
  | type_qualif_list type_qualif_attr { addQualifD ($2,$1) }
 
 
 
 
- 	     
+
 
 /*(*-----------------------------------------------------------------------*)*/
 /*(* xxx_type_id *)*/
 /*(*-----------------------------------------------------------------------*)*/
 
-type_name: 
- | spec_qualif_list                     
+type_name:
+ | spec_qualif_list
      { let (returnType, _) = fixDeclSpecForDecl $1 in  returnType }
  | spec_qualif_list abstract_declaratort
      { let (returnType, _) = fixDeclSpecForDecl $1 in $2 returnType }
 
 
 
-abstract_declaratort: 
+abstract_declaratort:
  | abstract_declarator { $1 }
  /*(* gccext: *)*/
  | attributes abstract_declarator { $2 }
@@ -1226,30 +1226,30 @@ abstract_declaratort:
 /*(* declaration and initializers *)*/
 /*(*************************************************************************)*/
 
-decl2: 
+decl2:
  | decl_spec TPtVirg
      { function local ->
-       let (returnType,storage) = fixDeclSpecForDecl $1 in 
+       let (returnType,storage) = fixDeclSpecForDecl $1 in
        let iistart = Ast_c.fakeInfo () in
-       DeclList ([{v_namei = None; v_type = returnType; 
+       DeclList ([{v_namei = None; v_type = returnType;
                    v_storage = unwrap storage; v_local = local;
                    v_attr = Ast_c.noattr;
-                },[]],  
+                },[]],
                 ($2::iistart::snd storage))
-     } 
- | decl_spec init_declarator_list TPtVirg 
+     }
+ | decl_spec init_declarator_list TPtVirg
      { function local ->
        let (returnType,storage) = fixDeclSpecForDecl $1 in
        let iistart = Ast_c.fakeInfo () in
        DeclList (
-         ($2 +> List.map (fun ((((name,f),attrs), ini), iivirg) -> 
+         ($2 +> List.map (fun ((((name,f),attrs), ini), iivirg) ->
            let s = str_of_name name in
-           let iniopt = 
+           let iniopt =
              match ini with
              | None -> None
              | Some (ini, iini) -> Some (iini, ini)
            in
-	   if fst (unwrap storage) =*= StoTypedef 
+	   if fst (unwrap storage) =*= StoTypedef
 	   then LP.add_typedef s;
            {v_namei = Some (name, iniopt);
             v_type = f returnType;
@@ -1257,25 +1257,25 @@ decl2:
             v_local = local;
             v_attr = attrs;
            },
-           iivirg 
+           iivirg
          )
          ),  ($3::iistart::snd storage))
-     } 
+     }
  /*(* cppext: *)*/
 
- | TMacroDecl TOPar argument_list TCPar TPtVirg 
+ | TMacroDecl TOPar argument_list TCPar TPtVirg
      { function _ ->
        MacroDecl ((fst $1, $3), [snd $1;$2;$4;$5;fakeInfo()]) }
- | Tstatic TMacroDecl TOPar argument_list TCPar TPtVirg 
+ | Tstatic TMacroDecl TOPar argument_list TCPar TPtVirg
      { function _ ->
        MacroDecl ((fst $2, $4), [snd $2;$3;$5;$6;fakeInfo();$1]) }
- | Tstatic TMacroDeclConst TMacroDecl TOPar argument_list TCPar TPtVirg 
+ | Tstatic TMacroDeclConst TMacroDecl TOPar argument_list TCPar TPtVirg
      { function _ ->
        MacroDecl ((fst $3, $5), [snd $3;$4;$6;$7;fakeInfo();$1;$2])}
 
 
 /*(*-----------------------------------------------------------------------*)*/
-decl_spec2: 
+decl_spec2:
  | storage_class_spec      { {nullDecl with storageD = (fst $1, [snd $1]) } }
  | type_spec               { addTypeD ($1,nullDecl) }
  | type_qualif             { {nullDecl with qualifD  = (fst $1, [snd $1]) } }
@@ -1286,11 +1286,11 @@ decl_spec2:
  | Tinline            decl_spec2 { addInlineD ((true, $1), $2) }
 
 /*(* can simplify by putting all in _opt ? must have at least one otherwise
-   *  decl_list is ambiguous ? (no cos have ';' between decl) 
+   *  decl_list is ambiguous ? (no cos have ';' between decl)
    *)*/
 
 
-storage_class_spec2: 
+storage_class_spec2:
  | Tstatic      { Sto Static,  $1 }
  | Textern      { Sto Extern,  $1 }
  | Tauto        { Sto Auto,    $1 }
@@ -1314,7 +1314,7 @@ decl_spec: decl_spec2    { dt "declspec" (); $1  }
 /*(*-----------------------------------------------------------------------*)*/
 /*(* declarators (right part of type and variable) *)*/
 /*(*-----------------------------------------------------------------------*)*/
-init_declarator2:  
+init_declarator2:
  | declaratori                  { ($1, None) }
  | declaratori teq initialize   { ($1, Some ($3, $2)) }
 
@@ -1332,7 +1332,7 @@ init_declarator: init_declarator2  { dt "init" (); $1 }
 /*(* gccext: *)*/
 /*(*----------------------------*)*/
 
-declaratori: 
+declaratori:
  | declarator              { LP.add_ident (str_of_name (fst $1)); $1, Ast_c.noattr }
  /*(* gccext: *)*/
  | declarator gcc_asm_decl { LP.add_ident (str_of_name (fst $1)); $1, Ast_c.noattr }
@@ -1342,14 +1342,14 @@ declaratori:
 
 
 
-gcc_asm_decl: 
+gcc_asm_decl:
  | Tasm TOPar asmbody TCPar              {  }
  | Tasm Tvolatile TOPar asmbody TCPar   {  }
 
 
 /*(*-----------------------------------------------------------------------*)*/
-initialize: 
- | assign_expr                                    
+initialize:
+ | assign_expr
      { InitExpr $1,                [] }
  | tobrace_ini initialize_list gcc_comma_opt_struct  tcbrace_ini
      { InitList (List.rev $2),     [$1;$4]++$3 }
@@ -1358,34 +1358,34 @@ initialize:
 
 
 /*
-(* opti: This time we use the weird order of non-terminal which requires in 
+(* opti: This time we use the weird order of non-terminal which requires in
  * the "caller" to do a List.rev cos quite critical. With this weird order it
  * allows yacc to use a constant stack space instead of exploding if we would
  * do a  'initialize2 Tcomma initialize_list'.
  *)
 */
-initialize_list: 
+initialize_list:
  | initialize2                        { [$1,   []] }
  | initialize_list TComma initialize2 { ($3,  [$2])::$1 }
 
 
 /*(* gccext: condexpr and no assign_expr cos can have ambiguity with comma *)*/
-initialize2: 
- | cond_expr 
-     { InitExpr $1,   [] } 
+initialize2:
+ | cond_expr
+     { InitExpr $1,   [] }
  | tobrace_ini initialize_list gcc_comma_opt_struct tcbrace_ini
      { InitList (List.rev $2),   [$1;$4]++$3 }
  | tobrace_ini tcbrace_ini
      { InitList [],  [$1;$2]  }
 
  /*(* gccext: labeled elements, a.k.a designators *)*/
- | designator_list TEq initialize2 
+ | designator_list TEq initialize2
      { InitDesignators ($1, $3), [$2] }
 
  /*(* gccext: old format *)*/
  | ident TDotDot initialize2
      { InitFieldOld (fst $1, $3),     [snd $1; $2] } /*(* in old kernel *)*/
-/* conflict 
+/* conflict
  | TOCro const_expr TCCro initialize2
      { InitIndexOld ($2, $4),    [$1;$3] }
 */
@@ -1393,12 +1393,12 @@ initialize2:
 
 
 /*(* they can be nested, can have a .x[3].y *)*/
-designator: 
- | TDot ident 
-     { DesignatorField (fst $2), [$1;snd $2] } 
- | TOCro const_expr TCCro 
+designator:
+ | TDot ident
+     { DesignatorField (fst $2), [$1;snd $2] }
+ | TOCro const_expr TCCro
      { DesignatorIndex ($2),  [$1;$3] }
- | TOCro const_expr TEllipsis const_expr TCCro 
+ | TOCro const_expr TEllipsis const_expr TCCro
      { DesignatorRange ($2, $4),  [$1;$3;$5] }
 
 
@@ -1406,8 +1406,8 @@ designator:
 /*(* workarounds *)*/
 /*(*----------------------------*)*/
 
-gcc_comma_opt_struct: 
- | TComma {  [$1] } 
+gcc_comma_opt_struct:
+ | TComma {  [$1] }
  | /*(* empty *)*/  {  [Ast_c.fakeInfo() +> Ast_c.rewrap_str ","]  }
 
 
@@ -1421,15 +1421,15 @@ gcc_comma_opt_struct:
 /*(* struct *)*/
 /*(*************************************************************************)*/
 
-s_or_u_spec2: 
+s_or_u_spec2:
  | struct_or_union ident tobrace_struct struct_decl_list_gcc tcbrace_struct
      { StructUnion (fst $1, Some (fst $2), $4),  [snd $1;snd $2;$3;$5]  }
  | struct_or_union       tobrace_struct struct_decl_list_gcc tcbrace_struct
      { StructUnion (fst $1, None, $3), [snd $1;$2;$4] }
- | struct_or_union ident       
+ | struct_or_union ident
      { StructUnionName (fst $1, fst $2), [snd $1;snd $2] }
 
-struct_or_union2: 
+struct_or_union2:
  | Tstruct   { Struct, $1 }
  | Tunion    { Union, $1 }
  /*(* gccext: *)*/
@@ -1438,7 +1438,7 @@ struct_or_union2:
 
 
 
-struct_decl2: 
+struct_decl2:
  | field_declaration { DeclarationField $1 }
  | TPtVirg { EmptyField $1  }
 
@@ -1449,34 +1449,34 @@ struct_decl2:
      { MacroDeclField ((fst $1, $3), [snd $1;$2;$4;$5;fakeInfo()]) }
 
  /*(* cppext: *)*/
- | cpp_directive 
+ | cpp_directive
      { CppDirectiveStruct $1 }
- | cpp_ifdef_directive/*(* struct_decl_list ... *)*/ 
+ | cpp_ifdef_directive/*(* struct_decl_list ... *)*/
      { IfdefStruct $1 }
 
 
 field_declaration:
- | spec_qualif_list struct_declarator_list TPtVirg 
-     { 
+ | spec_qualif_list struct_declarator_list TPtVirg
+     {
        let (returnType,storage) = fixDeclSpecForDecl $1 in
-       if fst (unwrap storage) <> NoSto 
+       if fst (unwrap storage) <> NoSto
        then Common2.internal_error "parsing dont allow this";
-       
-       FieldDeclList ($2 +> (List.map (fun (f, iivirg) ->     
+
+       FieldDeclList ($2 +> (List.map (fun (f, iivirg) ->
          f returnType, iivirg))
                          ,[$3])
          (* dont need to check if typedef or func initialised cos
-          * grammar dont allow typedef nor initialiser in struct 
+          * grammar dont allow typedef nor initialiser in struct
           *)
      }
 
- |  spec_qualif_list TPtVirg 
-     { 
+ |  spec_qualif_list TPtVirg
+     {
        (* gccext: allow empty elements if it is a structdef or enumdef *)
        let (returnType,storage) = fixDeclSpecForDecl $1 in
-       if fst (unwrap storage) <> NoSto 
+       if fst (unwrap storage) <> NoSto
        then Common2.internal_error "parsing dont allow this";
-       
+
        FieldDeclList ([(Simple (None, returnType)) , []], [$2])
      }
 
@@ -1484,19 +1484,19 @@ field_declaration:
 
 
 
-struct_declarator: 
- | declaratorsd                    
+struct_declarator:
+ | declaratorsd
      { (fun x -> Simple   (Some (fst $1), (snd $1) x)) }
- | dotdot const_expr2            
+ | dotdot const_expr2
      { (fun x -> BitField (None, x, $1, $2)) }
- | declaratorsd dotdot const_expr2 
+ | declaratorsd dotdot const_expr2
      { (fun x -> BitField (Some (fst $1), ((snd $1) x), $2, $3)) }
 
 
 /*(*----------------------------*)*/
 /*(* workarounds *)*/
 /*(*----------------------------*)*/
-declaratorsd: 
+declaratorsd:
  | declarator { (*also ? LP.add_ident (fst (fst $1)); *) $1 }
  /*(* gccext: *)*/
  | attributes declarator   { $2 }
@@ -1512,23 +1512,23 @@ struct_decl: struct_decl2  { et "struct" (); $1 }
 dotdot: TDotDot  { et "dotdot" (); $1 }
 const_expr2: const_expr { dt "const_expr2" (); $1 }
 
-struct_decl_list_gcc: 
- | struct_decl_list  { $1 } 
+struct_decl_list_gcc:
+ | struct_decl_list  { $1 }
  | /*(* empty *)*/       { [] } /*(* gccext: allow empty struct *)*/
 
 
 /*(*************************************************************************)*/
 /*(* enum *)*/
 /*(*************************************************************************)*/
-enum_spec: 
+enum_spec:
  | Tenum        tobrace_enum enumerator_list gcc_comma_opt tcbrace_enum
      { Enum (None,    $3),           [$1;$2;$5] ++ $4 }
  | Tenum ident  tobrace_enum enumerator_list gcc_comma_opt tcbrace_enum
      { Enum (Some (fst $2), $4),     [$1; snd $2; $3;$6] ++ $5 }
- | Tenum ident                                                
+ | Tenum ident
      { EnumName (fst $2),       [$1; snd $2] }
 
-enumerator: 
+enumerator:
  | idente                 { $1, None     }
  | idente  TEq const_expr { $1, Some ($2, $3) }
 
@@ -1546,36 +1546,36 @@ idente: ident_cpp { LP.add_ident (str_of_name $1); $1 }
 /*(*************************************************************************)*/
 function_definition: function_def    { fixFunc $1 }
 
-decl_list: 
+decl_list:
  | decl           { [$1 Ast_c.LocalDecl]   }
  | decl_list decl { $1 ++ [$2 Ast_c.LocalDecl] }
 
-function_def: 
+function_def:
  | start_fun compound      { LP.del_scope(); ($1, $2, None) }
- | start_fun decl_list compound      { 
+ | start_fun decl_list compound      {
      (* TODO: undo the typedef added ? *)
-     LP.del_scope(); 
+     LP.del_scope();
      ($1, $3, Some $2)
    }
 
-start_fun: start_fun2                        
-  { LP.new_scope(); 
-    fix_add_params_ident $1; 
+start_fun: start_fun2
+  { LP.new_scope();
+    fix_add_params_ident $1;
     (* toreput? !LP._lexer_hint.toplevel <- false;  *)
-    $1 
+    $1
   }
 
-start_fun2: decl_spec declaratorfd  
+start_fun2: decl_spec declaratorfd
      { let (returnType,storage) = fixDeclSpecForFuncDef $1 in
        let (id, attrs) = $2 in
-       (fst id, fixOldCDecl ((snd id) returnType) , storage, attrs) 
+       (fst id, fixOldCDecl ((snd id) returnType) , storage, attrs)
      }
 
 /*(*----------------------------*)*/
 /*(* workarounds *)*/
 /*(*----------------------------*)*/
 
-declaratorfd: 
+declaratorfd:
  | declarator { et "declaratorfd" (); $1, Ast_c.noattr }
  /*(* gccext: *)*/
  | attributes declarator   { et "declaratorfd" (); $2, $1 }
@@ -1587,21 +1587,21 @@ declaratorfd:
 /*(* cpp directives *)*/
 /*(*************************************************************************)*/
 
-cpp_directive: 
- | TIncludeStart TIncludeFilename 
-     { 
+cpp_directive:
+ | TIncludeStart TIncludeFilename
+     {
        let (i1, in_ifdef) = $1 in
        let (s, i2) = $2 in
 
        (* redo some lexing work :( *)
-       let inc_file = 
+       let inc_file =
          match () with
-         | _ when s =~ "^\"\\(.*\\)\"$" -> 
+         | _ when s =~ "^\"\\(.*\\)\"$" ->
              Local (Common.split "/" (matched1 s))
-         | _ when s =~ "^\\<\\(.*\\)\\>$" -> 
+         | _ when s =~ "^\\<\\(.*\\)\\>$" ->
              NonLocal (Common.split "/" (matched1 s))
-         | _ -> 
-             Weird s 
+         | _ ->
+             Weird s
        in
        Include { i_include = (inc_file, [i1;i2]);
                  i_rel_pos = Ast_c.noRelPos();
@@ -1610,7 +1610,7 @@ cpp_directive:
        }
      }
 
- | TDefine TIdentDefine define_val TDefEOL 
+ | TDefine TIdentDefine define_val TDefEOL
      { Define ((fst $2, [$1; snd $2;$4]), (DefineVar, $3)) }
 
  /*
@@ -1618,9 +1618,9 @@ cpp_directive:
   * A TOParDefine is a TOPar that was just next to the ident.
   *)*/
  | TDefine TIdentDefine TOParDefine param_define_list TCPar define_val TDefEOL
-     { Define 
-         ((fst $2, [$1; snd $2;$7]), 
-           (DefineFunc ($4, [$3;$5]), $6)) 
+     { Define
+         ((fst $2, [$1; snd $2;$7]),
+           (DefineFunc ($4, [$3;$5]), $6))
      }
 
  | TUndef             { Undef (fst $1, [snd $1]) }
@@ -1630,32 +1630,32 @@ cpp_directive:
 
 
 
-/*(* perhaps better to use assign_expr ? but in that case need 
+/*(* perhaps better to use assign_expr ? but in that case need
    * do a assign_expr_of_string in parse_c
    *)*/
-define_val: 
+define_val:
  | expr      { DefineExpr $1 }
  | statement { DefineStmt $1 }
  | decl      { DefineStmt (Decl ($1 Ast_c.NotLocalDecl), []) }
 
-/*(*old: 
+/*(*old:
   * | TypedefIdent { DefineType (nQ,(TypeName(fst $1,noTypedefDef()),[snd $1]))}
-  * get conflicts: 
+  * get conflicts:
   * | spec_qualif_list TMul
   *   { let (returnType, _) = fixDeclSpecForDecl $1 in  DefineType returnType }
   *)
 */
- | decl_spec 
-     { let returnType = fixDeclSpecForMacro $1 in 
+ | decl_spec
+     { let returnType = fixDeclSpecForMacro $1 in
        DefineType returnType
      }
- | decl_spec abstract_declarator 
-     { let returnType = fixDeclSpecForMacro $1 in 
+ | decl_spec abstract_declarator
+     { let returnType = fixDeclSpecForMacro $1 in
        let typ = $2 returnType in
        DefineType typ
      }
 
-/* can be in conflict with decl_spec, maybe change fixDeclSpecForMacro 
+/* can be in conflict with decl_spec, maybe change fixDeclSpecForMacro
  * to also allow storage ?
  | storage_class_spec { DefineTodo }
  | Tinline { DefineTodo }
@@ -1673,14 +1673,14 @@ define_val:
 
  | function_definition { DefineFunction $1 }
 
- | TOBraceDefineInit initialize_list gcc_comma_opt_struct TCBrace comma_opt 
+ | TOBraceDefineInit initialize_list gcc_comma_opt_struct TCBrace comma_opt
     { DefineInit (InitList (List.rev $2), [$1;$4]++$3++$5)  }
 
  /*(* note: had a conflict before when were putting TInt instead of expr *)*/
- | Tdo statement Twhile TOPar expr TCPar 
+ | Tdo statement Twhile TOPar expr TCPar
      {
-       (* TOREPUT 
-       if fst $5 <> "0" 
+       (* TOREPUT
+       if fst $5 <> "0"
        then pr2 "WEIRD: in macro and have not a while(0)";
        *)
        DefineDoWhileZero (($2,$5),   [$1;$3;$4;$6])
@@ -1698,9 +1698,9 @@ define_val:
 
 
 param_define:
- | TIdent               { mk_string_wrap $1 } 
- | TypedefIdent         { mk_string_wrap $1 } 
- | TDefParamVariadic    { mk_string_wrap $1 } 
+ | TIdent               { mk_string_wrap $1 }
+ | TypedefIdent         { mk_string_wrap $1 }
+ | TDefParamVariadic    { mk_string_wrap $1 }
  | TEllipsis            { "...", [$1] }
  /*(* they reuse keywords :(  *)*/
  | Tregister            { "register", [$1] }
@@ -1708,46 +1708,46 @@ param_define:
 
 
 
-cpp_ifdef_directive: 
- | TIfdef     
-     { let (tag,ii) = $1 in 
+cpp_ifdef_directive:
+ | TIfdef
+     { let (tag,ii) = $1 in
        IfdefDirective ((Ifdef, IfdefTag (Common2.some !tag)),  [ii]) }
- | TIfdefelse 
-     { let (tag,ii) = $1 in  
+ | TIfdefelse
+     { let (tag,ii) = $1 in
        IfdefDirective ((IfdefElse, IfdefTag (Common2.some !tag)), [ii]) }
- | TIfdefelif 
-     { let (tag,ii) = $1 in  
+ | TIfdefelif
+     { let (tag,ii) = $1 in
        IfdefDirective ((IfdefElseif, IfdefTag (Common2.some !tag)), [ii]) }
- | TEndif     
-     { let (tag,ii) = $1 in  
+ | TEndif
+     { let (tag,ii) = $1 in
        IfdefDirective ((IfdefEndif, IfdefTag (Common2.some !tag)), [ii]) }
 
- | TIfdefBool    
-     { let (_b, tag,ii) = $1 in  
+ | TIfdefBool
+     { let (_b, tag,ii) = $1 in
        IfdefDirective ((Ifdef, IfdefTag (Common2.some !tag)), [ii]) }
- | TIfdefMisc    
-     { let (_b, tag,ii) = $1 in  
+ | TIfdefMisc
+     { let (_b, tag,ii) = $1 in
        IfdefDirective ((Ifdef, IfdefTag (Common2.some !tag)), [ii]) }
- | TIfdefVersion 
-     { let (_b, tag,ii) = $1 in  
+ | TIfdefVersion
+     { let (_b, tag,ii) = $1 in
        IfdefDirective ((Ifdef, IfdefTag (Common2.some !tag)), [ii]) }
 
 
 /*(* cppext: *)*/
-cpp_other: 
+cpp_other:
  /*(* no conflict ? no need for a TMacroTop ? apparently not as at toplevel
     * the rule are slightly different, they cant be statement and so expr
     * at the top, only decl or function definition.
     *)*/
  | identifier TOPar argument_list TCPar TPtVirg
-     { 
-       Declaration (MacroDecl ((fst $1, $3), [snd $1;$2;$4;$5;fakeInfo()])) 
+     {
+       Declaration (MacroDecl ((fst $1, $3), [snd $1;$2;$4;$5;fakeInfo()]))
        (* old: MacroTop (fst $1, $3,    [snd $1;$2;$4;$5])  *)
      }
 
  /*(* TCParEOL to fix the end-of-stream bug of ocamlyacc *)*/
  | identifier TOPar argument_list TCParEOL
-     { MacroTop (fst $1, $3,    [snd $1;$2;$4;fakeInfo()]) } 
+     { MacroTop (fst $1, $3,    [snd $1;$2;$4;fakeInfo()]) }
 
   /*(* ex: EXPORT_NO_SYMBOLS; *)*/
  | identifier TPtVirg { EmptyDef [snd $1;$2] }
@@ -1758,34 +1758,34 @@ cpp_other:
 /*(* celem *)*/
 /*(*************************************************************************)*/
 
-external_declaration: 
+external_declaration:
  | function_definition               { Definition $1 }
  | decl                              { Declaration ($1 Ast_c.NotLocalDecl) }
 
 
-celem: 
+celem:
  | external_declaration                         { $1 }
 
  /*(* cppext: *)*/
- | cpp_directive                                
+ | cpp_directive
      { CppTop $1 }
- | cpp_other                                    
+ | cpp_other
      { $1 }
  | cpp_ifdef_directive /* (*external_declaration_list ...*)*/
      { IfdefTop $1 }
 
  /*(* can have asm declaration at toplevel *)*/
- | Tasm TOPar asmbody TCPar TPtVirg             { EmptyDef [$1;$2;$4;$5] } 
+ | Tasm TOPar asmbody TCPar TPtVirg             { EmptyDef [$1;$2;$4;$5] }
 
  /*
  (* in ~/kernels/src/linux-2.5.2/drivers/isdn/hisax/isdnl3.c sometimes
-  * the function ends with }; instead of just } 
+  * the function ends with }; instead of just }
   * can also remove this rule and report "parse error" pb to morton
   *)*/
- | TPtVirg    { EmptyDef [$1] } 
+ | TPtVirg    { EmptyDef [$1] }
 
-         
- | EOF        { FinalDef $1 } 
+
+ | EOF        { FinalDef $1 }
 
 
 
@@ -1809,15 +1809,15 @@ tcbrace_struct: TCBrace { LP.pop_context (); $1 }
 
 
 
-topar: TOPar 
-     { LP.new_scope ();et "topar" (); 
+topar: TOPar
+     { LP.new_scope ();et "topar" ();
        LP.push_context LP.InParameter;
-       $1  
+       $1
      }
-tcpar: TCPar 
-     { LP.del_scope ();dt "tcpar" (); 
-       LP.pop_context (); 
-       $1  
+tcpar: TCPar
+     { LP.del_scope ();dt "tcpar" ();
+       LP.pop_context ();
+       $1
      }
 
 
@@ -1829,7 +1829,7 @@ tcpar: TCPar
 
 
 /*(* old:
-compound2: 
+compound2:
  |                            { ([],[]) }
  |  statement_list            { ([], $1) }
  |  decl_list                 { ($1, []) }
@@ -1840,11 +1840,11 @@ statement_list: stat_or_decl_list { $1 }
 
 
 /*(*
-decl_list: 
+decl_list:
  | decl           { [$1]   }
  | decl_list decl { $1 ++ [$2] }
 
-statement_list: 
+statement_list:
  | statement { [$1] }
  | statement_list statement { $1 ++ [$2] }
 *)*/
@@ -1853,24 +1853,24 @@ statement_list:
 
 
 
-string_list: 
+string_list:
  | string_elem { $1 }
- | string_list string_elem { $1 ++ $2 } 
+ | string_list string_elem { $1 ++ $2 }
 
-colon_asm_list: 
+colon_asm_list:
  | colon_asm { [$1] }
  | colon_asm_list colon_asm  { $1 ++ [$2] }
 
-colon_option_list: 
- | colon_option { [$1, []] } 
+colon_option_list:
+ | colon_option { [$1, []] }
  | colon_option_list TComma colon_option { $1 ++ [$3, [$2]] }
 
 
-argument_list_ne: 
+argument_list_ne:
  | argument_ne                           { [$1, []] }
  | argument_list_ne TComma argument { $1 ++ [$3,    [$2]] }
 
-argument_list: 
+argument_list:
  | argument                           { [$1, []] }
  | argument_list TComma argument { $1 ++ [$3,    [$2]] }
 
@@ -1881,36 +1881,36 @@ expression_list:
 *)*/
 
 
-struct_decl_list: 
+struct_decl_list:
  | struct_decl                   { [$1] }
  | struct_decl_list struct_decl  { $1 ++ [$2] }
 
 
-struct_declarator_list: 
+struct_declarator_list:
  | struct_declarator                               { [$1,           []] }
  | struct_declarator_list TComma struct_declarator { $1 ++ [$3,     [$2]] }
 
 
-enumerator_list: 
+enumerator_list:
  | enumerator                        { [$1,          []]   }
  | enumerator_list TComma enumerator { $1 ++ [$3,    [$2]] }
 
 
-init_declarator_list: 
+init_declarator_list:
  | init_declarator                             { [$1,   []] }
  | init_declarator_list TComma init_declarator { $1 ++ [$3,     [$2]] }
 
 
-parameter_list: 
+parameter_list:
  | parameter_decl                       { [$1, []] }
  | parameter_list TComma parameter_decl { $1 ++ [$3,  [$2]] }
 
-taction_list_ne: 
+taction_list_ne:
  | TAction                 { [$1] }
  | TAction taction_list_ne { $1 :: $2 }
 
-taction_list: 
-/*old: was generating conflict, hence now taction_list_ne 
+taction_list:
+/*old: was generating conflict, hence now taction_list_ne
     | (* empty *) { [] }
  | TAction { [$1] }
  | taction_list TAction { $1 ++ [$2] }
@@ -1918,12 +1918,12 @@ taction_list:
  |                      { [] }
  | TAction taction_list { $1 :: $2 }
 
-param_define_list: 
+param_define_list:
  | /*(* empty *)*/ { [] }
  | param_define                           { [$1, []] }
  | param_define_list TComma param_define  { $1 ++ [$3, [$2]] }
 
-designator_list: 
+designator_list:
  | designator { [$1] }
  | designator_list designator { $1 ++ [$2] }
 
@@ -1941,12 +1941,12 @@ attributes: attribute_list { $1 }
 
 
 /*(* gccext:  which allow a trailing ',' in enum, as in perl *)*/
-gcc_comma_opt: 
- | TComma {  [$1] } 
+gcc_comma_opt:
+ | TComma {  [$1] }
  | /*(* empty *)*/  {  []  }
 
-comma_opt: 
- | TComma {  [$1] } 
+comma_opt:
+ | TComma {  [$1] }
  | /*(* empty *)*/  {  []  }
 
 /*(*
@@ -1955,7 +1955,7 @@ gcc_opt_virg:
  |  { }
 *)*/
 
-gcc_opt_expr: 
+gcc_opt_expr:
  | expr        { Some $1 }
  | /*(* empty *)*/ { None  }
 
@@ -1966,7 +1966,7 @@ opt_ptvirg:
 *)*/
 
 
-expr_opt: 
+expr_opt:
  | expr            { Some $1 }
  | /*(* empty *)*/ { None }
 

--- a/parsing_c/parsing_hacks.ml
+++ b/parsing_c/parsing_hacks.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2007, 2008 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,34 +14,34 @@
 open Common
 open Common2
 
-module TH = Token_helpers 
+module TH = Token_helpers
 module TV = Token_views_c
 module LP = Lexer_parser
 
 module Stat = Parsing_stat
 
-open Parser_c 
+open Parser_c
 
-open TV 
+open TV
 
 (*****************************************************************************)
 (* Some debugging functions  *)
 (*****************************************************************************)
 
-let pr2 s = 
-  if !Flag_parsing_c.verbose_parsing 
+let pr2 s =
+  if !Flag_parsing_c.verbose_parsing
   then Common.pr2 s
 
-let pr2_once s = 
-  if !Flag_parsing_c.verbose_parsing 
+let pr2_once s =
+  if !Flag_parsing_c.verbose_parsing
   then Common.pr2_once s
 
-let pr2_cpp s = 
+let pr2_cpp s =
   if !Flag_parsing_c.debug_cpp
   then Common.pr2_once ("CPP-" ^ s)
 
 
-let msg_gen cond is_known printer s = 
+let msg_gen cond is_known printer s =
   if cond
   then
     if not (!Flag_parsing_c.filter_msg)
@@ -49,7 +49,7 @@ let msg_gen cond is_known printer s =
     else
       if not (is_known s)
       then printer s
-        
+
 
 (* In the following, there are some harcoded names of types or macros
  * but they are not used by our heuristics! They are just here to
@@ -60,56 +60,56 @@ let msg_gen cond is_known printer s =
  * there is no more (or not that much) hardcoded linux stuff.
  *)
 
-let is_known_typdef = 
-    (fun s -> 
+let is_known_typdef =
+    (fun s ->
       (match s with
       | "u_char"   | "u_short"  | "u_int"  | "u_long"
-      | "u8" | "u16" | "u32" | "u64" 
-      | "s8"  | "s16" | "s32" | "s64" 
-      | "__u8" | "__u16" | "__u32"  | "__u64"  
+      | "u8" | "u16" | "u32" | "u64"
+      | "s8"  | "s16" | "s32" | "s64"
+      | "__u8" | "__u16" | "__u32"  | "__u64"
           -> true
-          
-      | "acpi_handle" 
-      | "acpi_status" 
+
+      | "acpi_handle"
+      | "acpi_status"
         -> true
 
-      | "FILE" 
-      | "DIR" 
+      | "FILE"
+      | "DIR"
         -> true
-          
+
       | s when s =~ ".*_t$" -> true
-      | _ -> false 
+      | _ -> false
       )
     )
 
-(* note: cant use partial application with let msg_typedef = 
- * because it would compute msg_typedef at compile time when 
+(* note: cant use partial application with let msg_typedef =
+ * because it would compute msg_typedef at compile time when
  * the flag debug_typedef is always false
  *)
-let msg_typedef s = 
+let msg_typedef s =
   incr Stat.nTypedefInfer;
   msg_gen (!Flag_parsing_c.debug_typedef)
     is_known_typdef
-    (fun s -> 
+    (fun s ->
       pr2_cpp ("TYPEDEF: promoting: " ^ s)
     )
     s
 
 let msg_maybe_dangereous_typedef s =
   if not (is_known_typdef s)
-  then 
+  then
     pr2
       ("PB MAYBE: dangerous typedef inference, maybe not a typedef: " ^ s)
 
 
 
-let msg_declare_macro s = 
+let msg_declare_macro s =
   incr Stat.nMacroDecl;
   msg_gen (!Flag_parsing_c.debug_cpp)
-    (fun s -> 
-      (match s with 
+    (fun s ->
+      (match s with
       | "DECLARE_MUTEX" | "DECLARE_COMPLETION"  | "DECLARE_RWSEM"
-      | "DECLARE_WAITQUEUE" | "DECLARE_WAIT_QUEUE_HEAD" 
+      | "DECLARE_WAITQUEUE" | "DECLARE_WAIT_QUEUE_HEAD"
       | "DEFINE_SPINLOCK" | "DEFINE_TIMER"
       | "DEVICE_ATTR" | "CLASS_DEVICE_ATTR" | "DRIVER_ATTR"
       | "SENSOR_DEVICE_ATTR"
@@ -130,39 +130,39 @@ let msg_declare_macro s =
     )
     (fun s -> pr2_cpp ("MACRO: found declare-macro: " ^ s))
     s
-      
 
-let msg_foreach s = 
+
+let msg_foreach s =
   incr Stat.nIteratorHeuristic;
   pr2_cpp ("MACRO: found foreach: " ^ s)
 
 
-(* ?? 
-let msg_debug_macro s = 
+(* ??
+let msg_debug_macro s =
   pr2_cpp ("MACRO: found debug-macro: " ^ s)
 *)
 
 
-let msg_macro_noptvirg s = 
+let msg_macro_noptvirg s =
   incr Stat.nMacroStmt;
   pr2_cpp ("MACRO: found macro with param noptvirg: " ^ s)
 
-let msg_macro_toplevel_noptvirg s = 
+let msg_macro_toplevel_noptvirg s =
   incr Stat.nMacroStmt;
   pr2_cpp ("MACRO: found toplevel macro noptvirg: " ^ s)
 
-let msg_macro_noptvirg_single s = 
+let msg_macro_noptvirg_single s =
   incr Stat.nMacroStmt;
   pr2_cpp ("MACRO: found single-macro noptvirg: " ^ s)
 
 
 
 
-let msg_macro_higher_order s = 
+let msg_macro_higher_order s =
   incr Stat.nMacroHigherOrder;
   msg_gen (!Flag_parsing_c.debug_cpp)
-    (fun s -> 
-      (match s with 
+    (fun s ->
+      (match s with
       | "DBGINFO"
       | "DBGPX"
       | "DFLOW"
@@ -174,17 +174,17 @@ let msg_macro_higher_order s =
     s
 
 
-let msg_stringification s = 
+let msg_stringification s =
   incr Stat.nMacroString;
   msg_gen (!Flag_parsing_c.debug_cpp)
-    (fun s -> 
-      (match s with 
+    (fun s ->
+      (match s with
       | "REVISION"
       | "UTS_RELEASE"
       | "SIZE_STR"
       | "DMA_STR"
           -> true
-      (* s when s =~ ".*STR.*" -> true  *) 
+      (* s when s =~ ".*STR.*" -> true  *)
       | _ -> false
       )
     )
@@ -197,18 +197,18 @@ let msg_stringification_params s =
 
 
 
-let msg_apply_known_macro s = 
+let msg_apply_known_macro s =
   incr Stat.nMacroExpand;
   pr2_cpp ("MACRO: found known macro = " ^ s)
 
-let msg_apply_known_macro_hint s = 
+let msg_apply_known_macro_hint s =
   incr Stat.nMacroHint;
   pr2_cpp ("MACRO: found known macro hint = " ^ s)
 
 
-  
 
-let msg_ifdef_bool_passing is_ifdef_positif =      
+
+let msg_ifdef_bool_passing is_ifdef_positif =
   incr Stat.nIfdefZero; (* of Version ? *)
   if is_ifdef_positif
   then pr2_cpp "commenting parts of a #if 1 or #if LINUX_VERSION"
@@ -224,10 +224,10 @@ let msg_ifdef_funheaders () =
   ()
 
 
-let msg_attribute s = 
+let msg_attribute s =
   incr Stat.nMacroAttribute;
   pr2_cpp("ATTR:" ^ s)
-  
+
 
 
 (*****************************************************************************)
@@ -248,7 +248,7 @@ let regexp_declare =  Str.regexp
   ".*DECLARE.*"
 
 (* linuxext: *)
-let regexp_foreach = Str.regexp_case_fold 
+let regexp_foreach = Str.regexp_case_fold
   ".*\\(for_?each\\|for_?all\\|iterate\\|loop\\|walk\\|scan\\|each\\|for\\)"
 
 let regexp_typedef = Str.regexp
@@ -261,7 +261,7 @@ let false_typedef = [
 
 let ok_typedef s = not (List.mem s false_typedef)
 
-let not_annot s = 
+let not_annot s =
   not (s ==~ regexp_annot)
 
 
@@ -272,16 +272,16 @@ let not_annot s =
 (*****************************************************************************)
 
 (* ------------------------------------------------------------------------- *)
-(* the pair is the status of '()' and '{}', ex: (-1,0) 
- * if too much ')' and good '{}' 
- * could do for [] too ? 
+(* the pair is the status of '()' and '{}', ex: (-1,0)
+ * if too much ')' and good '{}'
+ * could do for [] too ?
  * could do for ','   if encounter ',' at "toplevel", not inside () or {}
  * then if have ifdef, then certainly can lead to a problem.
  *)
 let (count_open_close_stuff_ifdef_clause: TV.ifdef_grouped list -> (int * int))=
- fun xs -> 
+ fun xs ->
    let cnt_paren, cnt_brace = ref 0, ref 0 in
-   xs +> TV.iter_token_ifdef (fun x -> 
+   xs +> TV.iter_token_ifdef (fun x ->
      (match x.tok with
      | x when TH.is_opar x  -> incr cnt_paren
      | TOBrace _ -> incr cnt_brace
@@ -296,19 +296,19 @@ let (count_open_close_stuff_ifdef_clause: TV.ifdef_grouped list -> (int * int))=
 (* ------------------------------------------------------------------------- *)
 let forLOOKAHEAD = 30
 
-  
+
 (* look if there is a '{' just after the closing ')', and handling the
- * possibility to have nested expressions inside nested parenthesis 
- * 
+ * possibility to have nested expressions inside nested parenthesis
+ *
  * todo: use indentation instead of premier(statement) ?
  *)
-let rec is_really_foreach xs = 
+let rec is_really_foreach xs =
   let rec is_foreach_aux = function
     | [] -> false, []
     | TCPar _::TOBrace _::xs -> true, xs
       (* the following attempts to handle the cases where there is a
 	 single statement in the body of the loop.  undoubtedly more
-	 cases are needed. 
+	 cases are needed.
          todo: premier(statement) - suivant(funcall)
       *)
     | TCPar _::TIdent _::xs -> true, xs
@@ -320,7 +320,7 @@ let rec is_really_foreach xs =
 
 
     | TCPar _::xs -> false, xs
-    | TOPar _::xs -> 
+    | TOPar _::xs ->
         let (_, xs') = is_foreach_aux xs in
         is_foreach_aux xs'
     | x::xs -> is_foreach_aux xs
@@ -329,7 +329,7 @@ let rec is_really_foreach xs =
 
 
 (* ------------------------------------------------------------------------- *)
-let set_ifdef_token_parenthize_info cnt x = 
+let set_ifdef_token_parenthize_info cnt x =
     match x with
     | TIfdef (tag, _)
     | TIfdefelse (tag, _)
@@ -337,28 +337,28 @@ let set_ifdef_token_parenthize_info cnt x =
     | TEndif (tag, _)
 
     | TIfdefBool (_, tag, _)
-    | TIfdefMisc (_, tag, _)   
+    | TIfdefMisc (_, tag, _)
     | TIfdefVersion (_, tag, _)
-        -> 
+        ->
         tag := Some cnt;
 
     | _ -> raise Impossible
-  
 
 
-let ifdef_paren_cnt = ref 0 
+
+let ifdef_paren_cnt = ref 0
 
 
-let rec set_ifdef_parenthize_info xs = 
+let rec set_ifdef_parenthize_info xs =
   xs +> List.iter (function
   | NotIfdefLine xs -> ()
-  | Ifdefbool (_, xxs, info_ifdef) 
-  | Ifdef (xxs, info_ifdef) -> 
-      
+  | Ifdefbool (_, xxs, info_ifdef)
+  | Ifdef (xxs, info_ifdef) ->
+
       incr ifdef_paren_cnt;
       let total_directives = List.length info_ifdef in
 
-      info_ifdef +> List.iter (fun x -> 
+      info_ifdef +> List.iter (fun x ->
         set_ifdef_token_parenthize_info (!ifdef_paren_cnt, total_directives)
           x.tok);
       xxs +> List.iter set_ifdef_parenthize_info
@@ -379,31 +379,31 @@ let rec set_ifdef_parenthize_info xs =
 let rec commentize_skip_start_to_end xs =
   match xs with
   | [] -> ()
-  | x::xs -> 
+  | x::xs ->
       (match x with
-      | {tok = TCommentSkipTagStart info} -> 
-          (try 
-            let (before, x2, after) = 
+      | {tok = TCommentSkipTagStart info} ->
+          (try
+            let (before, x2, after) =
               xs +> Common2.split_when (function
               | {tok = TCommentSkipTagEnd _ } -> true
-              | _ -> false 
+              | _ -> false
               )
             in
             let topass = x::x2::before in
-            topass +> List.iter (fun tok -> 
+            topass +> List.iter (fun tok ->
               set_as_comment Token_c.CppPassingExplicit tok
             );
             commentize_skip_start_to_end after
-          with Not_found -> 
+          with Not_found ->
             failwith "could not find end of skip_start special comment"
           )
-      | {tok = TCommentSkipTagEnd info} -> 
+      | {tok = TCommentSkipTagEnd info} ->
             failwith "found skip_end comment but no skip_start"
-      | _ -> 
+      | _ ->
           commentize_skip_start_to_end xs
       )
-         
-            
+
+
 
 
 (* ------------------------------------------------------------------------- *)
@@ -411,33 +411,33 @@ let rec commentize_skip_start_to_end xs =
 (* ------------------------------------------------------------------------- *)
 
 (* #if 0, #if 1,  #if LINUX_VERSION handling *)
-let rec find_ifdef_bool xs = 
-  xs +> List.iter (function 
+let rec find_ifdef_bool xs =
+  xs +> List.iter (function
   | NotIfdefLine _ -> ()
-  | Ifdefbool (is_ifdef_positif, xxs, info_ifdef_stmt) -> 
+  | Ifdefbool (is_ifdef_positif, xxs, info_ifdef_stmt) ->
 
       msg_ifdef_bool_passing is_ifdef_positif;
 
       (match xxs with
       | [] -> raise Impossible
-      | firstclause::xxs -> 
+      | firstclause::xxs ->
           info_ifdef_stmt +> List.iter (set_as_comment Token_c.CppDirective);
-            
+
           if is_ifdef_positif
-          then xxs +> List.iter 
+          then xxs +> List.iter
             (iter_token_ifdef (set_as_comment Token_c.CppPassingNormal))
           else begin
             firstclause +> iter_token_ifdef (set_as_comment Token_c.CppPassingNormal);
             (match List.rev xxs with
             (* keep only last *)
-            | last::startxs -> 
-                startxs +> List.iter 
+            | last::startxs ->
+                startxs +> List.iter
                   (iter_token_ifdef (set_as_comment Token_c.CppPassingNormal))
             | [] -> (* not #else *) ()
             );
           end
       );
-      
+
   | Ifdef (xxs, info_ifdef_stmt) -> xxs +> List.iter find_ifdef_bool
   )
 
@@ -446,50 +446,50 @@ let rec find_ifdef_bool xs =
 let thresholdIfdefSizeMid = 6
 
 (* infer ifdef involving not-closed expressions/statements *)
-let rec find_ifdef_mid xs = 
-  xs +> List.iter (function 
+let rec find_ifdef_mid xs =
+  xs +> List.iter (function
   | NotIfdefLine _ -> ()
-  | Ifdef (xxs, info_ifdef_stmt) -> 
-      (match xxs with 
+  | Ifdef (xxs, info_ifdef_stmt) ->
+      (match xxs with
       | [] -> raise Impossible
       | [first] -> ()
-      | first::second::rest -> 
+      | first::second::rest ->
           (* don't analyse big ifdef *)
-          if xxs +> List.for_all 
-            (fun xs -> List.length xs <= thresholdIfdefSizeMid) && 
+          if xxs +> List.for_all
+            (fun xs -> List.length xs <= thresholdIfdefSizeMid) &&
             (* don't want nested ifdef *)
-            xxs +> List.for_all (fun xs -> 
-              xs +> List.for_all 
+            xxs +> List.for_all (fun xs ->
+              xs +> List.for_all
                 (function NotIfdefLine _ -> true | _ -> false)
             )
-            
-          then 
+
+          then
             let counts = xxs +> List.map count_open_close_stuff_ifdef_clause in
-            let cnt1, cnt2 = List.hd counts in 
-            if cnt1 <> 0 || cnt2 <> 0 && 
+            let cnt1, cnt2 = List.hd counts in
+            if cnt1 <> 0 || cnt2 <> 0 &&
                counts +> List.for_all (fun x -> x =*= (cnt1, cnt2))
               (*
-                if counts +> List.exists (fun (cnt1, cnt2) -> 
-                cnt1 <> 0 || cnt2 <> 0 
-                ) 
+                if counts +> List.exists (fun (cnt1, cnt2) ->
+                cnt1 <> 0 || cnt2 <> 0
+                )
               *)
             then begin
               msg_ifdef_mid_something();
 
               (* keep only first, treat the rest as comment *)
               info_ifdef_stmt +> List.iter (set_as_comment Token_c.CppDirective);
-              (second::rest) +> List.iter 
+              (second::rest) +> List.iter
                 (iter_token_ifdef (set_as_comment Token_c.CppPassingCosWouldGetError));
             end
-              
+
       );
       List.iter find_ifdef_mid xxs
-        
+
   (* no need complex analysis for ifdefbool *)
-  | Ifdefbool (_, xxs, info_ifdef_stmt) -> 
+  | Ifdefbool (_, xxs, info_ifdef_stmt) ->
       List.iter find_ifdef_mid xxs
-          
-        
+
+
   )
 
 
@@ -498,19 +498,19 @@ let thresholdFunheaderLimit = 4
 (* ifdef defining alternate function header, type *)
 let rec find_ifdef_funheaders = function
   | [] -> ()
-  | NotIfdefLine _::xs -> find_ifdef_funheaders xs 
+  | NotIfdefLine _::xs -> find_ifdef_funheaders xs
 
   (* ifdef-funheader if ifdef with 2 lines and a '{' in next line *)
-  | Ifdef 
+  | Ifdef
       ([(NotIfdefLine (({col = 0} as _xline1)::line1))::ifdefblock1;
         (NotIfdefLine (({col = 0} as xline2)::line2))::ifdefblock2
-      ], info_ifdef_stmt 
+      ], info_ifdef_stmt
       )
     ::NotIfdefLine (({tok = TOBrace i; col = 0})::line3)
-    ::xs  
+    ::xs
    when List.length ifdefblock1 <= thresholdFunheaderLimit &&
         List.length ifdefblock2 <= thresholdFunheaderLimit
-    -> 
+    ->
       find_ifdef_funheaders xs;
 
       msg_ifdef_funheaders ();
@@ -520,19 +520,19 @@ let rec find_ifdef_funheaders = function
       ifdefblock2 +> iter_token_ifdef (set_as_comment Token_c.CppPassingCosWouldGetError);
 
   (* ifdef with nested ifdef *)
-  | Ifdef 
+  | Ifdef
       ([[NotIfdefLine (({col = 0} as _xline1)::line1)];
-        [Ifdef 
+        [Ifdef
             ([[NotIfdefLine (({col = 0} as xline2)::line2)];
               [NotIfdefLine (({col = 0} as xline3)::line3)];
             ], info_ifdef_stmt2
             )
         ]
-      ], info_ifdef_stmt 
+      ], info_ifdef_stmt
       )
     ::NotIfdefLine (({tok = TOBrace i; col = 0})::line4)
-    ::xs  
-    -> 
+    ::xs
+    ->
       find_ifdef_funheaders xs;
 
       msg_ifdef_funheaders ();
@@ -542,38 +542,38 @@ let rec find_ifdef_funheaders = function
       all_toks +> List.iter (set_as_comment Token_c.CppPassingCosWouldGetError);
 
  (* ifdef with elseif *)
-  | Ifdef 
+  | Ifdef
       ([[NotIfdefLine (({col = 0} as _xline1)::line1)];
         [NotIfdefLine (({col = 0} as xline2)::line2)];
         [NotIfdefLine (({col = 0} as xline3)::line3)];
-      ], info_ifdef_stmt 
+      ], info_ifdef_stmt
       )
     ::NotIfdefLine (({tok = TOBrace i; col = 0})::line4)
-    ::xs 
-    -> 
+    ::xs
+    ->
       find_ifdef_funheaders xs;
 
       msg_ifdef_funheaders ();
       info_ifdef_stmt +> List.iter (set_as_comment Token_c.CppDirective);
       let all_toks = [xline2;xline3] @ line2 @ line3 in
       all_toks +> List.iter (set_as_comment Token_c.CppPassingCosWouldGetError)
-        
+
   (* recurse *)
-  | Ifdef (xxs,info_ifdef_stmt)::xs 
-  | Ifdefbool (_, xxs,info_ifdef_stmt)::xs -> 
-      List.iter find_ifdef_funheaders xxs; 
+  | Ifdef (xxs,info_ifdef_stmt)::xs
+  | Ifdefbool (_, xxs,info_ifdef_stmt)::xs ->
+      List.iter find_ifdef_funheaders xxs;
       find_ifdef_funheaders xs
-        
+
 
 
 (* ?? *)
-let rec adjust_inifdef_include xs = 
-  xs +> List.iter (function 
+let rec adjust_inifdef_include xs =
+  xs +> List.iter (function
   | NotIfdefLine _ -> ()
-  | Ifdef (xxs, info_ifdef_stmt) | Ifdefbool (_, xxs, info_ifdef_stmt) -> 
-      xxs +> List.iter (iter_token_ifdef (fun tokext -> 
+  | Ifdef (xxs, info_ifdef_stmt) | Ifdefbool (_, xxs, info_ifdef_stmt) ->
+      xxs +> List.iter (iter_token_ifdef (fun tokext ->
         match tokext.tok with
-        | Parser_c.TInclude (s1, s2, inifdef_ref, ii) -> 
+        | Parser_c.TInclude (s1, s2, inifdef_ref, ii) ->
             inifdef_ref := true;
         | _ -> ()
       ));
@@ -585,54 +585,54 @@ let rec adjust_inifdef_include xs =
 (* cpp-builtin part2, macro, using standard.h or other defs *)
 (* ------------------------------------------------------------------------- *)
 
-(* now in cpp_token_c.ml *) 
+(* now in cpp_token_c.ml *)
 
 (* ------------------------------------------------------------------------- *)
 (* stringification *)
 (* ------------------------------------------------------------------------- *)
 
-let rec find_string_macro_paren xs = 
+let rec find_string_macro_paren xs =
   match xs with
   | [] -> ()
-  | Parenthised(xxs, info_parens)::xs -> 
-      xxs +> List.iter (fun xs -> 
-        if xs +> List.exists 
+  | Parenthised(xxs, info_parens)::xs ->
+      xxs +> List.iter (fun xs ->
+        if xs +> List.exists
           (function PToken({tok = (TString _| TMacroString _)}) -> true | _ -> false) &&
-          xs +> List.for_all 
-          (function PToken({tok = (TString _| TMacroString _)}) | PToken({tok = TIdent _}) -> 
+          xs +> List.for_all
+          (function PToken({tok = (TString _| TMacroString _)}) | PToken({tok = TIdent _}) ->
             true | _ -> false)
         then
-          xs +> List.iter (fun tok -> 
+          xs +> List.iter (fun tok ->
             match tok with
-            | PToken({tok = TIdent (s,_)} as id) -> 
+            | PToken({tok = TIdent (s,_)} as id) ->
                 msg_stringification s;
                 id.tok <- TMacroString (s, TH.info_of_tok id.tok);
             | _ -> ()
           )
-        else 
+        else
           find_string_macro_paren xs
       );
       find_string_macro_paren xs
-  | PToken(tok)::xs -> 
+  | PToken(tok)::xs ->
       find_string_macro_paren xs
-      
+
 
 (* ------------------------------------------------------------------------- *)
 (* macro2 *)
 (* ------------------------------------------------------------------------- *)
 
 (* don't forget to recurse in each case *)
-let rec find_macro_paren xs = 
+let rec find_macro_paren xs =
   match xs with
   | [] -> ()
-      
+
   (* attribute *)
   | PToken ({tok = Tattribute _} as id)
     ::Parenthised (xxs,info_parens)
     ::xs
-     -> 
+     ->
       pr2_cpp ("MACRO: __attribute detected ");
-      [Parenthised (xxs, info_parens)] +> 
+      [Parenthised (xxs, info_parens)] +>
         iter_token_paren (set_as_comment Token_c.CppAttr);
       set_as_comment Token_c.CppAttr id;
       find_macro_paren xs
@@ -642,7 +642,7 @@ let rec find_macro_paren xs =
   | PToken ({tok = TIdent (s,i1)} as id)
     ::PToken ({tok = TIdent (s2, i2)} as id2)
     ::xs when s ==~ regexp_annot
-     -> 
+     ->
       msg_attribute s;
       id.tok <- TMacroAttr (s, i1);
       find_macro_paren ((PToken id2)::xs); (* recurse also on id2 ? *)
@@ -651,7 +651,7 @@ let rec find_macro_paren xs =
   | PToken ({tok = TIdent (s,i1)} as _id)
     ::PToken ({tok = TIdent (s2, i2)} as id2)
     ::xs when s2 ==~ regexp_annot && (not (s ==~ regexp_typedef))
-     -> 
+     ->
       msg_attribute s2;
       id2.tok <- TMacroAttr (s2, i2);
       find_macro_paren xs
@@ -659,19 +659,19 @@ let rec find_macro_paren xs =
   | PToken ({tok = (Tstatic _ | Textern _)} as tok1)
     ::PToken ({tok = TIdent (s,i1)} as attr)
     ::xs when s ==~ regexp_annot
-    -> 
+    ->
       pr2_cpp ("storage attribute: " ^ s);
       attr.tok <- TMacroAttrStorage (s,i1);
       (* recurse, may have other storage attributes *)
       find_macro_paren (PToken (tok1)::xs)
-      
+
 
 *)
 
   (* storage attribute *)
   | PToken ({tok = (Tstatic _ | Textern _)} as tok1)
-    ::PToken ({tok = TMacroAttr (s,i1)} as attr)::xs 
-    -> 
+    ::PToken ({tok = TMacroAttr (s,i1)} as attr)::xs
+    ->
       pr2_cpp ("storage attribute: " ^ s);
       attr.tok <- TMacroAttrStorage (s,i1);
       (* recurse, may have other storage attributes *)
@@ -679,19 +679,19 @@ let rec find_macro_paren xs =
 
 
   (* stringification
-   * 
+   *
    * the order of the matching clause is important
-   * 
+   *
    *)
 
   (* string macro with params, before case *)
   | PToken ({tok = (TString _| TMacroString _)})::PToken ({tok = TIdent (s,_)} as id)
     ::Parenthised (xxs, info_parens)
-    ::xs -> 
+    ::xs ->
 
       msg_stringification_params s;
       id.tok <- TMacroString (s, TH.info_of_tok id.tok);
-      [Parenthised (xxs, info_parens)] +> 
+      [Parenthised (xxs, info_parens)] +>
         iter_token_paren (set_as_comment Token_c.CppMacro);
       find_macro_paren xs
 
@@ -699,11 +699,11 @@ let rec find_macro_paren xs =
   | PToken ({tok = TIdent (s,_)} as id)
     ::Parenthised (xxs, info_parens)
     ::PToken ({tok = (TString _ | TMacroString _)})
-    ::xs -> 
+    ::xs ->
 
       msg_stringification_params s;
       id.tok <- TMacroString (s, TH.info_of_tok id.tok);
-      [Parenthised (xxs, info_parens)] +> 
+      [Parenthised (xxs, info_parens)] +>
         iter_token_paren (set_as_comment Token_c.CppMacro);
       find_macro_paren xs
 
@@ -711,10 +711,10 @@ let rec find_macro_paren xs =
   (* for the case where the string is not inside a funcall, but
    * for instance in an initializer.
    *)
-        
+
   (* string macro variable, before case *)
   | PToken ({tok = (TString _ | TMacroString _)})::PToken ({tok = TIdent (s,_)} as id)
-      ::xs -> 
+      ::xs ->
 
       msg_stringification s;
       id.tok <- TMacroString (s, TH.info_of_tok id.tok);
@@ -723,19 +723,19 @@ let rec find_macro_paren xs =
   (* after case *)
   | PToken ({tok = TIdent (s,_)} as id)
       ::PToken ({tok = (TString _ | TMacroString _)})
-      ::xs -> 
+      ::xs ->
 
       msg_stringification s;
       id.tok <- TMacroString (s, TH.info_of_tok id.tok);
       find_macro_paren xs
 
 
-    
+
 
 
   (* recurse *)
-  | (PToken x)::xs -> find_macro_paren xs 
-  | (Parenthised (xxs, info_parens))::xs -> 
+  | (PToken x)::xs -> find_macro_paren xs
+  | (Parenthised (xxs, info_parens))::xs ->
       xxs +> List.iter find_macro_paren;
       find_macro_paren xs
 
@@ -744,21 +744,21 @@ let rec find_macro_paren xs =
 
 
 (* don't forget to recurse in each case *)
-let rec find_macro_lineparen xs = 
+let rec find_macro_lineparen xs =
   match xs with
   | [] -> ()
 
   (* linuxext: ex: static [const] DEVICE_ATTR(); *)
-  | (Line 
+  | (Line
         (
           [PToken ({tok = Tstatic _});
            PToken ({tok = TIdent (s,_)} as macro);
            Parenthised (xxs,info_parens);
            PToken ({tok = TPtVirg _});
-          ] 
+          ]
         ))
-    ::xs 
-    when (s ==~ regexp_macro) -> 
+    ::xs
+    when (s ==~ regexp_macro) ->
 
       msg_declare_macro s;
       let info = TH.info_of_tok macro.tok in
@@ -767,25 +767,25 @@ let rec find_macro_lineparen xs =
       find_macro_lineparen (xs)
 
   (* the static const case *)
-  | (Line 
+  | (Line
         (
           [PToken ({tok = Tstatic _});
            PToken ({tok = Tconst _} as const);
            PToken ({tok = TIdent (s,_)} as macro);
            Parenthised (xxs,info_parens);
            PToken ({tok = TPtVirg _});
-          ] 
+          ]
             (*as line1*)
 
         ))
-    ::xs 
-    when (s ==~ regexp_macro) -> 
+    ::xs
+    when (s ==~ regexp_macro) ->
 
       msg_declare_macro s;
       let info = TH.info_of_tok macro.tok in
       macro.tok <- TMacroDecl (Ast_c.str_of_info info, info);
-      
-      (* need retag this const, otherwise ambiguity in grammar 
+
+      (* need retag this const, otherwise ambiguity in grammar
          21: shift/reduce conflict (shift 121, reduce 137) on Tconst
   	 decl2 : Tstatic . TMacroDecl TOPar argument_list TCPar ...
 	 decl2 : Tstatic . Tconst TMacroDecl TOPar argument_list TCPar ...
@@ -797,18 +797,18 @@ let rec find_macro_lineparen xs =
 
 
   (* same but without trailing ';'
-   * 
+   *
    * I do not put the final ';' because it can be on a multiline and
    * because of the way mk_line is coded, we will not have access to
    * this ';' on the next line, even if next to the ')' *)
-  | (Line 
+  | (Line
         ([PToken ({tok = Tstatic _});
           PToken ({tok = TIdent (s,_)} as macro);
           Parenthised (xxs,info_parens);
-        ] 
+        ]
         ))
-    ::xs 
-    when s ==~ regexp_macro -> 
+    ::xs
+    when s ==~ regexp_macro ->
 
       msg_declare_macro s;
       let info = TH.info_of_tok macro.tok in
@@ -820,20 +820,20 @@ let rec find_macro_lineparen xs =
 
 
   (* on multiple lines *)
-  | (Line 
+  | (Line
         (
           (PToken ({tok = Tstatic _})::[]
           )))
-    ::(Line 
+    ::(Line
           (
             [PToken ({tok = TIdent (s,_)} as macro);
              Parenthised (xxs,info_parens);
              PToken ({tok = TPtVirg _});
             ]
-          ) 
+          )
         )
-    ::xs 
-    when (s ==~ regexp_macro) -> 
+    ::xs
+    when (s ==~ regexp_macro) ->
 
       msg_declare_macro s;
       let info = TH.info_of_tok macro.tok in
@@ -842,8 +842,8 @@ let rec find_macro_lineparen xs =
       find_macro_lineparen (xs)
 
 
-  (* linuxext: ex: DECLARE_BITMAP(); 
-   * 
+  (* linuxext: ex: DECLARE_BITMAP();
+   *
    * Here I use regexp_declare and not regexp_macro because
    * Sometimes it can be a FunCallMacro such as DEBUG(foo());
    * Here we don't have the preceding 'static' so only way to
@@ -853,15 +853,15 @@ let rec find_macro_lineparen xs =
    * unless the parameter of the DECLARE_xxx are weird and can not be mapped
    * on a argument_list
    *)
-        
-  | (Line 
+
+  | (Line
         ([PToken ({tok = TIdent (s,_)} as macro);
           Parenthised (xxs,info_parens);
           PToken ({tok = TPtVirg _});
         ]
         ))
-    ::xs 
-    when (s ==~ regexp_declare) -> 
+    ::xs
+    when (s ==~ regexp_declare) ->
 
       msg_declare_macro s;
       let info = TH.info_of_tok macro.tok in
@@ -869,34 +869,34 @@ let rec find_macro_lineparen xs =
 
       find_macro_lineparen (xs)
 
-        
+
   (* toplevel macros.
    * module_init(xxx)
-   * 
+   *
    * Could also transform the TIdent in a TMacroTop but can have false
    * positive, so easier to just change the TCPar and so just solve
    * the end-of-stream pb of ocamlyacc
    *)
-  | (Line 
+  | (Line
         ([PToken ({tok = TIdent (s,ii); col = col1; where = ctx} as _macro);
           Parenthised (xxs,info_parens);
         ] as _line1
         ))
     ::xs when col1 =|= 0
-    -> 
-      let condition = 
+    ->
+      let condition =
         (* to reduce number of false positive *)
         (match xs with
-        | (Line (PToken ({col = col2 } as other)::restline2))::_ -> 
+        | (Line (PToken ({col = col2 } as other)::restline2))::_ ->
             TH.is_eof other.tok || (col2 =|= 0 &&
              (match other.tok with
              | TOBrace _ -> false (* otherwise would match funcdecl *)
              | TCBrace _ when ctx <> InFunction -> false
-             | TPtVirg _ 
+             | TPtVirg _
              | TDotDot _
                -> false
              | tok when TH.is_binary_operator tok -> false
-                 
+
              | _ -> true
              )
             )
@@ -910,44 +910,44 @@ let rec find_macro_lineparen xs =
           (* just to avoid the end-of-stream pb of ocamlyacc  *)
           let tcpar = Common2.list_last info_parens in
           tcpar.tok <- TCParEOL (TH.info_of_tok tcpar.tok);
-          
+
           (*macro.tok <- TMacroTop (s, TH.info_of_tok macro.tok);*)
-          
+
         end;
 
        find_macro_lineparen (xs)
 
 
 
-  (* macro with parameters 
+  (* macro with parameters
    * ex: DEBUG()
    *     return x;
    *)
-  | (Line 
+  | (Line
         ([PToken ({tok = TIdent (s,ii); col = col1; where = ctx} as macro);
           Parenthised (xxs,info_parens);
         ] as _line1
         ))
-    ::(Line 
+    ::(Line
           (PToken ({col = col2 } as other)::restline2
           ) as line2)
-    ::xs 
+    ::xs
     (* when s ==~ regexp_macro *)
-    -> 
-      let condition = 
-        (col1 =|= col2 && 
+    ->
+      let condition =
+        (col1 =|= col2 &&
             (match other.tok with
             | TOBrace _ -> false (* otherwise would match funcdecl *)
             | TCBrace _ when ctx <> InFunction -> false
-            | TPtVirg _ 
+            | TPtVirg _
             | TDotDot _
                 -> false
             | tok when TH.is_binary_operator tok -> false
 
             | _ -> true
             )
-        ) 
-        || 
+        )
+        ||
         (col2 <= col1 &&
               (match other.tok, restline2 with
               | TCBrace _, _ when ctx =*= InFunction -> true
@@ -956,7 +956,7 @@ let rec find_macro_lineparen xs =
               | Telse _, _ -> true
 
               (* case of label, usually put in first line *)
-              | TIdent _, (PToken ({tok = TDotDot _}))::_ -> 
+              | TIdent _, (PToken ({tok = TDotDot _}))::_ ->
                   true
 
 
@@ -965,42 +965,42 @@ let rec find_macro_lineparen xs =
           )
 
       in
-      
+
       if condition
-      then 
+      then
         if col1 =|= 0 then ()
         else begin
           msg_macro_noptvirg s;
           macro.tok <- TMacroStmt (s, TH.info_of_tok macro.tok);
-          [Parenthised (xxs, info_parens)] +> 
+          [Parenthised (xxs, info_parens)] +>
             iter_token_paren (set_as_comment Token_c.CppMacro);
         end;
 
       find_macro_lineparen (line2::xs)
-        
-  (* linuxext:? single macro 
+
+  (* linuxext:? single macro
    * ex: LOCK
    *     foo();
    *     UNLOCK
-   * 
+   *
    * todo: factorize code with previous rule ?
    *)
-  | (Line 
+  | (Line
         ([PToken ({tok = TIdent (s,ii); col = col1; where = ctx} as macro);
         ] as _line1
         ))
-    ::(Line 
+    ::(Line
           (PToken ({col = col2 } as other)::restline2
           ) as line2)
-    ::xs -> 
+    ::xs ->
     (* when s ==~ regexp_macro *)
-      
-      let condition = 
-        (col1 =|= col2 && 
+
+      let condition =
+        (col1 =|= col2 &&
             col1 <> 0 && (* otherwise can match typedef of fundecl*)
             (match other.tok with
-            | TPtVirg _ -> false 
-            | TOr _ -> false 
+            | TPtVirg _ -> false
+            | TOr _ -> false
             | TCBrace _ when ctx <> InFunction -> false
             | tok when TH.is_binary_operator tok -> false
 
@@ -1015,15 +1015,15 @@ let rec find_macro_lineparen xs =
               | _ -> false
               ))
       in
-      
+
       if condition
       then begin
         msg_macro_noptvirg_single s;
         macro.tok <- TMacroStmt (s, TH.info_of_tok macro.tok);
       end;
       find_macro_lineparen (line2::xs)
-        
-  | x::xs -> 
+
+  | x::xs ->
       find_macro_lineparen xs
 
 
@@ -1032,8 +1032,8 @@ let rec find_macro_lineparen xs =
 (* define tobrace init *)
 (* ------------------------------------------------------------------------- *)
 
-let rec find_define_init_brace_paren xs = 
- let rec aux xs = 
+let rec find_define_init_brace_paren xs =
+ let rec aux xs =
   match xs with
   | [] -> ()
 
@@ -1043,17 +1043,17 @@ let rec find_define_init_brace_paren xs =
     ::(PToken ({tok = TOBrace i1} as tokbrace))
     ::(PToken tok2)
     ::(PToken tok3)
-    ::xs -> 
+    ::xs ->
       let is_init =
         match tok2.tok, tok3.tok with
         | TInt _, TComma _ -> true
         | TString _, TComma _ -> true
         | TIdent _, TComma _ -> true
         | _ -> false
-            
+
       in
       if is_init
-      then begin 
+      then begin
         pr2_cpp("found define initializer: " ^s);
         tokbrace.tok <- TOBraceDefineInit i1;
       end;
@@ -1067,30 +1067,30 @@ let rec find_define_init_brace_paren xs =
     ::(PToken ({tok = TOBrace i1} as tokbrace))
     ::(PToken tok2)
     ::(PToken tok3)
-    ::xs -> 
+    ::xs ->
       let is_init =
         match tok2.tok, tok3.tok with
         | TInt _, TComma _ -> true
         | TDot _, TIdent _ -> true
         | TIdent _, TComma _ -> true
         | _ -> false
-            
+
       in
       if is_init
-      then begin 
+      then begin
         pr2_cpp("found define initializer with param: " ^ s);
         tokbrace.tok <- TOBraceDefineInit i1;
       end;
 
       aux xs
 
-    
+
 
   (* recurse *)
-  | (PToken x)::xs -> aux xs 
-  | (Parenthised (xxs, info_parens))::xs -> 
+  | (PToken x)::xs -> aux xs
+  | (Parenthised (xxs, info_parens))::xs ->
       (* not need for tobrace init:
-       *  xxs +> List.iter aux; 
+       *  xxs +> List.iter aux;
        *)
       aux xs
  in
@@ -1108,32 +1108,32 @@ let rec find_actions = function
 
   | PToken ({tok = TIdent (s,ii)})
     ::Parenthised (xxs,info_parens)
-    ::xs -> 
+    ::xs ->
       find_actions xs;
       xxs +> List.iter find_actions;
       let modified = find_actions_params xxs in
-      if modified 
+      if modified
       then msg_macro_higher_order s
-        
-  | x::xs -> 
+
+  | x::xs ->
       find_actions xs
 
-and find_actions_params xxs = 
-  xxs +> List.fold_left (fun acc xs -> 
+and find_actions_params xxs =
+  xxs +> List.fold_left (fun acc xs ->
     let toks = tokens_of_paren xs in
-    if toks +> List.exists (fun x -> TH.is_statement x.tok) 
-      (* undo:  && List.length toks > 1 
+    if toks +> List.exists (fun x -> TH.is_statement x.tok)
+      (* undo:  && List.length toks > 1
        * good for sparse, not good for linux
        *)
     then begin
-      xs +> iter_token_paren (fun x -> 
+      xs +> iter_token_paren (fun x ->
         if TH.is_eof x.tok
-        then 
+        then
           (* certainly because paren detection had a pb because of
            * some ifdef-exp
            *)
           pr2 "PB: weird, I try to tag an EOF token as action"
-        else 
+        else
           x.tok <- TAction (TH.info_of_tok x.tok);
       );
       true (* modified *)
@@ -1147,11 +1147,11 @@ and find_actions_params xxs =
 (* main fix cpp function *)
 (* ------------------------------------------------------------------------- *)
 
-let filter_cpp_stuff xs = 
-  let rec aux xs = 
+let filter_cpp_stuff xs =
+  let rec aux xs =
     match xs with
     | [] -> []
-    | x::xs -> 
+    | x::xs ->
         (match x.tok with
         | tok when TH.is_comment tok -> aux xs
         (* don't want drop the define, or if drop, have to drop
@@ -1159,7 +1159,7 @@ let filter_cpp_stuff xs =
          * by not finding the TDefine in column 0 but by finding
          * a TDefineIdent in a column > 0
          *)
-        | Parser_c.TDefine _ -> 
+        | Parser_c.TDefine _ ->
             x::aux xs
         | tok when TH.is_cpp_instruction tok -> aux xs
         | _ -> x::aux xs
@@ -1198,27 +1198,27 @@ let insert_virtual_positions l =
   skip_fake l
 
 (* ------------------------------------------------------------------------- *)
-let fix_tokens_cpp2 ~macro_defs tokens = 
+let fix_tokens_cpp2 ~macro_defs tokens =
   let tokens2 = ref (tokens +> Common2.acc_map TV.mk_token_extended) in
-  
-  begin 
+
+  begin
     (* the order is important, if you put the action heuristic first,
      * then because of ifdef, can have not closed paren
-     * and so may believe that higher order macro 
-     * and it will eat too much tokens. So important to do 
+     * and so may believe that higher order macro
+     * and it will eat too much tokens. So important to do
      * first the ifdef.
-     * 
+     *
      * I recompute multiple times cleaner cos the mutable
      * can have be changed and so may have more comments
      * in the token original list.
-     * 
+     *
      *)
 
     commentize_skip_start_to_end !tokens2;
 
     (* ifdef *)
-    let cleaner = !tokens2 +> List.filter (fun x -> 
-      (* is_comment will also filter the TCommentCpp created in 
+    let cleaner = !tokens2 +> List.filter (fun x ->
+      (* is_comment will also filter the TCommentCpp created in
        * commentize_skip_start_to_end *)
       not (TH.is_comment x.tok) (* could filter also #define/#include *)
     ) in
@@ -1236,16 +1236,16 @@ let fix_tokens_cpp2 ~macro_defs tokens =
 
     let paren_grouped = TV.mk_parenthised  cleaner in
     Cpp_token_c.apply_macro_defs
-      ~msg_apply_known_macro 
-      ~msg_apply_known_macro_hint 
+      ~msg_apply_known_macro
+      ~msg_apply_known_macro_hint
       macro_defs paren_grouped;
     (* because the before field is used by apply_macro_defs *)
-    tokens2 := TV.rebuild_tokens_extented !tokens2; 
+    tokens2 := TV.rebuild_tokens_extented !tokens2;
 
     (* tagging contextual info (InFunc, InStruct, etc). Better to do
      * that after the "ifdef-simplification" phase.
      *)
-    let cleaner = !tokens2 +> List.filter (fun x -> 
+    let cleaner = !tokens2 +> List.filter (fun x ->
       not (TH.is_comment x.tok) (* could filter also #define/#include *)
     ) in
 
@@ -1269,16 +1269,16 @@ let fix_tokens_cpp2 ~macro_defs tokens =
     let cleaner = !tokens2 +> filter_cpp_stuff in
     let paren_grouped = TV.mk_parenthised  cleaner in
     find_actions  paren_grouped;
-    
+
 
 
     insert_virtual_positions (!tokens2 +> Common2.acc_map (fun x -> x.tok))
   end
 
-let time_hack1 ~macro_defs a = 
+let time_hack1 ~macro_defs a =
   Common.profile_code_exclusif "HACK" (fun () -> fix_tokens_cpp2 ~macro_defs a)
 
-let fix_tokens_cpp ~macro_defs a = 
+let fix_tokens_cpp ~macro_defs a =
   Common.profile_code "C parsing.fix_cpp" (fun () -> time_hack1 ~macro_defs a)
 
 
@@ -1294,26 +1294,26 @@ let fix_tokens_cpp ~macro_defs a =
 (*****************************************************************************)
 
 (* Why using yet another parsing_hack technique ? The fix_xxx where do
- * some pre-processing on the full list of tokens is not enough ? 
+ * some pre-processing on the full list of tokens is not enough ?
  * No cos sometimes we need more contextual info, and even if
  * set_context() tries to give some contextual info, it's not completely
  * accurate so the following code give yet another alternative, yet another
  * chance to transform some tokens.
- * 
+ *
  * todo?: maybe could try to get rid of this technique. Maybe a better
  * set_context() would make possible to move this code using a fix_xx
  * technique.
- * 
+ *
  * LALR(k) trick. We can do stuff by adding cases in lexer_c.mll, but
  * it is more general to do it via my LALR(k) tech. Because here we can
  * transform some token give some context information. So sometimes it
  * makes sense to transform a token in one context, sometimes not, and
  * lex can not provide us this context information. Note that the order
- * in the pattern matching in lookahead is important. Do not cut/paste. 
- * 
+ * in the pattern matching in lookahead is important. Do not cut/paste.
+ *
  * Note that in next there is only "clean" tokens, there is no comment
  * or space tokens. This is done by the caller.
- * 
+ *
  *)
 
 open Lexer_parser (* for the fields of lexer_hint type *)
@@ -1323,7 +1323,7 @@ let not_struct_enum = function
   | _ -> true
 
 
-let lookahead2 ~pass next before = 
+let lookahead2 ~pass next before =
 
   match (next, before) with
 
@@ -1334,16 +1334,16 @@ let lookahead2 ~pass next before =
   | (TIdent(s,i1)::TIdent(s2,i2)::_ , _) when not_struct_enum before && s =$= s2
       && ok_typedef s
       (* (take_safe 1 !passed_tok <> [TOPar]) ->  *)
-    -> 
+    ->
       (* parse_typedef_fix3:
        *    acpi_object		acpi_object;
-       * etait mal parsé, car pas le temps d'appeler dt()  dans le type_spec. 
+       * etait mal parsé, car pas le temps d'appeler dt()  dans le type_spec.
        * Le parser en interne a deja appelé le prochain token pour pouvoir
        * decider des choses.
        *  => special case in lexer_heuristic, again
        *)
-      if !Flag_parsing_c.debug_typedef 
-      then pr2 ("TYPEDEF: disable typedef cos special case: " ^ s); 
+      if !Flag_parsing_c.debug_typedef
+      then pr2 ("TYPEDEF: disable typedef cos special case: " ^ s);
 
       LP.disable_typedef();
 
@@ -1351,7 +1351,7 @@ let lookahead2 ~pass next before =
       TypedefIdent (s, i1)
 
   (* xx yy *)
-  | (TIdent (s, i1)::TIdent (s2, i2)::_  , _) when not_struct_enum before 
+  | (TIdent (s, i1)::TIdent (s2, i2)::_  , _) when not_struct_enum before
       && ok_typedef s
         ->
          (* && not_annot s2 BUT lead to false positive*)
@@ -1361,9 +1361,9 @@ let lookahead2 ~pass next before =
 
 
   (* xx inline *)
-  | (TIdent (s, i1)::Tinline i2::_  , _) when not_struct_enum before 
+  | (TIdent (s, i1)::Tinline i2::_  , _) when not_struct_enum before
       && ok_typedef s
-      -> 
+      ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
@@ -1372,7 +1372,7 @@ let lookahead2 ~pass next before =
   | (TIdent (s, i1)::(TComma _|TCPar _)::_ , (TComma _ |TOPar _)::_ )
     when not_struct_enum before && (LP.current_context() =*= LP.InParameter)
       && ok_typedef s
-      -> 
+      ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
@@ -1382,7 +1382,7 @@ let lookahead2 ~pass next before =
     when not_struct_enum before
         (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
       && ok_typedef s
-    -> 
+    ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
@@ -1393,25 +1393,25 @@ let lookahead2 ~pass next before =
     when not_struct_enum before
       (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
       && ok_typedef s
-    -> 
+    ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
 
 
   (* xx const *   USELESS because of next rule ? *)
-  | (TIdent (s, i1)::(Tconst _|Tvolatile _|Trestrict _)::TMul _::_ , _ ) 
-      when not_struct_enum before 
+  | (TIdent (s, i1)::(Tconst _|Tvolatile _|Trestrict _)::TMul _::_ , _ )
+      when not_struct_enum before
       (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
       && ok_typedef s
       ->
 
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
-  
+
   (* xx const *)
-  | (TIdent (s, i1)::(Tconst _|Tvolatile _|Trestrict _)::_ , _ ) 
-      when not_struct_enum before 
+  | (TIdent (s, i1)::(Tconst _|Tvolatile _|Trestrict _)::_ , _ )
+      when not_struct_enum before
       && ok_typedef s
       (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
       ->
@@ -1421,8 +1421,8 @@ let lookahead2 ~pass next before =
 
 
   (* xx * const *)
-  | (TIdent (s, i1)::TMul _::(Tconst _ | Tvolatile _|Trestrict _)::_ , _ ) 
-      when not_struct_enum before 
+  | (TIdent (s, i1)::TMul _::(Tconst _ | Tvolatile _|Trestrict _)::_ , _ )
+      when not_struct_enum before
       && ok_typedef s
       ->
       (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
@@ -1436,14 +1436,14 @@ let lookahead2 ~pass next before =
       ok_typedef s ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
-      
+
 
 
   (* ( xx ) [sizeof, ~] *)
   | (TIdent (s, i1)::TCPar _::(Tsizeof _|TTilde _)::_ ,     TOPar _::_ )
     when not_struct_enum before
       && ok_typedef s
-    -> 
+    ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
@@ -1451,31 +1451,31 @@ let lookahead2 ~pass next before =
   | (TIdent (s, i1)::TOCro _::_, (TComma _ |TOPar _)::_)
       when (LP.current_context() =*= LP.InParameter)
       && ok_typedef s
-     -> 
+     ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
-        
+
   (*------------------------------------------------------------*)
   (* if 'x*y' maybe an expr, maybe just a classic multiplication *)
   (* but if have a '=', or ','   I think not *)
   (*------------------------------------------------------------*)
 
   (* static xx * yy  *)
-  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::_ , 
+  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::_ ,
      (Tregister _|Tstatic _  |Tvolatile _|Tconst _|Trestrict _)::_) when
-      ok_typedef s 
+      ok_typedef s
         ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
-        
+
   (*  TODO  xx * yy ; AND in start of compound element  *)
 
 
   (*  xx * yy,      AND  in paramdecl *)
   | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TComma _::_ , _)
     when not_struct_enum before && (LP.current_context() =*= LP.InParameter)
-      && ok_typedef s 
-      -> 
+      && ok_typedef s
+      ->
 
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
@@ -1486,46 +1486,46 @@ let lookahead2 ~pass next before =
       TIdent (s, i1)
   | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TPtVirg _::_ , _)
     when not_struct_enum before && (LP.is_top_or_struct (LP.current_context ()))
-      -> 
+      ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
   (*  xx * yy ,     AND in Toplevel  *)
   | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TComma _::_ , _)
     when not_struct_enum before && (LP.current_context () =*= LP.InTopLevel)
-      && ok_typedef s 
-      -> 
+      && ok_typedef s
+      ->
 
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
   (*  xx * yy (     AND in Toplevel  *)
   | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TOPar _::_ , _)
-    when not_struct_enum before 
+    when not_struct_enum before
       && (LP.is_top_or_struct (LP.current_context ()))
-      && ok_typedef s 
+      && ok_typedef s
       ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
-        
+
   (* xx * yy [ *)
   (* todo? enough ? cos in struct def we can have some expression ! *)
   | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TOCro _::_ , _)
-    when not_struct_enum before && 
+    when not_struct_enum before &&
       (LP.is_top_or_struct (LP.current_context ()))
-      && ok_typedef s 
-      -> 
+      && ok_typedef s
+      ->
       msg_typedef s;  LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
   (* u16: 10; in struct *)
   | (TIdent (s, i1)::TDotDot _::_ , (TOBrace _ | TPtVirg _)::_)
     when       (LP.is_top_or_struct (LP.current_context ()))
-      && ok_typedef s 
-      -> 
+      && ok_typedef s
+      ->
       msg_typedef s;  LP.add_typedef_root s;
       TypedefIdent (s, i1)
-        
+
 
     (*  why need TOPar condition as stated in preceding rule ? really needed ? *)
     (*   YES cos at toplevel can have some expression !! for instance when *)
@@ -1535,16 +1535,16 @@ let lookahead2 ~pass next before =
       when (take_safe 1 !passed_tok <> [Tstruct] &&
       (take_safe 1 !passed_tok <> [Tenum]))
       &&
-      !LP._lexer_hint = Some LP.Toplevel -> 
-      msg_typedef s; 
+      !LP._lexer_hint = Some LP.Toplevel ->
+      msg_typedef s;
       LP.add_typedef_root s;
       TypedefIdent s
      *)
 
   (*  xx * yy =  *)
   | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TEq _::_ , _)
-    when not_struct_enum before 
-      && ok_typedef s 
+    when not_struct_enum before
+      && ok_typedef s
       ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
@@ -1553,16 +1553,16 @@ let lookahead2 ~pass next before =
   (*  xx * yy)      AND in paramdecl *)
   | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TCPar _::_ , _)
       when not_struct_enum before && (LP.current_context () =*= LP.InParameter)
-      && ok_typedef s 
+      && ok_typedef s
         ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
-          
+
 
   (*  xx * yy; *) (* wrong ? *)
-  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TPtVirg _::_ , 
-     (TOBrace _| TPtVirg _)::_)  when not_struct_enum before 
-      && ok_typedef s 
+  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TPtVirg _::_ ,
+     (TOBrace _| TPtVirg _)::_)  when not_struct_enum before
+      && ok_typedef s
         ->
       msg_typedef s;  LP.add_typedef_root s;
       msg_maybe_dangereous_typedef s;
@@ -1570,20 +1570,20 @@ let lookahead2 ~pass next before =
 
 
   (*  xx * yy,  and ';' before xx *) (* wrong ? *)
-  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TComma _::_ , 
+  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::TComma _::_ ,
      (TOBrace _| TPtVirg _)::_) when
-      ok_typedef s 
+      ok_typedef s
     ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
 
   (* xx_t * yy *)
-  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::_ , _)  
-      when s ==~ regexp_typedef && not_struct_enum before 
-        (* struct user_info_t sometimes *) 
-      && ok_typedef s 
-        -> 
+  | (TIdent (s, i1)::TMul _::TIdent (s2, i2)::_ , _)
+      when s ==~ regexp_typedef && not_struct_enum before
+        (* struct user_info_t sometimes *)
+      && ok_typedef s
+        ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
@@ -1591,15 +1591,15 @@ let lookahead2 ~pass next before =
   | (TIdent (s, i1)::TMul _::TMul _::TIdent (s2, i2)::_ , _)
     when not_struct_enum before
         (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
-      && ok_typedef s 
+      && ok_typedef s
       ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
   (* xx *** yy *)
   | (TIdent (s, i1)::TMul _::TMul _::TMul _::TIdent (s2, i2)::_ , _)
-    when not_struct_enum before 
-      && ok_typedef s 
+    when not_struct_enum before
+      && ok_typedef s
         (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
       ->
       msg_typedef s; LP.add_typedef_root s;
@@ -1607,9 +1607,9 @@ let lookahead2 ~pass next before =
 
   (*  xx ** ) *)
   | (TIdent (s, i1)::TMul _::TMul _::TCPar _::_ , _)
-    when not_struct_enum before  
+    when not_struct_enum before
         (* && !LP._lexer_hint = Some LP.ParameterDeclaration *)
-      && ok_typedef s 
+      && ok_typedef s
       ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
@@ -1617,41 +1617,41 @@ let lookahead2 ~pass next before =
 
 
   (* ----------------------------------- *)
-  (* old: why not do like for other rules and start with TIdent ? 
+  (* old: why not do like for other rules and start with TIdent ?
    * why do TOPar :: TIdent :: ..., _  and not TIdent :: ...,  TOPAr::_ ?
    * new: prefer now start with TIdent because otherwise the add_typedef_root
    * may have no effect if in second pass or if have disable the add_typedef.
    *)
 
   (*  (xx) yy *)
-  | (TIdent (s, i1)::TCPar i2::(TIdent (_,i3)|TInt (_,i3))::_ , 
-    (TOPar info)::x::_)  
+  | (TIdent (s, i1)::TCPar i2::(TIdent (_,i3)|TInt (_,i3))::_ ,
+    (TOPar info)::x::_)
     when not (TH.is_stuff_taking_parenthized x) &&
       Ast_c.line_of_info i2 =|= Ast_c.line_of_info i3
-      && ok_typedef s 
-      -> 
+      && ok_typedef s
+      ->
 
       msg_typedef s; LP.add_typedef_root s;
       (*TOPar info*)
       TypedefIdent (s, i1)
 
 
-  (* (xx) (    yy) 
+  (* (xx) (    yy)
    * but false positif: typedef int (xxx_t)(...), so do specialisation below.
    *)
   (*
-  | (TIdent (s, i1)::TCPar _::TOPar _::_ , (TOPar info)::x::_)  
-    when not (TH.is_stuff_taking_parenthized x)  
-      && ok_typedef s 
+  | (TIdent (s, i1)::TCPar _::TOPar _::_ , (TOPar info)::x::_)
+    when not (TH.is_stuff_taking_parenthized x)
+      && ok_typedef s
         ->
       msg_typedef s; LP.add_typedef_root s;
       (* TOPar info *)
       TypedefIdent (s, i1)
   *)
   (* special case:  = (xx) (    yy) *)
-  | (TIdent (s, i1)::TCPar _::TOPar _::_ , 
+  | (TIdent (s, i1)::TCPar _::TOPar _::_ ,
     (TOPar info)::(TEq _ |TEqEq _)::_)
-    when ok_typedef s 
+    when ok_typedef s
         ->
       msg_typedef s; LP.add_typedef_root s;
       (* TOPar info *)
@@ -1659,26 +1659,26 @@ let lookahead2 ~pass next before =
 
 
   (*  (xx * ) yy *)
-  | (TIdent (s, i1)::TMul _::TCPar _::TIdent (s2, i2)::_ , (TOPar info)::_) when 
-      ok_typedef s 
-        -> 
+  | (TIdent (s, i1)::TMul _::TCPar _::TIdent (s2, i2)::_ , (TOPar info)::_) when
+      ok_typedef s
+        ->
       msg_typedef s; LP.add_typedef_root s;
       (*TOPar info*)
       TypedefIdent (s,i1)
 
 
   (* (xx){ ... }  constructor *)
-  | (TIdent (s, i1)::TCPar _::TOBrace _::_ , TOPar _::x::_)  
-      when (*s ==~ regexp_typedef && *) not (TH.is_stuff_taking_parenthized x) 
-      && ok_typedef s 
+  | (TIdent (s, i1)::TCPar _::TOBrace _::_ , TOPar _::x::_)
+      when (*s ==~ regexp_typedef && *) not (TH.is_stuff_taking_parenthized x)
+      && ok_typedef s
         ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
 
         (* can have sizeof on expression
-           | (Tsizeof::TOPar::TIdent s::TCPar::_,   _) -> 
-           msg_typedef s; 
+           | (Tsizeof::TOPar::TIdent s::TCPar::_,   _) ->
+           msg_typedef s;
            LP.add_typedef_root s;
            Tsizeof
          *)
@@ -1686,17 +1686,17 @@ let lookahead2 ~pass next before =
 
   (* ----------------------------------- *)
   (* x ( *y )(params),  function pointer *)
-  | (TIdent (s, i1)::TOPar _::TMul _::TIdent _::TCPar _::TOPar _::_,  _) 
+  | (TIdent (s, i1)::TOPar _::TMul _::TIdent _::TCPar _::TOPar _::_,  _)
       when not_struct_enum before
-      && ok_typedef s 
+      && ok_typedef s
         ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
 
   (* x* ( *y )(params),  function pointer 2 *)
-  | (TIdent (s, i1)::TMul _::TOPar _::TMul _::TIdent _::TCPar _::TOPar _::_,  _) 
+  | (TIdent (s, i1)::TMul _::TOPar _::TMul _::TIdent _::TCPar _::TOPar _::_,  _)
       when not_struct_enum before
-      && ok_typedef s 
+      && ok_typedef s
         ->
       msg_typedef s; LP.add_typedef_root s;
       TypedefIdent (s, i1)
@@ -1708,32 +1708,32 @@ let lookahead2 ~pass next before =
   | ((TIfdef (_,ii) |TIfdefelse (_,ii) |TIfdefelif (_,ii) |TEndif (_,ii) |
       TIfdefBool (_,_,ii)|TIfdefMisc(_,_,ii)|TIfdefVersion(_,_,ii))
         as x)
-    ::_, _ 
-      -> 
+    ::_, _
+      ->
       (*
-      if not !Flag_parsing_c.ifdef_to_if 
+      if not !Flag_parsing_c.ifdef_to_if
       then TCommentCpp (Ast_c.CppDirective, ii)
-      else 
+      else
       *)
       (* not !LP._lexer_hint.toplevel *)
       if !Flag_parsing_c.ifdef_directive_passing
         || (pass >= 2)
       then begin
-        
+
         if (LP.current_context () =*= LP.InInitializer)
-        then begin 
+        then begin
           pr2_cpp "In Initializer passing"; (* cheat: dont count in stat *)
           incr Stat.nIfdefInitializer;
-        end else begin 
+        end else begin
           pr2_cpp("IFDEF: or related insde function. I treat it as comment");
           incr Stat.nIfdefPassing;
         end;
         TCommentCpp (Token_c.CppDirective, ii)
       end
       else x
-        
-  | (TUndef (id, ii) as x)::_, _ 
-      -> 
+
+  | (TUndef (id, ii) as x)::_, _
+      ->
         if (pass >= 2)
         then begin
           pr2_cpp("UNDEF: I treat it as comment");
@@ -1741,8 +1741,8 @@ let lookahead2 ~pass next before =
         end
         else x
 
-  | (TCppDirectiveOther (ii) as x)::_, _ 
-      -> 
+  | (TCppDirectiveOther (ii) as x)::_, _
+      ->
         if (pass >= 2)
         then begin
           pr2_cpp ("OTHER directive: I treat it as comment");
@@ -1753,19 +1753,19 @@ let lookahead2 ~pass next before =
    (* If ident contain a for_each, then certainly a macro. But to be
     * sure should look if there is a '{' after the ')', but it requires
     * to count the '('. Because this can be expensive, we do that only
-    * when the token contains "for_each". 
+    * when the token contains "for_each".
     *)
-  | (TIdent (s, i1)::TOPar _::rest, _) 
+  | (TIdent (s, i1)::TOPar _::rest, _)
      when not (LP.current_context () =*= LP.InTopLevel)
-      (* otherwise a function such as static void loopback_enable(int i) { 
-       * will be considered as a loop 
+      (* otherwise a function such as static void loopback_enable(int i) {
+       * will be considered as a loop
        *)
         ->
 
- 
-      if s ==~ regexp_foreach && 
+
+      if s ==~ regexp_foreach &&
         is_really_foreach (Common.take_safe forLOOKAHEAD rest)
-   
+
       then begin
         msg_foreach s;
         TMacroIterator (s, i1)
@@ -1773,12 +1773,12 @@ let lookahead2 ~pass next before =
       else TIdent (s, i1)
 
 
-                    
+
  (*-------------------------------------------------------------*)
  | v::xs, _ -> v
  | _ -> raise Impossible
 
-let lookahead ~pass a b = 
+let lookahead ~pass a b =
   Common.profile_code "C parsing.lookahead" (fun () -> lookahead2 ~pass a b)
 
 

--- a/parsing_c/parsing_hacks.mli
+++ b/parsing_c/parsing_hacks.mli
@@ -1,17 +1,17 @@
-open Common 
+open Common
 
 (* This module tries to detect some cpp idioms so that we can parse as-is
- * files by adjusting or commenting some tokens. Parsing hack style. 
+ * files by adjusting or commenting some tokens. Parsing hack style.
  * Sometime we use some indentation information,
  * sometimes we do some kind of lalr(k) by finding patterns. Often try to
  * work on better token representation, like ifdef-paren-ized, brace-ized,
  * paren-ized, so can do easier pattern matching to more easily match
- * complex cpp idiom pattern (cf token_views_c.ml). 
- * We also try to get more contextual information such as whether the 
+ * complex cpp idiom pattern (cf token_views_c.ml).
+ * We also try to get more contextual information such as whether the
  * token is in a initializer as some common patterns have different
  * use depending on context.
- * 
- * 
+ *
+ *
  * Example of cpp idioms:
  *  - if 0 for commenting stuff (not always code, sometimes just real comments)
  *  - ifdef old version
@@ -25,13 +25,13 @@ open Common
  *  - macro no ptvirg
  *  - macro string, and macro function string taking param and ##
  *  - macro attribute
- * 
+ *
  * Cf the TMacroXxx in parser_c.mly and MacroXxx in ast_c.ml
- * 
+ *
  * Also try to infer typedef.
- * 
- * Also do other stuff involving cpp like expanding some macros, 
- * or try parse well define body by finding the end of define virtual 
+ *
+ * Also do other stuff involving cpp like expanding some macros,
+ * or try parse well define body by finding the end of define virtual
  * end-of-line token. But now most of the code is actually in cpp_token_c.ml
  * It is related to what is in the yacfe configuration file (e.g. standard.h)
  *)
@@ -45,18 +45,18 @@ val regexp_typedef: Str.regexp
 (* can reset this global *)
 val ifdef_paren_cnt: int ref
 
-val filter_cpp_stuff : 
+val filter_cpp_stuff :
   Token_views_c.token_extended list -> Token_views_c.token_extended list
-val insert_virtual_positions: 
+val insert_virtual_positions:
   Parser_c.token list -> Parser_c.token list
 
-val fix_tokens_cpp : 
+val fix_tokens_cpp :
   macro_defs:(string, Cpp_token_c.define_def) Hashtbl.t ->
   Parser_c.token list -> Parser_c.token list
 
 (* next stream tokens -> passed stream tokens -> final next token *)
-val lookahead : 
-  pass:int -> 
+val lookahead :
+  pass:int ->
   Parser_c.token list -> Parser_c.token list -> Parser_c.token
 
 

--- a/parsing_c/parsing_stat.ml
+++ b/parsing_c/parsing_stat.ml
@@ -1,18 +1,18 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2008, 2009 University of Urbana Champaign
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
  *)
 
-open Common 
+open Common
 
 (* if do .mli:
 val print_parsing_stat_list: parsing_stat list -> unit
@@ -25,26 +25,26 @@ type parsing_stat = {
     filename: filename;
     mutable have_timeout: bool;
 
-    mutable correct: int;  
+    mutable correct: int;
     mutable bad: int;
 
     mutable commentized: int; (* by our cpp commentizer *)
 
     (* if want to know exactly what was passed through, uncomment:
-     *  
+     *
      * mutable passing_through_lines: int;
-     * 
+     *
      * it differs from bad by starting from the error to
      * the synchro point instead of starting from start of
      * function to end of function.
      *)
 
-    mutable problematic_lines: 
+    mutable problematic_lines:
       (string list (* ident in error line *) * int (* line_error *)) list;
 
-  } 
+  }
 
-let default_stat file =  { 
+let default_stat file =  {
     filename = file;
     have_timeout = false;
     correct = 0; bad = 0;
@@ -52,46 +52,46 @@ let default_stat file =  {
     problematic_lines = [];
   }
 
-(* todo: stat per dir ?  give in terms of func_or_decl numbers:   
- * nbfunc_or_decl pbs / nbfunc_or_decl total ?/ 
+(* todo: stat per dir ?  give in terms of func_or_decl numbers:
+ * nbfunc_or_decl pbs / nbfunc_or_decl total ?/
  *
- * note: cela dit si y'a des fichiers avec des #ifdef dont on connait pas les 
- * valeurs alors on parsera correctement tout le fichier et pourtant y'aura 
- * aucune def  et donc aucune couverture en fait.   
- * ==> TODO evaluer les parties non parsé ? 
+ * note: cela dit si y'a des fichiers avec des #ifdef dont on connait pas les
+ * valeurs alors on parsera correctement tout le fichier et pourtant y'aura
+ * aucune def  et donc aucune couverture en fait.
+ * ==> TODO evaluer les parties non parsé ?
  *)
 
-let print_parsing_stat_list ?(verbose=false) = fun statxs -> 
+let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   let total = List.length statxs in
-  let perfect = 
-    statxs 
-      +> List.filter (function 
+  let perfect =
+    statxs
+      +> List.filter (function
           {have_timeout = false; bad = 0} -> true | _ -> false)
-      +> List.length 
+      +> List.length
   in
 
   if verbose then begin
   pr "\n\n\n---------------------------------------------------------------";
   pr "pbs with files:";
-  statxs 
-    +> List.filter (function 
-      | {have_timeout = true} -> true 
-      | {bad = n} when n > 0 -> true 
+  statxs
+    +> List.filter (function
+      | {have_timeout = true} -> true
+      | {bad = n} when n > 0 -> true
       | _ -> false)
-    +> List.iter (function 
-        {filename = file; have_timeout = timeout; bad = n} -> 
+    +> List.iter (function
+        {filename = file; have_timeout = timeout; bad = n} ->
           pr (file ^ "  " ^ (if timeout then "TIMEOUT" else i_to_s n));
         );
 
   pr "\n\n\n";
   pr "files with lots of tokens passed/commentized:";
   let threshold_passed = 100 in
-  statxs 
-    +> List.filter (function 
+  statxs
+    +> List.filter (function
       | {commentized = n} when n > threshold_passed -> true
       | _ -> false)
-    +> List.iter (function 
-        {filename = file; commentized = n} -> 
+    +> List.iter (function
+        {filename = file; commentized = n} ->
           pr (file ^ "  " ^ (i_to_s n));
         );
 
@@ -101,14 +101,14 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   pr (
   (spf "NB total files = %d; " total) ^
   (spf "perfect = %d; " perfect) ^
-  (spf "pbs = %d; "     (statxs +> List.filter (function 
-      {have_timeout = b; bad = n} when n > 0 -> true | _ -> false) 
+  (spf "pbs = %d; "     (statxs +> List.filter (function
+      {have_timeout = b; bad = n} when n > 0 -> true | _ -> false)
                                +> List.length)) ^
-  (spf "timeout = %d; " (statxs +> List.filter (function 
-      {have_timeout = true; bad = n} -> true | _ -> false) 
+  (spf "timeout = %d; " (statxs +> List.filter (function
+      {have_timeout = true; bad = n} -> true | _ -> false)
                                +> List.length)) ^
   (spf "=========> %d" ((100 * perfect) / total)) ^ "%"
-                                                          
+
   );
   let good = statxs +> List.fold_left (fun acc {correct = x} -> acc+x) 0 in
   let bad  = statxs +> List.fold_left (fun acc {bad = x} -> acc+x) 0  in
@@ -131,57 +131,57 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
 (*****************************************************************************)
 (* asked/inspired by reviewer of CC'09 *)
 
-let lines_around_error_line ~context (file, line) = 
+let lines_around_error_line ~context (file, line) =
   let arr = Common2.cat_array file in
-  
+
   let startl = max 0 (line - context) in
   let endl   = min (Array.length arr) (line + context) in
-  let res = ref [] in 
+  let res = ref [] in
 
-  for i = startl to endl -1 do 
+  for i = startl to endl -1 do
     Common.push arr.(i) res
   done;
   List.rev !res
 
 
 
-let print_recurring_problematic_tokens xs = 
+let print_recurring_problematic_tokens xs =
   let h = Hashtbl.create 101 in
-  xs +> List.iter (fun x -> 
-    let file = x.filename in 
-    x.problematic_lines +> List.iter (fun (xs, line_error) -> 
-      xs +> List.iter (fun s -> 
+  xs +> List.iter (fun x ->
+    let file = x.filename in
+    x.problematic_lines +> List.iter (fun (xs, line_error) ->
+      xs +> List.iter (fun s ->
         Common2.hupdate_default s
-          (fun (old, example)  -> old + 1, example) 
+          (fun (old, example)  -> old + 1, example)
           (fun() -> 0, (file, line_error)) h;
       )));
   Common2.pr2_xxxxxxxxxxxxxxxxx();
   pr2 ("maybe 10 most problematic tokens");
   Common2.pr2_xxxxxxxxxxxxxxxxx();
   Common.hash_to_list h
-  +> List.sort (fun (k1,(v1,_)) (k2,(v2,_)) -> compare v2 v1) 
+  +> List.sort (fun (k1,(v1,_)) (k2,(v2,_)) -> compare v2 v1)
   +> Common.take_safe 10
-  +> List.iter (fun (k,(i, (file_ex, line_ex))) -> 
+  +> List.iter (fun (k,(i, (file_ex, line_ex))) ->
     pr2 (spf "%s: present in %d parsing errors" k i);
     pr2 ("example: ");
     let lines = lines_around_error_line ~context:2 (file_ex, line_ex) in
     lines +> List.iter (fun s -> pr2 ("       " ^ s));
-    
+
   );
   Common2.pr2_xxxxxxxxxxxxxxxxx();
   ()
 
-  
+
 
 
 (*****************************************************************************)
 (* Stat *)
 (*****************************************************************************)
 
-(* Those variables were written for CC09, to evaluate the need for 
+(* Those variables were written for CC09, to evaluate the need for
  * some of our heuristics and extensions.
- * 
- * coupling: if you add a new var, modify also assoc_stat_number below 
+ *
+ * coupling: if you add a new var, modify also assoc_stat_number below
  *)
 
 let nTypedefInfer = ref 0
@@ -189,8 +189,8 @@ let nTypedefInfer = ref 0
 let nIncludeGrammar = ref 0
 let nIncludeHack = ref 0
 
-let nIteratorGrammar = ref 0 
-let nIteratorHeuristic = ref 0 
+let nIteratorGrammar = ref 0
+let nIteratorHeuristic = ref 0
 
 let nMacroTopDecl = ref 0
 let nMacroStructDecl = ref 0
@@ -263,7 +263,7 @@ let nMacroExpand = ref 0
 
 let nNotParsedCorrectly = ref 0
 
-let assoc_stat_number = 
+let assoc_stat_number =
   [
     "nTypedefInfer", nTypedefInfer;
 
@@ -338,7 +338,7 @@ let assoc_stat_number =
     "nIteratorGrammar", nIteratorGrammar;
   ]
 
-let print_stat_numbers () = 
-  assoc_stat_number +> List.iter (fun (k, vref) -> 
+let print_stat_numbers () =
+  assoc_stat_number +> List.iter (fun (k, vref) ->
     pr2 (spf "%-30s -> %d" k !vref);
   )

--- a/parsing_c/parsing_stat.mli
+++ b/parsing_c/parsing_stat.mli
@@ -4,14 +4,14 @@ type parsing_stat = {
   mutable correct : int;
   mutable bad : int;
   mutable commentized : int;
-  mutable problematic_lines : 
+  mutable problematic_lines :
       (string list (* ident in error line *) * int (* line_error *)) list;
 }
 val default_stat : Common.filename -> parsing_stat
 
-val print_parsing_stat_list : ?verbose:bool -> 
+val print_parsing_stat_list : ?verbose:bool ->
   parsing_stat list -> unit
-val print_recurring_problematic_tokens: 
+val print_recurring_problematic_tokens:
   parsing_stat list -> unit
 
 

--- a/parsing_c/pretty_print_c.ml
+++ b/parsing_c/pretty_print_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau, Julia Lawall
- * 
+ *
  * Copyright (C) 2006, 2007, 2008, 2009 Ecole des Mines de Nantes and DIKU
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -68,84 +68,84 @@ module F = Control_flow_c
 let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
   let start_block () = pr_nl(); pr_indent() in
   let end_block   () = pr_unindent(); pr_nl() in
-  
+
   let indent_if_needed (s,_) f =
     match s with
       Compound _ -> pr_space(); f()
     | _ ->
         (*no newline at the end - someone else will do that*)
 	start_block(); f(); pr_unindent() in
-  
-  let rec pp_expression = fun ((exp, typ), ii) -> 
+
+  let rec pp_expression = fun ((exp, typ), ii) ->
     (match exp, ii with
     | Ident (ident),         []     -> pp_name ident
     (* only a MultiString can have multiple ii *)
     | Constant (MultiString _), is     -> is +> List.iter pr_elem
-    | Constant (c),         [i]     -> pr_elem i 
-    | FunCall  (e, es),     [i1;i2] -> 
-        pp_expression e; pr_elem i1; 
+    | Constant (c),         [i]     -> pr_elem i
+    | FunCall  (e, es),     [i1;i2] ->
+        pp_expression e; pr_elem i1;
 	pp_arg_list es;
         pr_elem i2;
-        
-    | CondExpr (e1, e2, e3),    [i1;i2]    -> 
+
+    | CondExpr (e1, e2, e3),    [i1;i2]    ->
         pp_expression e1; pr_space(); pr_elem i1; pr_space();
-	do_option (function x -> pp_expression x; pr_space()) e2; pr_elem i2; 
+	do_option (function x -> pp_expression x; pr_space()) e2; pr_elem i2;
         pp_expression e3
-    | Sequence (e1, e2),          [i]  -> 
+    | Sequence (e1, e2),          [i]  ->
         pp_expression e1; pr_elem i; pr_space(); pp_expression e2
-    | Assignment (e1, op, e2),    [i]  -> 
+    | Assignment (e1, op, e2),    [i]  ->
         pp_expression e1; pr_space(); pr_elem i; pr_space(); pp_expression e2
-          
+
     | Postfix  (e, op),    [i] -> pp_expression e; pr_elem i;
     | Infix    (e, op),    [i] -> pr_elem i; pp_expression e;
     | Unary    (e, op),    [i] -> pr_elem i; pp_expression e
-    | Binary   (e1, op, e2),    [i] -> 
+    | Binary   (e1, op, e2),    [i] ->
         pp_expression e1; pr_space(); pr_elem i; pr_space(); pp_expression e2
-          
-    | ArrayAccess    (e1, e2),   [i1;i2] -> 
+
+    | ArrayAccess    (e1, e2),   [i1;i2] ->
         pp_expression e1; pr_elem i1; pp_expression e2; pr_elem i2
-    | RecordAccess   (e, name),     [i1] -> 
+    | RecordAccess   (e, name),     [i1] ->
         pp_expression e; pr_elem i1; pp_name name;
-    | RecordPtAccess (e, name),     [i1] -> 
+    | RecordPtAccess (e, name),     [i1] ->
         pp_expression e; pr_elem i1; pp_name name;
-	  
+
     | SizeOfExpr  (e),     [i] -> pr_elem i; pp_expression e
-    | SizeOfType  (t),     [i1;i2;i3] -> 
+    | SizeOfType  (t),     [i1;i2;i3] ->
         pr_elem i1; pr_elem i2; pp_type t; pr_elem i3
-    | Cast    (t, e),      [i1;i2] -> 
+    | Cast    (t, e),      [i1;i2] ->
         pr_elem i1; pp_type t; pr_elem i2; pp_expression e
-	  
-    | StatementExpr (statxs, [ii1;ii2]),  [i1;i2] -> 
+
+    | StatementExpr (statxs, [ii1;ii2]),  [i1;i2] ->
         pr_elem i1;
         pr_elem ii1;
         statxs +> List.iter pp_statement_seq;
         pr_elem ii2;
         pr_elem i2;
-    | Constructor (t, xs), lp::rp::i1::i2::iicommaopt -> 
+    | Constructor (t, xs), lp::rp::i1::i2::iicommaopt ->
         pr_elem lp;
         pp_type t;
         pr_elem rp;
         pr_elem i1;
-        xs +> List.iter (fun (x, ii) -> 
+        xs +> List.iter (fun (x, ii) ->
           assert (List.length ii <= 1);
           ii +> List.iter (function x -> pr_elem x; pr_space());
           pp_init x
         );
         iicommaopt +> List.iter pr_elem;
         pr_elem i2;
-	
+
     | ParenExpr (e), [i1;i2] -> pr_elem i1; pp_expression e; pr_elem i2;
-	
-    | (Ident (_) | Constant _ | FunCall (_,_) | CondExpr (_,_,_) 
+
+    | (Ident (_) | Constant _ | FunCall (_,_) | CondExpr (_,_,_)
     | Sequence (_,_)
-    | Assignment (_,_,_) 
+    | Assignment (_,_,_)
     | Postfix (_,_) | Infix (_,_) | Unary (_,_) | Binary (_,_,_)
     | ArrayAccess (_,_) | RecordAccess (_,_) | RecordPtAccess (_,_)
-    | SizeOfExpr (_) | SizeOfType (_) | Cast (_,_) 
+    | SizeOfExpr (_) | SizeOfType (_) | Cast (_,_)
     | StatementExpr (_) | Constructor _
     | ParenExpr (_)),_ -> raise Impossible
     );
-    
+
     if !Flag_parsing_c.pretty_print_type_info
     then begin
       pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "/*");
@@ -159,39 +159,39 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 	    pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str s)));
       pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "*/");
     end
-	
+
   and pp_arg_list es =
-    es +> List.iter (fun (e, opt) -> 
+    es +> List.iter (fun (e, opt) ->
       assert (List.length opt <= 1); (* opt must be a comma? *)
       opt +> List.iter (function x -> pr_elem x; pr_space());
       pp_argument e)
-      
-  and pp_argument argument = 
+
+  and pp_argument argument =
     let rec pp_action (ActMisc ii) = ii +> List.iter pr_elem in
     match argument with
     | Left e -> pp_expression e
-    | Right weird -> 
+    | Right weird ->
 	(match weird with
 	| ArgType param -> pp_param param
 	| ArgAction action -> pp_action action)
-	  
+
 (* ---------------------- *)
   and pp_name = function
-    | RegularName (s, ii) -> 
+    | RegularName (s, ii) ->
         let (i1) = Common2.tuple_of_list1 ii in
         pr_elem i1
-    | CppConcatenatedName xs -> 
-        xs +> List.iter (fun ((x,ii1), ii2) -> 
+    | CppConcatenatedName xs ->
+        xs +> List.iter (fun ((x,ii1), ii2) ->
           ii2 +> List.iter pr_elem;
           ii1 +> List.iter pr_elem;
         )
-    | CppVariadicName (s, ii) -> 
+    | CppVariadicName (s, ii) ->
         ii +> List.iter pr_elem
-    | CppIdentBuilder ((s,iis), xs) -> 
+    | CppIdentBuilder ((s,iis), xs) ->
         let (iis, iop, icp) = Common2.tuple_of_list3 iis in
         pr_elem iis;
         pr_elem iop;
-        xs +> List.iter (fun ((x,iix), iicomma) -> 
+        xs +> List.iter (fun ((x,iix), iicomma) ->
           iicomma +> List.iter pr_elem;
           iix +> List.iter pr_elem;
         );
@@ -202,11 +202,11 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
     | Labeled (Label (name, st)), ii ->
         let (i2) = Common2.tuple_of_list1 ii in
 	pr_outdent(); pp_name name; pr_elem i2; pr_nl(); pp_statement st
-    | Labeled (Case  (e, st)), [i1;i2] -> 
+    | Labeled (Case  (e, st)), [i1;i2] ->
 	pr_unindent();
         pr_elem i1; pp_expression e; pr_elem i2; pr_nl(); pr_indent();
 	pp_statement st
-    | Labeled (CaseRange  (e, e2, st)), [i1;i2;i3] -> 
+    | Labeled (CaseRange  (e, e2, st)), [i1;i2;i3] ->
 	pr_unindent();
         pr_elem i1; pp_expression e; pr_elem i2; pp_expression e2; pr_elem i3;
 	pr_nl(); pr_indent();
@@ -214,18 +214,18 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
     | Labeled (Default st), [i1;i2] ->
 	pr_unindent(); pr_elem i1; pr_elem i2; pr_nl(); pr_indent();
 	pp_statement st
-    | Compound statxs, [i1;i2] -> 
+    | Compound statxs, [i1;i2] ->
         pr_elem i1; start_block();
         statxs +> Common2.print_between pr_nl pp_statement_seq;
         end_block(); pr_elem i2;
-        
+
     | ExprStatement (None), [i] -> pr_elem i;
     | ExprStatement (None), [] -> ()
     | ExprStatement (Some e), [i] -> pp_expression e; pr_elem i
         (* the last ExprStatement of a for does not have a trailing
            ';' hence the [] for ii *)
-    | ExprStatement (Some e), [] -> pp_expression e; 
-    | Selection  (If (e, st1, st2)), i1::i2::i3::is -> 
+    | ExprStatement (Some e), [] -> pp_expression e;
+    | Selection  (If (e, st1, st2)), i1::i2::i3::is ->
         pr_elem i1; pr_space(); pr_elem i2; pp_expression e; pr_elem i3;
 	indent_if_needed st1 (function _ -> pp_statement st1);
         (match (st2, is) with
@@ -236,23 +236,23 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 	    pr_elem iifakend
         | x -> raise Impossible
         )
-    | Selection  (Switch (e, st)), [i1;i2;i3;iifakend] -> 
+    | Selection  (Switch (e, st)), [i1;i2;i3;iifakend] ->
         pr_elem i1; pr_space(); pr_elem i2; pp_expression e; pr_elem i3;
 	indent_if_needed st (function _-> pp_statement st); pr_elem iifakend
-    | Iteration  (While (e, st)), [i1;i2;i3;iifakend] -> 
+    | Iteration  (While (e, st)), [i1;i2;i3;iifakend] ->
         pr_elem i1; pr_space(); pr_elem i2; pp_expression e; pr_elem i3;
 	indent_if_needed st (function _-> pp_statement st); pr_elem iifakend
-    | Iteration  (DoWhile (st, e)), [i1;i2;i3;i4;i5;iifakend] -> 
+    | Iteration  (DoWhile (st, e)), [i1;i2;i3;i4;i5;iifakend] ->
         pr_elem i1;
 	indent_if_needed st (function _ -> pp_statement st);
-	pr_elem i2; pr_elem i3; pp_expression e; 
+	pr_elem i2; pr_elem i3; pp_expression e;
         pr_elem i4; pr_elem i5;
         pr_elem iifakend
-          
-          
+
+
     | Iteration  (For ((e1opt,il1),(e2opt,il2),(e3opt, il3),st)),
         [i1;i2;i3;iifakend] ->
-	  
+
           pr_elem i1; pr_space();
           pr_elem i2;
           pp_statement (ExprStatement e1opt, il1);
@@ -262,108 +262,108 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
           pr_elem i3;
           indent_if_needed st (function _ -> pp_statement st);
           pr_elem iifakend
-	    
+
     | Iteration  (MacroIteration (s,es,st)), [i1;i2;i3;iifakend] ->
         pr_elem i1; pr_space();
         pr_elem i2;
-	
-        es +> List.iter (fun (e, opt) -> 
+
+        es +> List.iter (fun (e, opt) ->
           assert (List.length opt <= 1);
           opt +> List.iter pr_elem;
           pp_argument e;
         );
-	
+
         pr_elem i3;
         indent_if_needed st (function _ -> pp_statement st);
         pr_elem iifakend
-          
-    | Jump (Goto name), ii               -> 
+
+    | Jump (Goto name), ii               ->
         let (i1, i3) = Common2.tuple_of_list2 ii in
         pr_elem i1; pr_space(); pp_name name; pr_elem i3;
     | Jump ((Continue|Break|Return)), [i1;i2] -> pr_elem i1; pr_elem i2;
     | Jump (ReturnExpr e), [i1;i2] ->
 	pr_elem i1; pr_space(); pp_expression e; pr_elem i2
-    | Jump (GotoComputed e), [i1;i2;i3] -> 
+    | Jump (GotoComputed e), [i1;i2;i3] ->
         pr_elem i1; pr_elem i2; pp_expression e; pr_elem i3
-	  
+
     | Decl decl, [] -> pp_decl decl
-    | Asm asmbody, ii -> 
+    | Asm asmbody, ii ->
         (match ii with
-        | [iasm;iopar;icpar;iptvirg] -> 
+        | [iasm;iopar;icpar;iptvirg] ->
             pr_elem iasm; pr_elem iopar;
             pp_asmbody asmbody;
             pr_elem icpar; pr_elem iptvirg
-        | [iasm;ivolatile;iopar;icpar;iptvirg] -> 
-            pr_elem iasm; pr_elem ivolatile; pr_elem iopar; 
+        | [iasm;ivolatile;iopar;icpar;iptvirg] ->
+            pr_elem iasm; pr_elem ivolatile; pr_elem iopar;
             pp_asmbody asmbody;
             pr_elem icpar; pr_elem iptvirg
         | _ -> raise Impossible
         )
-	  
-    | NestedFunc def, ii -> 
+
+    | NestedFunc def, ii ->
         assert (null ii);
         pp_def def
-    | MacroStmt, ii -> 
+    | MacroStmt, ii ->
         ii +> List.iter pr_elem ;
-	
-    | (Labeled (Case  (_,_)) 
+
+    | (Labeled (Case  (_,_))
     | Labeled (CaseRange  (_,_,_)) | Labeled (Default _)
-    | Compound _ | ExprStatement _ 
+    | Compound _ | ExprStatement _
     | Selection  (If (_, _, _)) | Selection  (Switch (_, _))
-    | Iteration  (While (_, _)) | Iteration  (DoWhile (_, _)) 
+    | Iteration  (While (_, _)) | Iteration  (DoWhile (_, _))
     | Iteration  (For ((_,_), (_,_), (_, _), _))
     | Iteration  (MacroIteration (_,_,_))
     | Jump ((Continue|Break|Return)) | Jump (ReturnExpr _)
     | Jump (GotoComputed _)
-    | Decl _ 
+    | Decl _
 	), _ -> raise Impossible
-	    
+
   and pp_statement_seq = function
     | StmtElem st -> pp_statement st
     | IfdefStmt ifdef -> pp_ifdef ifdef
     | CppDirectiveStmt cpp -> pp_directive cpp
     | IfdefStmt2 (ifdef, xxs) -> pp_ifdef_tree_sequence ifdef xxs
-	  
+
 (* ifdef XXX elsif YYY elsif ZZZ endif *)
-  and pp_ifdef_tree_sequence ifdef xxs = 
+  and pp_ifdef_tree_sequence ifdef xxs =
     match ifdef with
-    | if1::ifxs -> 
+    | if1::ifxs ->
 	pp_ifdef if1;
 	pp_ifdef_tree_sequence_aux  ifxs xxs
     | _ -> raise Impossible
-	  
+
 (* XXX elsif YYY elsif ZZZ endif *)
-  and pp_ifdef_tree_sequence_aux ifdefs xxs = 
-    Common2.zip ifdefs xxs +> List.iter (fun (ifdef, xs) -> 
+  and pp_ifdef_tree_sequence_aux ifdefs xxs =
+    Common2.zip ifdefs xxs +> List.iter (fun (ifdef, xs) ->
       xs +> List.iter pp_statement_seq;
       pp_ifdef ifdef
     )
-	
-	
-	
-	
-	
+
+
+
+
+
 (* ---------------------- *)
-  and pp_asmbody (string_list, colon_list) = 
+  and pp_asmbody (string_list, colon_list) =
     string_list +> List.iter pr_elem ;
-    colon_list +> List.iter (fun (Colon xs, ii) -> 
+    colon_list +> List.iter (fun (Colon xs, ii) ->
       ii +> List.iter pr_elem;
-      xs +> List.iter (fun (x,iicomma) -> 
+      xs +> List.iter (fun (x,iicomma) ->
 	assert ((List.length iicomma) <= 1);
 	iicomma +> List.iter (function x -> pr_elem x; pr_space());
-	(match x with 
+	(match x with
 	| ColonMisc, ii -> ii +> List.iter pr_elem;
-	| ColonExpr e, [istring;iopar;icpar] -> 
+	| ColonExpr e, [istring;iopar;icpar] ->
             pr_elem istring;
             pr_elem iopar;
             pp_expression e;
             pr_elem icpar
 	| (ColonExpr _), _ -> raise Impossible)
         ))
-      
-      
+
+
 (* ---------------------- *)
-      
+
 (*
    pp_type_with_ident
    pp_base_type
@@ -371,41 +371,41 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
    pp_type_left
    pp_type_right
    pp_type
-   
+
    pp_decl
 *)
-  and (pp_type_with_ident: 
-	 (string * info) option -> (storage * il) option -> 
+  and (pp_type_with_ident:
+	 (string * info) option -> (storage * il) option ->
 	   fullType -> attribute list ->
-	     unit) = 
+	     unit) =
     fun ident sto ((qu, iiqu), (ty, iity)) attrs ->
       pp_base_type ((qu, iiqu), (ty, iity))  sto;
       (match (ident,ty) with
 	(Some _,_) | (_,Pointer _) -> pr_space()
       |	_ -> ());
       pp_type_with_ident_rest ident ((qu, iiqu), (ty, iity)) attrs
-	
-	
-  and (pp_base_type: fullType -> (storage * il) option -> unit) = 
-    fun (qu, (ty, iity)) sto -> 
-      let get_sto sto = 
-        match sto with 
+
+
+  and (pp_base_type: fullType -> (storage * il) option -> unit) =
+    fun (qu, (ty, iity)) sto ->
+      let get_sto sto =
+        match sto with
         | None -> [] | Some (s, iis) -> (*assert (List.length iis = 1);*) iis
       in
-      let print_sto_qu (sto, (qu, iiqu)) = 
+      let print_sto_qu (sto, (qu, iiqu)) =
         let all_ii = get_sto sto @ iiqu in
-        all_ii 
+        all_ii
           +> List.sort Ast_c.compare_pos
           +> Common2.print_between pr_space pr_elem
-          
+
       in
-      let print_sto_qu_ty (sto, (qu, iiqu), iity) = 
+      let print_sto_qu_ty (sto, (qu, iiqu), iity) =
         let all_ii = get_sto sto @ iiqu @ iity in
         let all_ii2 = all_ii +> List.sort Ast_c.compare_pos in
-	  
+
         if all_ii <> all_ii2
-        then begin 
-            (* TODO in fact for pointer, the qualifier is after the type 
+        then begin
+            (* TODO in fact for pointer, the qualifier is after the type
              * cf -test strangeorder
              *)
           pr2 "STRANGEORDER";
@@ -413,78 +413,78 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
         end
         else all_ii2 +> Common2.print_between pr_space pr_elem
       in
-	
+
       match ty, iity with
       | (Pointer t, [i])                           -> pp_base_type t sto
       | (ParenType t, _)                           -> pp_base_type t sto
       | (Array (eopt, t), [i1;i2])                 -> pp_base_type t sto
-      | (FunctionType (returnt, paramst), [i1;i2]) -> 
+      | (FunctionType (returnt, paramst), [i1;i2]) ->
           pp_base_type returnt sto
-	      
-	      
-      | (StructUnion (su, sopt, fields),iis) -> 
+
+
+      | (StructUnion (su, sopt, fields),iis) ->
           print_sto_qu (sto, qu);
-	    
+
           (match sopt,iis with
-          | Some s , [i1;i2;i3;i4] -> 
-              pr_elem i1; pr_elem i2; pr_elem i3; 
-          | None, [i1;i2;i3] -> 
-              pr_elem i1; pr_elem i2; 
+          | Some s , [i1;i2;i3;i4] ->
+              pr_elem i1; pr_elem i2; pr_elem i3;
+          | None, [i1;i2;i3] ->
+              pr_elem i1; pr_elem i2;
           | x -> raise Impossible
 	  );
-	    
-          fields +> List.iter 
-            (fun (field) -> 
-		
-              match field with 
+
+          fields +> List.iter
+            (fun (field) ->
+
+              match field with
               | DeclarationField(FieldDeclList(onefield_multivars,iiptvirg))->
                   (match onefield_multivars with
-                  | x::xs -> 
+                  | x::xs ->
                     (* handling the first var. Special case, with the
                        first var, we print the whole type *)
-			
+
 		      (match x with
-		      | (Simple (nameopt, typ)), iivirg -> 
+		      | (Simple (nameopt, typ)), iivirg ->
                         (* first var cant have a preceding ',' *)
-			  assert (List.length iivirg =|= 0); 
-			  let identinfo = 
-                            match nameopt with 
-			    | None -> None 
+			  assert (List.length iivirg =|= 0);
+			  let identinfo =
+                            match nameopt with
+			    | None -> None
                             | Some name -> Some (get_s_and_ii_of_name name)
                           in
 			  pp_type_with_ident identinfo None typ Ast_c.noattr;
-			    
-		      | (BitField (nameopt, typ, iidot, expr)), iivirg -> 
+
+		      | (BitField (nameopt, typ, iidot, expr)), iivirg ->
                       (* first var cant have a preceding ',' *)
-			  assert (List.length iivirg =|= 0); 
+			  assert (List.length iivirg =|= 0);
 			  (match nameopt with
-			  | None -> 
+			  | None ->
 			      pp_type typ;
-			  | Some name -> 
+			  | Some name ->
                               let (s, is) = get_s_and_ii_of_name name in
 			      pp_type_with_ident
 				(Some (s, is)) None typ Ast_c.noattr;
 			  );
                           pr_elem iidot;
 			  pp_expression expr
-                            
+
                       ); (* match x, first onefield_multivars *)
-			
+
                       (* for other vars *)
 		      xs +> List.iter (function
-			| (Simple (nameopt, typ)), iivirg -> 
+			| (Simple (nameopt, typ)), iivirg ->
 			    iivirg +> List.iter pr_elem;
-			    let identinfo = 
-			      match nameopt with 
-			      | None -> None 
+			    let identinfo =
+			      match nameopt with
+			      | None -> None
 			      | Some name -> Some (get_s_and_ii_of_name name)
 			    in
 			    pp_type_with_ident_rest identinfo typ Ast_c.noattr
 
-			| (BitField (nameopt, typ, iidot, expr)), iivirg -> 
+			| (BitField (nameopt, typ, iidot, expr)), iivirg ->
 			    iivirg +> List.iter pr_elem;
 			    (match nameopt with
-			    | Some name -> 
+			    | Some name ->
                                 let (s,is) = get_s_and_ii_of_name name in
 				pp_type_with_ident_rest
 				  (Some (s, is)) typ Ast_c.noattr;
@@ -492,15 +492,15 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 				pp_expression expr
 			    | x -> raise Impossible
 			    )); (* iter other vars *)
-			
+
 		  | [] -> raise Impossible
 		  ); (* onefield_multivars *)
 		  assert (List.length iiptvirg =|= 1);
 		  iiptvirg +> List.iter pr_elem;
-		    
-		    
-	      | MacroDeclField ((s, es), ii)  -> 
-                 let (iis, lp, rp, iiend, ifakestart) = 
+
+
+	      | MacroDeclField ((s, es), ii)  ->
+                 let (iis, lp, rp, iiend, ifakestart) =
                    Common2.tuple_of_list5 ii in
                  (* iis::lp::rp::iiend::ifakestart::iisto
 	         iisto +> List.iter pr_elem; (* static and const *)
@@ -508,77 +508,77 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 	         pr_elem ifakestart;
 	         pr_elem iis;
 	         pr_elem lp;
-	         es +> List.iter (fun (e, opt) -> 
+	         es +> List.iter (fun (e, opt) ->
                    assert (List.length opt <= 1);
                    opt +> List.iter pr_elem;
                    pp_argument e;
 	         );
-	         
+
 	         pr_elem rp;
 	         pr_elem iiend;
 
-		      
-		      
-	      | EmptyField iipttvirg_when_emptyfield -> 
+
+
+	      | EmptyField iipttvirg_when_emptyfield ->
                   pr_elem iipttvirg_when_emptyfield
-		      
+
 	      | CppDirectiveStruct cpp -> pp_directive cpp
 	      | IfdefStruct ifdef -> pp_ifdef ifdef
 	  );
-	    
+
           (match sopt,iis with
           | Some s , [i1;i2;i3;i4] -> pr_elem i4
-          | None, [i1;i2;i3] ->       pr_elem i3; 
+          | None, [i1;i2;i3] ->       pr_elem i3;
           | x -> raise Impossible
 	  );
-	    
-	    
-	    
-      | (Enum  (sopt, enumt), iis) -> 
+
+
+
+      | (Enum  (sopt, enumt), iis) ->
           print_sto_qu (sto, qu);
-	    
+
           (match sopt, iis with
-          | (Some s, ([i1;i2;i3;i4]|[i1;i2;i3;i4;_])) -> 
+          | (Some s, ([i1;i2;i3;i4]|[i1;i2;i3;i4;_])) ->
               pr_elem i1; pr_elem i2; pr_elem i3;
-          | (None, ([i1;i2;i3]|[i1;i2;i3;_])) -> 
+          | (None, ([i1;i2;i3]|[i1;i2;i3;_])) ->
               pr_elem i1; pr_elem i2
           | x -> raise Impossible
 	  );
-	    
-          enumt +> List.iter (fun ((name, eopt), iicomma) -> 
+
+          enumt +> List.iter (fun ((name, eopt), iicomma) ->
             assert (List.length iicomma <= 1);
             iicomma +> List.iter (function x -> pr_elem x; pr_space());
             pp_name name;
-            eopt +> Common.do_option (fun (ieq, e) -> 
+            eopt +> Common.do_option (fun (ieq, e) ->
               pr_elem ieq;
               pp_expression e;
 	  ));
-	    
+
           (match sopt, iis with
           | (Some s, [i1;i2;i3;i4]) ->    pr_elem i4
-          | (Some s, [i1;i2;i3;i4;i5]) -> 
+          | (Some s, [i1;i2;i3;i4;i5]) ->
               pr_elem i5; pr_elem i4 (* trailing comma *)
           | (None, [i1;i2;i3]) ->         pr_elem i3
-          | (None, [i1;i2;i3;i4]) ->      
+          | (None, [i1;i2;i3;i4]) ->
               pr_elem i4; pr_elem i3 (* trailing comma *)
-		  
-		  
+
+
           | x -> raise Impossible
 	  );
-	    
-	    
-      | (BaseType _, iis) -> 
+
+
+      | (BaseType _, iis) ->
           print_sto_qu_ty (sto, qu, iis);
-	    
-      | (StructUnionName (s, structunion), iis) -> 
+
+      | (StructUnionName (s, structunion), iis) ->
           assert (List.length iis =|= 2);
           print_sto_qu_ty (sto, qu, iis);
-	    
-      | (EnumName  s, iis) -> 
+
+      | (EnumName  s, iis) ->
           assert (List.length iis =|= 2);
           print_sto_qu_ty (sto, qu, iis);
-	    
-      | (TypeName (name,typ), noii) -> 
+
+      | (TypeName (name,typ), noii) ->
           assert (null noii);
           let (_s, iis) = get_s_and_ii_of_name name in
           print_sto_qu_ty (sto, qu, [iis]);
@@ -586,52 +586,52 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
           if !Flag_parsing_c.pretty_print_typedef_value
           then begin
             pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "{*");
-            typ +> Common.do_option (fun typ -> 
+            typ +> Common.do_option (fun typ ->
                 pp_type typ;
             );
             pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "*}");
           end;
-	    
-      | (TypeOfExpr (e), iis) -> 
+
+      | (TypeOfExpr (e), iis) ->
           print_sto_qu (sto, qu);
           (match iis with
-          | [itypeof;iopar;icpar] -> 
+          | [itypeof;iopar;icpar] ->
               pr_elem itypeof; pr_elem iopar;
               pp_expression e;
               pr_elem icpar;
           | _ -> raise Impossible
           )
-	      
-      | (TypeOfType (t), iis) -> 
+
+      | (TypeOfType (t), iis) ->
           print_sto_qu (sto, qu);
           (match iis with
-          | [itypeof;iopar;icpar] -> 
+          | [itypeof;iopar;icpar] ->
               pr_elem itypeof; pr_elem iopar;
-              pp_type t; 
+              pp_type t;
               pr_elem icpar;
           | _ -> raise Impossible
 	  )
-	      
-      | (Pointer _ | (*ParenType _ |*) Array _ | FunctionType _ 
+
+      | (Pointer _ | (*ParenType _ |*) Array _ | FunctionType _
             (* | StructUnion _ | Enum _ | BaseType _ *)
             (* | StructUnionName _ | EnumName _ | TypeName _  *)
             (* | TypeOfExpr _ | TypeOfType _ *)
          ), _ -> raise Impossible
-		
-      
-      
-(* used because of DeclList, in    int i,*j[23];  we dont print anymore the 
-   int before *j *) 
-  and (pp_type_with_ident_rest: (string * info) option -> 
-    fullType -> attribute list -> unit) = 
-    
-    fun ident (((qu, iiqu), (ty, iity)) as fullt) attrs -> 
-      let print_ident ident = Common.do_option (fun (s, iis) -> 
+
+
+
+(* used because of DeclList, in    int i,*j[23];  we dont print anymore the
+   int before *j *)
+  and (pp_type_with_ident_rest: (string * info) option ->
+    fullType -> attribute list -> unit) =
+
+    fun ident (((qu, iiqu), (ty, iity)) as fullt) attrs ->
+      let print_ident ident = Common.do_option (fun (s, iis) ->
         (* XXX attrs +> pp_attributes pr_elem pr_space; *)
         pr_elem iis
 	) ident
       in
-      
+
       match ty, iity with
       (* the work is to do in base_type !! *)
       | (BaseType _, iis)                       -> print_ident ident
@@ -642,35 +642,35 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
       | (TypeName (_name,_typ), iis)            -> print_ident ident
       | (TypeOfExpr (e), iis)                   -> print_ident ident
       | (TypeOfType (e), iis)                   -> print_ident ident
-	    
-	    
-	    
-      | (Pointer t, [i]) ->  
-          (* subtil:  void ( *done)(int i)   is a Pointer 
+
+
+
+      | (Pointer t, [i]) ->
+          (* subtil:  void ( *done)(int i)   is a Pointer
              (FunctionType (return=void, params=int i) *)
           (*WRONG I THINK, use left & right function *)
           (* bug: pp_type_with_ident_rest None t;      print_ident ident *)
-          pr_elem i; 
+          pr_elem i;
           iiqu +> List.iter pr_elem; (* le const est forcement apres le '*' *)
           pp_type_with_ident_rest ident t attrs;
-	  
-      (* ugly special case ... todo? maybe sufficient in practice *)       
-      | (ParenType (q1, (Pointer (q2, (FunctionType t, ii3))   , 
-                         [ipointer])  ), [i1;i2]) ->  
+
+      (* ugly special case ... todo? maybe sufficient in practice *)
+      | (ParenType (q1, (Pointer (q2, (FunctionType t, ii3))   ,
+                         [ipointer])  ), [i1;i2]) ->
 			   pp_type_left (q2, (FunctionType t, ii3));
 			   pr_elem i1;
 			   pr_elem ipointer;
 			   print_ident ident;
 			   pr_elem i2;
 			   pp_type_right (q2, (FunctionType t, ii3));
-			   
+
       (* another ugly special case *)
-      | (ParenType 
+      | (ParenType
            (q1, (Array (eopt,
-			(q2, (Pointer 
-				(q3, (FunctionType t, iifunc)), 
+			(q2, (Pointer
+				(q3, (FunctionType t, iifunc)),
 			      [ipointer]))),
-		 [iarray1;iarray2])), [i1;i2]) -> 
+		 [iarray1;iarray2])), [i1;i2]) ->
 		   pp_type_left (q3, (FunctionType t, iifunc));
 		   pr_elem i1;
 		   pr_elem ipointer;
@@ -680,148 +680,148 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 		   pr_elem iarray2;
 		   pr_elem i2;
 		   pp_type_right (q3, (FunctionType t, iifunc))
-		     
-		     
-		     
-      | (ParenType t, [i1;i2]) ->  
+
+
+
+      | (ParenType t, [i1;i2]) ->
           pr2 "PB PARENTYPE ZARB, I forget about the ()";
           pp_type_with_ident_rest ident t attrs;
-          
-	  
-      | (Array (eopt, t), [i1;i2]) -> 
+
+
+      | (Array (eopt, t), [i1;i2]) ->
           pp_type_left fullt;
-	  
+
           iiqu +> List.iter pr_elem;
           print_ident ident;
-	  
+
           pp_type_right fullt;
-	  
-	  
-      | (FunctionType (returnt, paramst), [i1;i2]) -> 
+
+
+      | (FunctionType (returnt, paramst), [i1;i2]) ->
           pp_type_left fullt;
-	  
+
           iiqu +> List.iter pr_elem;
           print_ident ident;
-	  
+
           pp_type_right fullt;
-          
-	  
+
+
       | (FunctionType _ | Array _ | ParenType _ | Pointer _), _ ->
 	  raise Impossible
-              
-	      
-  and (pp_type_left: fullType -> unit) = 
-    fun ((qu, iiqu), (ty, iity)) -> 
+
+
+  and (pp_type_left: fullType -> unit) =
+    fun ((qu, iiqu), (ty, iity)) ->
       match ty, iity with
-      | (Pointer t, [i]) ->  
-          pr_elem i; 
+      | (Pointer t, [i]) ->
+          pr_elem i;
           iiqu +> List.iter pr_elem; (* le const est forcement apres le '*' *)
           pp_type_left t
-	    
+
       | (Array (eopt, t), [i1;i2]) -> pp_type_left t
       | (FunctionType (returnt, paramst), [i1;i2]) -> pp_type_left returnt
-	    
+
       | (ParenType t, _) ->  failwith "parenType"
-	    
-	    
-      | (BaseType _, iis)    -> ()    
-      | (Enum  (sopt, enumt), iis) -> ()    
-      | (StructUnion (_, sopt, fields),iis)  -> ()    
-      | (StructUnionName (s, structunion), iis) -> ()    
-      | (EnumName  s, iis) -> ()    
+
+
+      | (BaseType _, iis)    -> ()
+      | (Enum  (sopt, enumt), iis) -> ()
+      | (StructUnion (_, sopt, fields),iis)  -> ()
+      | (StructUnionName (s, structunion), iis) -> ()
+      | (EnumName  s, iis) -> ()
       | (TypeName (_name,_typ), iis) -> ()
-	    
+
       | TypeOfType _, _ -> ()
       | TypeOfExpr _, _ -> ()
-	    
+
       | (FunctionType _ | Array _ | Pointer _), _ -> raise Impossible
 
-      
-  and pp_param param = 
+
+  and pp_param param =
     let {p_namei = nameopt;
          p_register = (b,iib);
          p_type=t;} = param in
-    
+
     iib +> List.iter pr_elem;
 
     match nameopt with
-    | None -> 
+    | None ->
         pp_type t
-    | Some name -> 
+    | Some name ->
         let (s,i1) = get_s_and_ii_of_name name in
 	pp_type_with_ident
           (Some (s, i1)) None t Ast_c.noattr
-          
-        
-	  
-	  
-  and pp_type_right (((qu, iiqu), (ty, iity)) : fullType) = 
+
+
+
+
+  and pp_type_right (((qu, iiqu), (ty, iity)) : fullType) =
     match ty, iity with
     | (Pointer t, [i]) ->  pp_type_right t
-	    
-    | (Array (eopt, t), [i1;i2]) -> 
+
+    | (Array (eopt, t), [i1;i2]) ->
         pr_elem i1;
         eopt +> do_option pp_expression;
         pr_elem i2;
         pp_type_right t
-	    
+
     | (ParenType t, _) ->  failwith "parenType"
-    | (FunctionType (returnt, paramst), [i1;i2]) -> 
+    | (FunctionType (returnt, paramst), [i1;i2]) ->
         pr_elem i1;
         (match paramst with
-        | (ts, (b, iib)) -> 
-            ts +> List.iter (fun (param,iicomma) -> 
+        | (ts, (b, iib)) ->
+            ts +> List.iter (fun (param,iicomma) ->
               assert ((List.length iicomma) <= 1);
               iicomma +> List.iter (function x -> pr_elem x; pr_space());
-                
+
               pp_param param;
 	    );
             iib +> List.iter pr_elem;
         );
         pr_elem i2
-	  
-    | (BaseType _, iis)        -> ()    
-    | (Enum  (sopt, enumt), iis) -> ()    
-    | (StructUnion (_, sopt, fields),iis)-> ()      
-    | (StructUnionName (s, structunion), iis) -> ()    
-    | (EnumName  s, iis) -> ()    
+
+    | (BaseType _, iis)        -> ()
+    | (Enum  (sopt, enumt), iis) -> ()
+    | (StructUnion (_, sopt, fields),iis)-> ()
+    | (StructUnionName (s, structunion), iis) -> ()
+    | (EnumName  s, iis) -> ()
     | (TypeName (name,_typ), iis) -> ()
-	    
+
     | TypeOfType _, _ -> ()
     | TypeOfExpr _, _ -> ()
-	    
+
     | (FunctionType _ | Array _ | Pointer _), _ -> raise Impossible
-      
+
   and pp_type t =
     pp_type_with_ident None None t Ast_c.noattr
-      
+
 (* ---------------------- *)
   and pp_decl = function
-    | DeclList ((({v_namei = var; 
+    | DeclList ((({v_namei = var;
                    v_type = returnType;
-                   v_storage = storage; 
+                   v_storage = storage;
                    v_attr = attrs;
-                  },[])::xs), 
-	       iivirg::ifakestart::iisto) -> 
-	
+                  },[])::xs),
+	       iivirg::ifakestart::iisto) ->
+
 	pr_elem ifakestart;
-		  
+
         (* old: iisto +> List.iter pr_elem; *)
-		  
-	
+
+
         (* handling the first var. Special case, we print the whole type *)
 	(match var with
-	| Some (name, iniopt) -> 
+	| Some (name, iniopt) ->
             let (s,iis) = get_s_and_ii_of_name name in
 	    pp_type_with_ident
 	      (Some (s, iis)) (Some (storage, iisto))
 	      returnType attrs;
-	    iniopt +> do_option (fun (iini, init) -> 
-	      pr_elem iini; 
+	    iniopt +> do_option (fun (iini, init) ->
+	      pr_elem iini;
               pp_init init);
 	| None -> pp_type returnType
 	);
-		  
+
       (* for other vars, we just call pp_type_with_ident_rest. *)
 	xs +> List.iter (function
 	| ({v_namei = Some (name, iniopt);
@@ -829,46 +829,46 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 	    v_storage = storage2;
 	    v_attr = attrs;
 	  }, iivirg) ->
-			 
+
             let (s,iis) = get_s_and_ii_of_name name in
 	    assert (storage2 =*= storage);
 	    iivirg +> List.iter pr_elem;
 	    pp_type_with_ident_rest
 	      (Some (s, iis)) returnType attrs;
-	    iniopt +> do_option (fun (iini, init) -> 
+	    iniopt +> do_option (fun (iini, init) ->
 	      pr_elem iini; pp_init init
             );
-	    
-	    
+
+
 	| x -> raise Impossible
 	);
-	
+
 	pr_elem iivirg;
-	
-    | MacroDecl ((s, es), iis::lp::rp::iiend::ifakestart::iisto) -> 
+
+    | MacroDecl ((s, es), iis::lp::rp::iiend::ifakestart::iisto) ->
 	pr_elem ifakestart;
 	iisto +> List.iter pr_elem; (* static and const *)
 	pr_elem iis;
 	pr_elem lp;
-	es +> List.iter (fun (e, opt) -> 
+	es +> List.iter (fun (e, opt) ->
           assert (List.length opt <= 1);
           opt +> List.iter pr_elem;
           pp_argument e;
 	);
-	
+
 	pr_elem rp;
 	pr_elem iiend;
-	
+
     | (DeclList (_, _) | (MacroDecl _)) -> raise Impossible
-	  
-	  
+
+
 (* ---------------------- *)
 and pp_init (init, iinit) =
   match init, iinit with
       | InitExpr e, [] -> pp_expression e;
-      | InitList xs, i1::i2::iicommaopt -> 
+      | InitList xs, i1::i2::iicommaopt ->
           pr_elem i1; start_block();
-          xs +> List.iter (fun (x, ii) -> 
+          xs +> List.iter (fun (x, ii) ->
             assert (List.length ii <= 1);
             ii +> List.iter (function e -> pr_elem e; pr_nl());
             pp_init x
@@ -876,50 +876,50 @@ and pp_init (init, iinit) =
           iicommaopt +> List.iter pr_elem;
 	  end_block();
           pr_elem i2;
-	  
+
       | InitDesignators (xs, initialiser), [i1] -> (* : *)
           xs +> List.iter pp_designator;
           pr_elem i1;
           pp_init initialiser
-	    
+
     (* no use of '=' in the "Old" style *)
       | InitFieldOld (string, initialiser), [i1;i2] -> (* label:   in oldgcc *)
           pr_elem i1; pr_elem i2; pp_init initialiser
       | InitIndexOld (expression, initialiser), [i1;i2] -> (* [1] in oldgcc *)
-          pr_elem i1; pp_expression expression; pr_elem i2; 
+          pr_elem i1; pp_expression expression; pr_elem i2;
           pp_init initialiser
-	    
-      | (InitIndexOld _ | InitFieldOld _ | InitDesignators _ 
+
+      | (InitIndexOld _ | InitFieldOld _ | InitDesignators _
       | InitList _ | InitExpr _
 	  ), _ -> raise Impossible
-      
-      
-      
+
+
+
   and pp_designator = function
-    | DesignatorField (s), [i1; i2] -> 
-	pr_elem i1; pr_elem i2; 
-    | DesignatorIndex (expression), [i1;i2] -> 
-	pr_elem i1; pp_expression expression; pr_elem i2; 
-	
-    | DesignatorRange (e1, e2), [iocro;iellipsis;iccro] -> 
+    | DesignatorField (s), [i1; i2] ->
+	pr_elem i1; pr_elem i2;
+    | DesignatorIndex (expression), [i1;i2] ->
+	pr_elem i1; pp_expression expression; pr_elem i2;
+
+    | DesignatorRange (e1, e2), [iocro;iellipsis;iccro] ->
 	pr_elem iocro; pp_expression e1; pr_elem iellipsis;
-	pp_expression e2; pr_elem iccro; 
-	
+	pp_expression e2; pr_elem iccro;
+
     | (DesignatorField _ | DesignatorIndex _ | DesignatorRange _
 	), _ -> raise Impossible
-	    
-	    
+
+
 (* ---------------------- *)
   and pp_attributes pr_elem pr_space attrs =
-    attrs +> List.iter (fun (attr, ii) -> 
+    attrs +> List.iter (fun (attr, ii) ->
       ii +> List.iter pr_elem;
     );
-    
+
 (* ---------------------- *)
-  and pp_def def = 
+  and pp_def def =
     let defbis, ii = def in
-    match ii with 
-    | iifunc1::iifunc2::i1::i2::ifakestart::isto -> 
+    match ii with
+    | iifunc1::iifunc2::i1::i2::ifakestart::isto ->
 	let {f_name = name;
              f_type = (returnt, (paramst, (b, iib)));
              f_storage = sto;
@@ -928,114 +928,114 @@ and pp_init (init, iinit) =
 	} = defbis
 	in
         pr_elem ifakestart;
-        
-        pp_type_with_ident None (Some (sto, isto)) 
+
+        pp_type_with_ident None (Some (sto, isto))
           returnt Ast_c.noattr;
-	
+
         pp_attributes pr_elem pr_space attrs;
         pp_name name;
-	
+
         pr_elem iifunc1;
-	
-        (* not anymore, cf tests/optional_name_parameter and 
+
+        (* not anymore, cf tests/optional_name_parameter and
            macro_parameter_shortcut.c
            (match paramst with
-           | [(((bool, None, t), ii_b_s), iicomma)] -> 
-               assert 
-		 (match t with 
+           | [(((bool, None, t), ii_b_s), iicomma)] ->
+               assert
+		 (match t with
 		 | qu, (BaseType Void, ii) -> true
-		 | _ -> true 
+		 | _ -> true
 	       );
                assert (null iicomma);
                assert (null ii_b_s);
                pp_type_with_ident None None t
-           
-           | paramst -> 
+
+           | paramst ->
                paramst +> List.iter (fun (((bool, s, t), ii_b_s), iicomma) ->
 	       iicomma +> List.iter pr_elem;
-           
+
 	       (match b, s, ii_b_s with
-               | false, Some s, [i1] -> 
+               | false, Some s, [i1] ->
 		   pp_type_with_ident (Some (s, i1)) None t;
-               | true, Some s, [i1;i2] -> 
+               | true, Some s, [i1;i2] ->
 		   pr_elem i1;
 		   pp_type_with_ident (Some (s, i2)) None t;
-	   
+
             (* in definition we have name for params, except when f(void) *)
-               | _, None, _ -> raise Impossible 
-               | false, None, [] -> 
-           
+               | _, None, _ -> raise Impossible
+               | false, None, [] ->
+
                | _ -> raise Impossible
            )));
-	   
+
          (* normally ii represent the ",..." but it is also abused
             with the f(void) case *)
          (* assert (List.length iib <= 2);*)
            iib +> List.iter pr_elem;
-	   
+
         *)
-        paramst +> List.iter (fun (param,iicomma) -> 
+        paramst +> List.iter (fun (param,iicomma) ->
           assert ((List.length iicomma) <= 1);
           iicomma +> List.iter (function x -> pr_elem x; pr_space());
-          
+
           pp_param param;
         );
         iib +> List.iter pr_elem;
-        
-	
+
+
         pr_elem iifunc2;
-        pr_elem i1; 
+        pr_elem i1;
         statxs +> List.iter pp_statement_seq;
         pr_elem i2;
     | _ -> raise Impossible
-	  
-	  
-	  
+
+
+
 (* ---------------------- *)
-	  
-  and pp_ifdef ifdef = 
+
+  and pp_ifdef ifdef =
     match ifdef with
-    | IfdefDirective (ifdef, ii) -> 
+    | IfdefDirective (ifdef, ii) ->
 	List.iter pr_elem ii
-	  
-	  
+
+
   and pp_directive = function
-    | Include {i_include = (s, ii);} -> 
+    | Include {i_include = (s, ii);} ->
 	let (i1,i2) = Common2.tuple_of_list2 ii in
 	pr_elem i1; pr_elem i2
-    | Define ((s,ii), (defkind, defval)) -> 
+    | Define ((s,ii), (defkind, defval)) ->
 	let (idefine,iident,ieol) = Common2.tuple_of_list3 ii in
 	pr_elem idefine;
 	pr_elem iident;
-        
+
 	let define_val = function
           | DefineExpr e -> pp_expression e
           | DefineStmt st -> pp_statement st
-          | DefineDoWhileZero ((st,e), ii) -> 
+          | DefineDoWhileZero ((st,e), ii) ->
               (match ii with
-              | [ido;iwhile;iopar;icpar] -> 
+              | [ido;iwhile;iopar;icpar] ->
                   pr_elem ido;
                   pp_statement st;
-                  pr_elem iwhile; pr_elem iopar; 
+                  pr_elem iwhile; pr_elem iopar;
                   pp_expression e;
                   pr_elem icpar
               | _ -> raise Impossible
 	      )
           | DefineFunction def -> pp_def def
-		
+
           | DefineType ty -> pp_type ty
           | DefineText (s, ii) -> List.iter pr_elem ii
           | DefineEmpty -> ()
           | DefineInit ini -> pp_init ini
-		
+
           | DefineTodo -> pr2 "DefineTodo"
 	in
 	(match defkind with
 	| DefineVar -> ()
-	| DefineFunc (params, ii) -> 
+	| DefineFunc (params, ii) ->
             let (i1,i2) = Common2.tuple_of_list2 ii in
-            pr_elem i1; 
-            params +> List.iter (fun ((s,iis), iicomma) -> 
+            pr_elem i1;
+            params +> List.iter (fun ((s,iis), iicomma) ->
               assert (List.length iicomma <= 1);
               iicomma +> List.iter pr_elem;
               iis +> List.iter pr_elem;
@@ -1044,42 +1044,42 @@ and pp_init (init, iinit) =
 	);
 	define_val defval;
 	pr_elem ieol
-          
-    | Undef (s, ii) -> 
+
+    | Undef (s, ii) ->
 	List.iter pr_elem ii
-    | PragmaAndCo (ii) -> 
+    | PragmaAndCo (ii) ->
 	List.iter pr_elem ii in
-	  
-	  
-	  
-	  
+
+
+
+
   let pp_toplevel = function
     | Declaration decl -> pp_decl decl
     | Definition def -> pp_def def
 
-    | CppTop directive -> pp_directive directive 
-	
-	
-    | MacroTop (s, es,   [i1;i2;i3;i4]) -> 
+    | CppTop directive -> pp_directive directive
+
+
+    | MacroTop (s, es,   [i1;i2;i3;i4]) ->
 	pr_elem i1;
 	pr_elem i2;
-	es +> List.iter (fun (e, opt) -> 
+	es +> List.iter (fun (e, opt) ->
           assert (List.length opt <= 1);
           opt +> List.iter pr_elem;
           pp_argument e;
 	);
 	pr_elem i3;
 	pr_elem i4;
-      
-      
+
+
     | EmptyDef ii -> ii +> List.iter pr_elem
-    | NotParsedCorrectly ii -> 
+    | NotParsedCorrectly ii ->
 	assert (List.length ii >= 1);
-	ii +> List.iter pr_elem 
+	ii +> List.iter pr_elem
     | FinalDef info -> pr_elem (Ast_c.rewrap_str "" info)
-	
+
     | IfdefTop ifdefdir -> pp_ifdef ifdefdir
-	
+
     | (MacroTop _) -> raise Impossible in
 
 
@@ -1092,7 +1092,7 @@ and pp_init (init, iinit) =
                      f_storage = stob;
                      f_body = body;
                      f_attr = attrs},ii) ->
-		     
+
 		       assert(null body);
       (*
 	 iif ii;
@@ -1107,25 +1107,25 @@ and pp_init (init, iinit) =
 		       pr2 "Def";
 
 
-    | F.Decl decl -> 
+    | F.Decl decl ->
         (* vk_decl bigf decl *)
-	pr2 "Decl" 
-	
-    | F.ExprStatement (st, (eopt, ii)) ->  
-	pp_statement (ExprStatement eopt, ii) 
-	
-    | F.IfHeader (_, (e,ii)) 
+	pr2 "Decl"
+
+    | F.ExprStatement (st, (eopt, ii)) ->
+	pp_statement (ExprStatement eopt, ii)
+
+    | F.IfHeader (_, (e,ii))
     | F.SwitchHeader (_, (e,ii))
     | F.WhileHeader (_, (e,ii))
-    | F.DoWhileTail (e,ii) -> 
+    | F.DoWhileTail (e,ii) ->
         (*
            iif ii;
            vk_expr bigf e
         *)
 	pr2 "XXX";
-      
-      
-    | F.ForHeader (_st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) -> 
+
+
+    | F.ForHeader (_st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) ->
         (*
            iif i1; iif i2; iif i3;
            iif ii;
@@ -1134,120 +1134,120 @@ and pp_init (init, iinit) =
            e3opt +> do_option (vk_expr bigf);
         *)
 	pr2 "XXX"
-      
-    | F.MacroIterHeader (_s, ((s,es), ii)) -> 
+
+    | F.MacroIterHeader (_s, ((s,es), ii)) ->
         (*
            iif ii;
            vk_argument_list bigf es;
         *)
 	pr2 "XXX"
-      
-      
-    | F.ReturnExpr (_st, (e,ii)) -> 
+
+
+    | F.ReturnExpr (_st, (e,ii)) ->
         (* iif ii; vk_expr bigf e*)
 	pr2 "XXX"
-      
-      
-    | F.Case  (_st, (e,ii)) -> 
+
+
+    | F.Case  (_st, (e,ii)) ->
       (* iif ii; vk_expr bigf e *)
 	pr2 "XXX"
-      
-    | F.CaseRange (_st, ((e1, e2),ii)) -> 
+
+    | F.CaseRange (_st, ((e1, e2),ii)) ->
         (* iif ii; vk_expr bigf e1; vk_expr bigf e2 *)
 	pr2 "XXX"
-      
-      
-      
+
+
+
     | F.CaseNode i -> ()
-	
-    | F.DefineExpr e  -> 
+
+    | F.DefineExpr e  ->
         (* vk_expr bigf e *)
 	pr2 "XXX"
-      
-    | F.DefineType ft  -> 
+
+    | F.DefineType ft  ->
         (* vk_type bigf ft *)
 	pr2 "XXX"
-      
-    | F.DefineHeader ((s,ii), (defkind))  -> 
+
+    | F.DefineHeader ((s,ii), (defkind))  ->
         (*
            iif ii;
            vk_define_kind bigf defkind;
         *)
 	pr2 "XXX"
-      
-      
-    | F.DefineDoWhileZeroHeader (((),ii)) -> 
+
+
+    | F.DefineDoWhileZeroHeader (((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-      
-      
-    | F.Include {i_include = (s, ii);} -> 
+
+
+    | F.Include {i_include = (s, ii);} ->
         (* iif ii; *)
 	pr2 "XXX"
-      
-      
-    | F.MacroTop (s, args, ii) -> 
+
+
+    | F.MacroTop (s, args, ii) ->
         (* iif ii;
            vk_argument_list bigf args *)
 	pr2 "XXX"
-      
-      
-    | F.Break    (st,((),ii)) -> 
+
+
+    | F.Break    (st,((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-    | F.Continue (st,((),ii)) -> 
+    | F.Continue (st,((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-    | F.Default  (st,((),ii)) -> 
+    | F.Default  (st,((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-    | F.Return   (st,((),ii)) -> 
+    | F.Return   (st,((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-    | F.Goto  (st, name, ((),ii)) -> 
+    | F.Goto  (st, name, ((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-    | F.Label (st, name, ((),ii)) -> 
+    | F.Label (st, name, ((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-    | F.EndStatement iopt -> 
+    | F.EndStatement iopt ->
         (* do_option infof iopt *)
 	pr2 "XXX"
-    | F.DoHeader (st, info) -> 
+    | F.DoHeader (st, info) ->
         (* infof info *)
 	pr2 "XXX"
-    | F.Else info -> 
+    | F.Else info ->
         (* infof info *)
 	pr2 "XXX"
-    | F.SeqEnd (i, info) -> 
+    | F.SeqEnd (i, info) ->
         (* infof info *)
 	pr2 "XXX"
-    | F.SeqStart (st, i, info) -> 
+    | F.SeqStart (st, i, info) ->
         (* infof info *)
 	pr2 "XXX"
-      
-    | F.MacroStmt (st, ((),ii)) -> 
+
+    | F.MacroStmt (st, ((),ii)) ->
         (* iif ii *)
 	pr2 "XXX"
-    | F.Asm (st, (asmbody,ii)) -> 
+    | F.Asm (st, (asmbody,ii)) ->
         (*
            iif ii;
            vk_asmbody bigf asmbody
         *)
 	pr2 "XXX"
-      
-      
-    | F.IfdefHeader (info) -> 
+
+
+    | F.IfdefHeader (info) ->
 	pp_ifdef info
-    | F.IfdefElse (info) -> 
+    | F.IfdefElse (info) ->
 	pp_ifdef info
-    | F.IfdefEndif (info) -> 
+    | F.IfdefEndif (info) ->
 	pp_ifdef info
-	
-    | F.DefineTodo -> 
+
+    | F.DefineTodo ->
 	pr2 "XXX"
-      
-      
+
+
     | (F.TopNode|F.EndNode|
       F.ErrorExit|F.Exit|F.Enter|
       F.FallThroughNode|F.AfterNode|F.FalseNode|F.TrueNode|F.InLoopNode|
@@ -1265,9 +1265,9 @@ and pp_init (init, iinit) =
     type_with_ident = pp_type_with_ident;
     toplevel = pp_toplevel;
     flow = pp_flow}
-    
+
 (*****************************************************************************)
-    
+
 (* Here we do not use (mcode, env). It is a simple C pretty printer. *)
 let pr_elem info =
   let s = Ast_c.str_of_info info in
@@ -1275,7 +1275,7 @@ let pr_elem info =
     let before = !(info.comments_tag).mbefore in
     if not (null before) then begin
       pp "-->";
-      before +> List.iter (fun (comment_like, pinfo) -> 
+      before +> List.iter (fun (comment_like, pinfo) ->
         let s = pinfo.Parse_info.str in
         pp s
       );
@@ -1283,7 +1283,7 @@ let pr_elem info =
     end;
   end;
   pp s
-    
+
 let pr_space _ = Format.print_space()
 
 let pr_nl _ = ()
@@ -1293,7 +1293,7 @@ let pr_unindent _ = ()
 
 let ppc =
   pretty_print_c pr_elem pr_space pr_nl pr_outdent pr_indent pr_unindent
-    
+
 let pp_expression_simple = ppc.expression
 let pp_statement_simple  = ppc.statement
 let pp_type_simple       = ppc.ty
@@ -1333,18 +1333,18 @@ let pp_program_gen pr_elem pr_space =
 
 
 
-let string_of_expression e = 
+let string_of_expression e =
   Common2.format_to_string (fun () ->
     pp_expression_simple e
       )
-    
+
 let (debug_info_of_node:
-       Ograph_extended.nodei -> Control_flow_c.cflow -> string) = 
-  fun nodei flow -> 
+       Ograph_extended.nodei -> Control_flow_c.cflow -> string) =
+  fun nodei flow ->
     let node = flow#nodes#assoc nodei in
     let s = Common2.format_to_string (fun () ->
       pp_flow_simple node
     ) in
     let pos = Lib_parsing_c.min_pinfo_of_node node in
     (spf "%s(n%d)--> %s" (Parse_info.string_of_parse_info_bis pos) nodei s)
-      
+

--- a/parsing_c/test_parsing_c.ml
+++ b/parsing_c/test_parsing_c.ml
@@ -5,42 +5,42 @@ open Ast_c
 
 let score_path = "/home/pad/c-yacfe/tmp"
 
-let tmpfile = "/tmp/output.c" 
+let tmpfile = "/tmp/output.c"
 
 
 (*****************************************************************************)
 (* Subsystem testing *)
 (*****************************************************************************)
 
-let test_tokens_c file = 
-  if not (file =~ ".*\\.c") 
+let test_tokens_c file =
+  if not (file =~ ".*\\.c")
   then pr2 "warning: seems not a .c file";
 
-  Flag_parsing_c.debug_lexer := true; 
+  Flag_parsing_c.debug_lexer := true;
   Flag_parsing_c.verbose_lexing := true;
   Flag_parsing_c.verbose_parsing := true;
 
   Parse_c.tokens file +> List.iter (fun x -> pr2_gen x);
   ()
-        
+
 
 
 (* ---------------------------------------------------------------------- *)
-let test_parse_gen xs ext = 
-        
+let test_parse_gen xs ext =
+
   Flag_parsing_c.debug_typedef := true;
   Flag_parsing_c.debug_cpp := true;
   Flag_parsing_c.debug_etdt := false;
   Flag_parsing_c.filter_msg := true;
 
-  let dirname_opt = 
+  let dirname_opt =
     match xs with
     | [x] when Common2.is_directory x -> Some x
     | _ -> None
   in
 
   (* old:
-     let xs = if !Flag.dir then 
+     let xs = if !Flag.dir then
      process_output_to_list ("find " ^ x ^" -name \"*.c\"") else x::xs in
   *)
   let fullxs = Common2.files_of_dir_or_files_no_vcs ext xs in
@@ -50,7 +50,7 @@ let test_parse_gen xs ext =
 
   Common2.check_stack_nbfiles (List.length fullxs);
 
-  fullxs +> List.iter (fun file -> 
+  fullxs +> List.iter (fun file ->
     if not (file =~ (".*\\."^ext))
     then pr2 ("warning: seems not a ."^ext^" file");
 
@@ -59,70 +59,70 @@ let test_parse_gen xs ext =
     pr2 ("PARSING: " ^ file);
 
     let (xs, stat) = Parse_c.parse_print_error_heuristic file in
-    xs +> List.iter (fun (ast, (s, toks)) -> 
+    xs +> List.iter (fun (ast, (s, toks)) ->
       Parse_c.print_commentized toks
     );
 
     Common.push stat stat_list;
-    let s = 
-      spf "bad = %d, timeout = %B" 
+    let s =
+      spf "bad = %d, timeout = %B"
         stat.Parsing_stat.bad stat.Parsing_stat.have_timeout
     in
     if stat.Parsing_stat.bad =|= 0 && not stat.Parsing_stat.have_timeout
     then Hashtbl.add newscore file (Common2.Ok)
     else Hashtbl.add newscore file (Common2.Pb s)
   );
-  
-  dirname_opt +> Common.do_option (fun dirname -> 
+
+  dirname_opt +> Common.do_option (fun dirname ->
     Common2.pr2_xxxxxxxxxxxxxxxxx();
     pr2 "regression testing  information";
     Common2.pr2_xxxxxxxxxxxxxxxxx();
     let str = Str.global_replace (Str.regexp "/") "__" dirname in
     let def = if !Flag_parsing_c.filter_define_error then "_def_" else "" in
     let ext = if ext =$= "c" then "" else ext in
-    Common2.regression_testing newscore 
+    Common2.regression_testing newscore
       (Filename.concat score_path
        ("score_parsing__" ^str ^ def ^ ext ^ ".marshalled"))
   );
 
-  if not (null !stat_list) 
-  then begin 
+  if not (null !stat_list)
+  then begin
     Parsing_stat.print_recurring_problematic_tokens !stat_list;
     Parsing_stat.print_parsing_stat_list !stat_list;
   end;
   ()
 
 
-let test_parse_c xs = 
+let test_parse_c xs =
   test_parse_gen xs "c"
-let test_parse_h xs = 
+let test_parse_h xs =
   test_parse_gen xs "h"
-let test_parse_ch xs = 
+let test_parse_ch xs =
   test_parse_gen xs "[ch]"
 
 
 (* ---------------------------------------------------------------------- *)
 
-let test_parse xs = 
+let test_parse xs =
 
   Flag_parsing_c.filter_msg_define_error := true;
   Flag_parsing_c.filter_define_error := true;
   Flag_parsing_c.verbose_lexing := false;
   Flag_parsing_c.verbose_parsing := false;
 
-  let dirname_opt = 
+  let dirname_opt =
     match xs with
     | [x] when Common2.is_directory x -> Some x
     | _ -> None
   in
-  dirname_opt +> Common.do_option (fun dir -> 
+  dirname_opt +> Common.do_option (fun dir ->
 
-    let ext = "h" in 
+    let ext = "h" in
     let fullxs = Common2.files_of_dir_or_files_no_vcs ext [dir] in
-    fullxs +> List.iter (fun file -> 
+    fullxs +> List.iter (fun file ->
       let xs = Parse_c.parse_cpp_define_file file in
-      xs +> List.iter (fun (x, def) -> 
-        let (s, params, body) = def in 
+      xs +> List.iter (fun (x, def) ->
+        let (s, params, body) = def in
         Hashtbl.replace !Parse_c._defs s (s, params, body);
       );
     );
@@ -135,7 +135,7 @@ let test_parse xs =
   let stat_list = ref [] in
   Common2.check_stack_nbfiles (List.length fullxs);
 
-  fullxs +> List.iter (fun file -> 
+  fullxs +> List.iter (fun file ->
     if not (file =~ (".*\\."^ext))
     then pr2 ("warning: seems not a ."^ext^" file");
 
@@ -143,15 +143,15 @@ let test_parse xs =
     pr2 ("PARSING: " ^ file);
 
     let (xs, stat) = Parse_c.parse_print_error_heuristic file in
-    xs +> List.iter (fun (ast, (s, toks)) -> 
+    xs +> List.iter (fun (ast, (s, toks)) ->
       Parse_c.print_commentized toks
     );
 
     Common.push stat stat_list;
   );
-  
-  if not (null !stat_list) 
-  then begin 
+
+  if not (null !stat_list)
+  then begin
     Parsing_stat.print_recurring_problematic_tokens !stat_list;
     Parsing_stat.print_parsing_stat_list !stat_list;
   end;
@@ -173,42 +173,42 @@ let test_dump_c file =
 
 (* ---------------------------------------------------------------------- *)
 (* file can be   "foo.c"  or "foo.c:main" *)
-let test_cfg file = 
-  let (file, specific_func) = 
+let test_cfg file =
+  let (file, specific_func) =
     if file =~ "\\(.*\\.c\\):\\(.*\\)"
-    then 
-      let (a,b) = matched2 file in 
+    then
+      let (a,b) = matched2 file in
       a, Some b
-    else 
+    else
       file, None
   in
 
-  if not (file =~ ".*\\.c") 
+  if not (file =~ ".*\\.c")
   then pr2 "warning: seems not a .c file";
 
   let (program, _stat) = Parse_c.parse_print_error_heuristic file in
 
-  program +> List.iter (fun (e,_) -> 
-    let toprocess = 
+  program +> List.iter (fun (e,_) ->
+    let toprocess =
       match specific_func, e with
       | None, _ -> true
-      | Some s, Ast_c.Definition (defbis,_)  -> 
+      | Some s, Ast_c.Definition (defbis,_)  ->
           s =$= Ast_c.str_of_name (defbis.Ast_c.f_name)
-      | _, _ -> false 
+      | _, _ -> false
     in
-          
+
     if toprocess
-    then 
+    then
       (* old: Flow_to_ast.test !Flag.show_flow def *)
-      (try 
+      (try
           let flow = Ast_to_flow.ast_to_control_flow e in
-          flow +> do_option (fun flow -> 
+          flow +> do_option (fun flow ->
             Ast_to_flow.deadcode_detection flow;
             let flow = Ast_to_flow.annotate_loop_nodes flow in
 
-            let flow' = 
+            let flow' =
 (*
-              if !Flag_cocci.show_before_fixed_flow 
+              if !Flag_cocci.show_before_fixed_flow
               then flow
               else Ctlcocci_integration.fix_flow_ctl flow
 *)
@@ -223,16 +223,16 @@ let test_cfg file =
 
 
 
-let test_cfg_ifdef file = 
+let test_cfg_ifdef file =
   let (ast2, _stat) = Parse_c.parse_print_error_heuristic file in
   let ast = Parse_c.program_of_program2 ast2 in
 
   let ast = Cpp_ast_c.cpp_ifdef_statementize ast in
 
-  ast +> List.iter (fun e -> 
-    (try 
+  ast +> List.iter (fun e ->
+    (try
         let flow = Ast_to_flow.ast_to_control_flow e in
-        flow +> do_option (fun flow -> 
+        flow +> do_option (fun flow ->
           Ast_to_flow.deadcode_detection flow;
           let flow = Ast_to_flow.annotate_loop_nodes flow in
           Ograph_extended.print_ograph_mutable flow ("/tmp/output.dot") true
@@ -242,12 +242,12 @@ let test_cfg_ifdef file =
   )
 
 (* ---------------------------------------------------------------------- *)
-let test_parse_unparse infile = 
-  if not (infile =~ ".*\\.c") 
+let test_parse_unparse infile =
+  if not (infile =~ ".*\\.c")
   then pr2 "warning: seems not a .c file";
 
   let (program2, _stat) = Parse_c.parse_print_error_heuristic infile in
-  let program2_with_ppmethod = 
+  let program2_with_ppmethod =
     program2 +> List.map (fun x -> x, Unparse_c.PPnormal)
   in
   Unparse_c.pp_program program2_with_ppmethod tmpfile;
@@ -260,24 +260,24 @@ let test_parse_unparse infile =
 
 
 
-let test_type_c infile = 
-  if not (infile =~ ".*\\.c") 
+let test_type_c infile =
+  if not (infile =~ ".*\\.c")
   then pr2 "warning: seems not a .c file";
 
   Flag_parsing_c.pretty_print_type_info := true;
 
   let (program2, _stat) =  Parse_c.parse_print_error_heuristic infile in
   let _program2 =
-    program2 
-    +> Common2.unzip 
-    +> (fun (program, infos) -> 
-      Type_annoter_c.annotate_program !Type_annoter_c.initial_env 
+    program2
+    +> Common2.unzip
+    +> (fun (program, infos) ->
+      Type_annoter_c.annotate_program !Type_annoter_c.initial_env
         program +> List.map fst,
       infos
     )
     +> Common2.uncurry Common2.zip
   in
-  let program2_with_ppmethod = 
+  let program2_with_ppmethod =
     program2 +> List.map (fun x -> x, Unparse_c.PPnormal)
   in
   Unparse_c.pp_program program2_with_ppmethod tmpfile;
@@ -287,74 +287,74 @@ let test_type_c infile =
 
 (* ---------------------------------------------------------------------- *)
 (* ex: demos/platform_ifdef.c *)
-let test_comment_annotater infile = 
+let test_comment_annotater infile =
   let (program2, _stat) =  Parse_c.parse_print_error_heuristic infile in
   let asts = program2 +> List.map (fun (ast,_) -> ast) in
-  let toks = program2 +> List.map (fun (ast, (s, toks)) -> toks) +> 
+  let toks = program2 +> List.map (fun (ast, (s, toks)) -> toks) +>
     List.flatten in
 
   Flag_parsing_c.pretty_print_comment_info := true;
 
   pr2 "pretty print, before comment annotation: --->";
-  Common2.adjust_pp_with_indent (fun () -> 
-  asts +> List.iter (fun ast -> 
+  Common2.adjust_pp_with_indent (fun () ->
+  asts +> List.iter (fun ast ->
     Pretty_print_c.pp_toplevel_simple ast;
   );
   );
 
   let _ = Comment_annotater_c.annotate_program toks asts in
 
-  Common2.adjust_pp_with_indent (fun () -> 
+  Common2.adjust_pp_with_indent (fun () ->
   pr2 "pretty print, after comment annotation: --->";
-  asts +> List.iter (fun ast -> 
+  asts +> List.iter (fun ast ->
     Pretty_print_c.pp_toplevel_simple ast;
   );
   );
 
 
   ()
-  
-  
+
+
 (* ---------------------------------------------------------------------- *)
 (* used by generic_makefile now *)
-let test_compare_c file1 file2 = 
+let test_compare_c file1 file2 =
   let (correct, diffxs) = Compare_c.compare_default file1 file2 in
   let res = Compare_c.compare_result_to_bool correct in
-  if res 
+  if res
   then raise (Common.UnixExit 0)
   else raise (Common.UnixExit (-1))
 
 
 let test_compare_c_hardcoded () =
-  Compare_c.compare_default 
-    "tests/compare1.c" 
-    "tests/compare2.c" 
+  Compare_c.compare_default
+    "tests/compare1.c"
+    "tests/compare2.c"
     (*
-      "tests/equal_modulo1.c" 
-      "tests/equal_modulo2.c" 
+      "tests/equal_modulo1.c"
+      "tests/equal_modulo2.c"
     *)
-  +> Compare_c.compare_result_to_string 
+  +> Compare_c.compare_result_to_string
   +> pr2
 
 
 
 (* ---------------------------------------------------------------------- *)
-let test_attributes file = 
+let test_attributes file =
   let (ast2, _stat) = Parse_c.parse_c_and_cpp file in
   let ast = Parse_c.program_of_program2 ast2 in
 
   Visitor_c.vk_program { Visitor_c.default_visitor_c with
-    Visitor_c.kdef = (fun (k, bigf) (defbis, ii) -> 
+    Visitor_c.kdef = (fun (k, bigf) (defbis, ii) ->
       let sattr  = Ast_c.s_of_attr defbis.f_attr in
       pr2 (spf "%-30s: %s" (Ast_c.str_of_name (defbis.f_name)) sattr);
     );
-    Visitor_c.kdecl = (fun (k, bigf) decl -> 
+    Visitor_c.kdecl = (fun (k, bigf) decl ->
       match decl with
-      | DeclList (xs, ii) -> 
-          xs +> List.iter (fun (onedecl, iicomma) -> 
-            
+      | DeclList (xs, ii) ->
+          xs +> List.iter (fun (onedecl, iicomma) ->
+
             let sattr  = Ast_c.s_of_attr onedecl.v_attr in
-            let idname = 
+            let idname =
               match onedecl.v_namei with
               | Some (name, ini) -> Ast_c.str_of_name name
               | None -> "novar"
@@ -362,7 +362,7 @@ let test_attributes file =
             pr2 (spf "%-30s: %s" idname sattr);
           );
       | _ -> ()
-          
+
     );
   } ast;
   ()
@@ -370,57 +370,57 @@ let test_attributes file =
 
 let cpp_options () = [
   Cpp_ast_c.I "/home/yyzhou/pad/linux/include";
-] ++ 
-  Cpp_ast_c.cpp_option_of_cmdline 
+] ++
+  Cpp_ast_c.cpp_option_of_cmdline
   (!Flag_parsing_c.cpp_i_opts,!Flag_parsing_c.cpp_d_opts)
 
-let test_cpp file = 
+let test_cpp file =
   let (ast2, _stat) = Parse_c.parse_c_and_cpp file in
   let dirname = Filename.dirname file in
   let ast = Parse_c.program_of_program2 ast2 in
   let _ast' = Cpp_ast_c.cpp_expand_include (cpp_options()) dirname ast in
-  
+
   ()
 
 
 
-let extract_macros ~selection x = 
-  (* CONFIG [ch] ? also do for .c ? maybe less needed now that I 
+let extract_macros ~selection x =
+  (* CONFIG [ch] ? also do for .c ? maybe less needed now that I
    * add local_macros.
    *)
 
-  let ext = "h" in 
+  let ext = "h" in
   let fullxs = Common2.files_of_dir_or_files_no_vcs ext [x] in
-  fullxs +> List.iter (fun file -> 
-   
+  fullxs +> List.iter (fun file ->
+
     pr ("/* PARSING: " ^ file ^ " */");
     let xs = Parse_c.parse_cpp_define_file file in
-    xs +> List.iter (fun (x, def) -> 
-      let (s, params, body) = def in 
+    xs +> List.iter (fun (x, def) ->
+      let (s, params, body) = def in
       assert(s = x);
       (match params, body with
       | Cpp_token_c.NoParam, Cpp_token_c.DefineBody [Parser_c.TInt _]
-      | Cpp_token_c.NoParam, Cpp_token_c.DefineBody [] -> 
+      | Cpp_token_c.NoParam, Cpp_token_c.DefineBody [] ->
           ()
-      | _ -> 
+      | _ ->
 
-          let s1 = 
+          let s1 =
             match params with
             | Cpp_token_c.NoParam -> spf "#define %s " s
-            | Cpp_token_c.Params xs -> 
+            | Cpp_token_c.Params xs ->
                 spf "#define %s(%s) "
                   s (Common.join "," xs)
           in
-          let s2, bodytoks = 
+          let s2, bodytoks =
             match body with
-            | Cpp_token_c.DefineHint _ -> 
+            | Cpp_token_c.DefineHint _ ->
                 failwith "weird, hint in regular header file"
-            | Cpp_token_c.DefineBody xs -> 
+            | Cpp_token_c.DefineBody xs ->
                 Common.join " " (xs +> List.map Token_helpers.str_of_tok),
                 xs
           in
 
-          let print = 
+          let print =
             match () with
             | () when s ==~ Parsing_hacks.regexp_annot -> true
             | () when List.exists (function
@@ -437,7 +437,7 @@ let extract_macros ~selection x =
 
 
 (* ---------------------------------------------------------------------- *)
-let test_xxx a  = 
+let test_xxx a  =
   ()
 
 (*
@@ -458,36 +458,36 @@ let test_xxx a  =
 (*****************************************************************************)
 
 let actions () = [
-  "-tokens_c", "   <file>", 
+  "-tokens_c", "   <file>",
   Common.mk_action_1_arg test_tokens_c;
-  "-parse_c", "   <file or dir>", 
+  "-parse_c", "   <file or dir>",
   Common.mk_action_n_arg test_parse_c;
-  "-parse_h", "   <file or dir>", 
+  "-parse_h", "   <file or dir>",
   Common.mk_action_n_arg test_parse_h;
-  "-parse_ch", "   <file or dir>", 
+  "-parse_ch", "   <file or dir>",
   Common.mk_action_n_arg test_parse_ch;
-  "-dump_c", "   <file>", 
+  "-dump_c", "   <file>",
   Common.mk_action_1_arg test_dump_c;
 
-  "-parse", "   <file or dir>", 
+  "-parse", "   <file or dir>",
   Common.mk_action_n_arg test_parse;
 
-  "-show_flow", "   <file or file:function>", 
+  "-show_flow", "   <file or file:function>",
   Common.mk_action_1_arg test_cfg;
-  "-control_flow", "   <file or file:function>", 
+  "-control_flow", "   <file or file:function>",
   Common.mk_action_1_arg test_cfg;
   "-test_cfg_ifdef", " <file>",
   Common.mk_action_1_arg test_cfg_ifdef;
-  "-parse_unparse", "   <file>", 
+  "-parse_unparse", "   <file>",
   Common.mk_action_1_arg test_parse_unparse;
-  "-type_c", "   <file>", 
+  "-type_c", "   <file>",
   Common.mk_action_1_arg test_type_c;
-  "-compare_c", "   <file1> <file2>", 
+  "-compare_c", "   <file1> <file2>",
   Common.mk_action_2_arg test_compare_c (* result is in unix code *);
-  "-comment_annotater_c", "   <file>", 
+  "-comment_annotater_c", "   <file>",
   Common.mk_action_1_arg test_comment_annotater;
 
-  "-compare_c_hardcoded", "  ", 
+  "-compare_c_hardcoded", "  ",
   Common.mk_action_0_arg test_compare_c_hardcoded;
 
   "-test_attributes", " <file>",
@@ -502,7 +502,7 @@ let actions () = [
   Common.mk_action_1_arg (extract_macros ~selection:true);
 
 
-  "-xxx", "   <file1> <>", 
+  "-xxx", "   <file1> <>",
   Common.mk_action_n_arg test_xxx;
 ]
 

--- a/parsing_c/token_c.ml
+++ b/parsing_c/token_c.ml
@@ -5,7 +5,7 @@
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -26,20 +26,20 @@ open Common
  * tokens which pour le coup were not in the ast at all. So,
  * to avoid recursive mutual dependencies, we provide this file
  * so that ast_c does not need to depend on yacc which depends on
- * ast_c, etc. 
- * 
+ * ast_c, etc.
+ *
  * Also, ocamlyacc imposes some stupid constraints on the way we can define
  * the token type. ocamlyacc forces us to do a token type that
  * cant be a pair of a sum type, it must be directly a sum type.
  * We don't have this constraint here.
- * 
+ *
  * Also, some yacc tokens are not used in the grammar because they are filtered
  * in some intermediate phases. But they still must be declared because
  * ocamllex may generate them, or some intermediate phase may also
  * generate them (like some functions in parsing_hacks.ml).
  * Here we don't have this problem again so we can have a clearer token type.
- * 
- * 
+ *
+ *
  *)
 
 (*****************************************************************************)
@@ -47,20 +47,20 @@ open Common
 (*****************************************************************************)
 
 (* history: was in ast_c.ml before:
- *  This type is not in the Ast but is associated with the TCommentCpp 
+ *  This type is not in the Ast but is associated with the TCommentCpp
  *  token. I put this enum here because parser_c.mly need it. I could have put
  *  it also in lexer_parser.
- * 
+ *
  * update: now in token_c.ml, and actually right now we want those tokens
- * to be in the ast so that in the matching/transforming of C code, we 
- * can detect if some metavariables match code which have some 
+ * to be in the ast so that in the matching/transforming of C code, we
+ * can detect if some metavariables match code which have some
  * cpp_passed tokens next to them (and so where we should issue a warning).
  *)
-type cppcommentkind = 
-  | CppDirective 
-  | CppAttr 
-  | CppMacro 
-  | CppPassingNormal (* ifdef 0, cplusplus, etc *) 
+type cppcommentkind =
+  | CppDirective
+  | CppAttr
+  | CppMacro
+  | CppPassingNormal (* ifdef 0, cplusplus, etc *)
   | CppPassingCosWouldGetError (* expr passsing *)
   | CppPassingExplicit (* skip_start/end tag *)
 
@@ -69,8 +69,8 @@ type cppcommentkind =
 (*****************************************************************************)
 
 (*
- * TODO? Do we want to handle also non OriginTok-like tokens here ? 
- * Right now we use this file to be able to later store in the 
+ * TODO? Do we want to handle also non OriginTok-like tokens here ?
+ * Right now we use this file to be able to later store in the
  * ast some information about comments and passed cpp tokens, to
  * improve our matching/transforming and unparsing in coccinelle.
  * So we should be concerned really only with origin tok, so right
@@ -78,13 +78,13 @@ type cppcommentkind =
  * Ast_c.parse_info, or even more complex Ast_c.info.
  * Also right now I defined only the token_tags of comment-like
  * tokens.
- *) 
+ *)
 
-type info = Parse_info.t 
+type info = Parse_info.t
 
 (* I try to be consistent with the names in parser_c.mli *)
 type token = token_tag * info
- and token_tag = 
+ and token_tag =
   | TCommentSpace
   | TCommentNewline
 
@@ -97,13 +97,13 @@ type token = token_tag * info
 
 
 
-(* Later if decide to include more kinds of tokens, then may 
+(* Later if decide to include more kinds of tokens, then may
  * have to move the current token_tag like TCommentXxx in their
  * own type and have a generic TCommentLike of comment_like_token
  * in token_tag. Could also do like in token_helpers have some
  * is_xxx predicate, but it's not very pretty (but required when
  * some tokens can belong to multiple categories).
- * 
+ *
  * It's supposed to be all the tokens that are not otherwise represented
  * in the ast via regular constructors and info.
  *)
@@ -117,15 +117,15 @@ type comment_like_token = token
 
 (* simpler than in token_helpers :) because we don't have the ocamlyacc
  * constraints on how to define the token type. *)
-let info_of_token = snd 
+let info_of_token = snd
 
 
 
 (*****************************************************************************)
 (*****************************************************************************)
-(* remaining tokens 
+(* remaining tokens
 
-could define a type  token_class = Comment | Ident | Operator | ... 
+could define a type  token_class = Comment | Ident | Operator | ...
 
   | TInt of (string * Ast_c.info)
   | TFloat of ((string * Ast_c.floatType) * Ast_c.info)

--- a/parsing_c/token_helpers.ml
+++ b/parsing_c/token_helpers.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2007, 2008 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -21,9 +21,9 @@ open Parser_c
 (* Is_xxx, categories *)
 (*****************************************************************************)
 
-(* could define a type  token_class = Comment | Ident | Operator | ... 
+(* could define a type  token_class = Comment | Ident | Operator | ...
  * update: now token_c can maybe do that.
- * but still, sometimes tokens belon to multiple classes. Could maybe 
+ * but still, sometimes tokens belon to multiple classes. Could maybe
  * return then a set of classes.
  *)
 
@@ -49,46 +49,46 @@ let is_just_comment = function
 
 
 let is_comment = function
-  | TComment _    
-  | TCommentSpace _ | TCommentNewline _ 
-  | TCommentCpp _ 
+  | TComment _
+  | TCommentSpace _ | TCommentNewline _
+  | TCommentCpp _
   | TCommentMisc _ -> true
   | _ -> false
 
 (* coupling with comment_annotater_c.ml.
  * In fact more tokens than comments are not in the ast, but
- * they were usually temporally created by ocamllex and removed 
+ * they were usually temporally created by ocamllex and removed
  * in parsing_hacks.
 *)
 let is_not_in_ast = is_comment
 
 let is_fake_comment = function
-  | TCommentCpp _    | TCommentMisc _ 
+  | TCommentCpp _    | TCommentMisc _
       -> true
   | _ -> false
 
-let is_not_comment x = 
+let is_not_comment x =
   not (is_comment x)
 
 
 (* ---------------------------------------------------------------------- *)
 
 let is_cpp_instruction = function
-  | TInclude _ 
+  | TInclude _
   | TDefine _
-  | TIfdef _   | TIfdefelse _ | TIfdefelif _ | TEndif _ 
+  | TIfdef _   | TIfdefelse _ | TIfdefelif _ | TEndif _
   | TIfdefBool _ | TIfdefMisc _ | TIfdefVersion _
-  | TUndef _ 
+  | TUndef _
   | TCppDirectiveOther _
       -> true
   | _ -> false
 
 
 let is_gcc_token = function
-  | Tasm _ 
-  | Tinline _ 
-  | Tattribute _ 
-  | Ttypeof _ 
+  | Tasm _
+  | Tinline _
+  | Tattribute _
+  | Ttypeof _
       -> true
   | _ -> false
 
@@ -111,7 +111,7 @@ let is_obrace = function
 
 let is_cbrace = function
   | TCBrace _ -> true
-  | _ -> false 
+  | _ -> false
 
 
 
@@ -124,9 +124,9 @@ let is_eof = function
 
 
 let is_statement = function
-  | Tfor _ | Tdo _ | Tif _ | Twhile _ | Treturn _ 
+  | Tfor _ | Tdo _ | Tif _ | Twhile _ | Treturn _
   | Tbreak _ | Telse _ | Tswitch _ | Tcase _ | Tcontinue _
-  | Tgoto _ 
+  | Tgoto _
   | TPtVirg _
   | TMacroIterator _
       -> true
@@ -134,48 +134,48 @@ let is_statement = function
 
 (* is_start_of_something is used in parse_c for error recovery, to find
  * a synchronisation token.
- * 
+ *
  * Would like to put TIdent or TDefine, TIfdef but they can be in the
  * middle of a function, for instance with label:.
- * 
+ *
  * Could put Typedefident but fired ? it would work in error recovery
  * on the already_passed tokens, which has been already gone in the
  * Parsing_hacks.lookahead machinery, but it will not work on the
  * "next" tokens. But because the namespace for labels is different
  * from namespace for ident/typedef, we can use the name for a typedef
- * for a label and so dangerous to put Typedefident at true here. 
- * 
+ * for a label and so dangerous to put Typedefident at true here.
+ *
  * Can look in parser_c.output to know what can be at toplevel
  * at the very beginning.
  *)
 
 let is_start_of_something = function
-  | Tchar _  | Tshort _ | Tint _ | Tdouble _ |  Tfloat _ | Tlong _ 
-  | Tunsigned _ | Tsigned _ | Tvoid _ 
+  | Tchar _  | Tshort _ | Tint _ | Tdouble _ |  Tfloat _ | Tlong _
+  | Tunsigned _ | Tsigned _ | Tvoid _
   | Tauto _ | Tregister _ | Textern _ | Tstatic _
   | Tconst _ | Tvolatile _
   | Ttypedef _
-  | Tstruct _ | Tunion _ | Tenum _ 
+  | Tstruct _ | Tunion _ | Tenum _
     -> true
   | _ -> false
 
 
 
 let is_binary_operator = function
-  | TOrLog _ | TAndLog _ |  TOr _ |  TXor _ |  TAnd _ 
-  | TEqEq _ |  TNotEq _  | TInf _ |  TSup _ |  TInfEq _ |  TSupEq _ 
-  | TShl _ | TShr _  
-  | TPlus _ |  TMinus _ |  TMul _ |  TDiv _ |  TMod _ 
+  | TOrLog _ | TAndLog _ |  TOr _ |  TXor _ |  TAnd _
+  | TEqEq _ |  TNotEq _  | TInf _ |  TSup _ |  TInfEq _ |  TSupEq _
+  | TShl _ | TShr _
+  | TPlus _ |  TMinus _ |  TMul _ |  TDiv _ |  TMod _
         -> true
-  | _ -> false 
+  | _ -> false
 
 let is_stuff_taking_parenthized = function
-  | Tif _ 
-  | Twhile _ 
+  | Tif _
+  | Twhile _
   | Tswitch _
   | Ttypeof _
   | TMacroIterator _
-    -> true 
+    -> true
   | _ -> false
 
 
@@ -197,14 +197,14 @@ let is_ident_like = function
   | TMacroIterator _
       -> true
 
-  | _ -> false 
+  | _ -> false
 
 
 (*****************************************************************************)
 (* Visitors *)
 (*****************************************************************************)
 
-(* Because ocamlyacc force us to do it that way. The ocamlyacc token 
+(* Because ocamlyacc force us to do it that way. The ocamlyacc token
  * cant be a pair of a sum type, it must be directly a sum type.
  *)
 let info_of_tok = function
@@ -219,7 +219,7 @@ let info_of_tok = function
 
   | TInt  (s, i) -> i
 
-  | TDefine (ii) -> ii 
+  | TDefine (ii) -> ii
   | TInclude (includes, filename, inifdef, i1) ->     i1
 
   | TUndef (s, ii) -> ii
@@ -348,27 +348,27 @@ let info_of_tok = function
   | Ttypeof              (i) -> i
 
   | EOF                  (i) -> i
-  
+
 
 
 
 (* used by tokens to complete the parse_info with filename, line, col infos *)
 let visitor_info_of_tok f = function
-  | TString ((s, isWchar), i)  -> TString ((s, isWchar), f i) 
-  | TChar  ((s, isWchar), i)   -> TChar  ((s, isWchar), f i) 
-  | TFloat ((s, floatType), i) -> TFloat ((s, floatType), f i) 
-  | TAssign  (assignOp, i)     -> TAssign  (assignOp, f i) 
+  | TString ((s, isWchar), i)  -> TString ((s, isWchar), f i)
+  | TChar  ((s, isWchar), i)   -> TChar  ((s, isWchar), f i)
+  | TFloat ((s, floatType), i) -> TFloat ((s, floatType), f i)
+  | TAssign  (assignOp, i)     -> TAssign  (assignOp, f i)
 
-  | TIdent  (s, i)       -> TIdent  (s, f i) 
-  | TypedefIdent  (s, i) -> TypedefIdent  (s, f i) 
-  | TInt  (s, i)         -> TInt  (s, f i) 
+  | TIdent  (s, i)       -> TIdent  (s, f i)
+  | TypedefIdent  (s, i) -> TypedefIdent  (s, f i)
+  | TInt  (s, i)         -> TInt  (s, f i)
 
-  | TDefine (i1) -> TDefine(f i1) 
+  | TDefine (i1) -> TDefine(f i1)
 
-  | TUndef (s,i1) -> TUndef(s, f i1) 
-  | TCppDirectiveOther (i1) -> TCppDirectiveOther(f i1) 
+  | TUndef (s,i1) -> TUndef(s, f i1)
+  | TCppDirectiveOther (i1) -> TCppDirectiveOther(f i1)
 
-  | TInclude (includes, filename, inifdef, i1) -> 
+  | TInclude (includes, filename, inifdef, i1) ->
       TInclude (includes, filename, inifdef, f i1)
 
   | TIncludeStart (i1, inifdef) -> TIncludeStart (f i1, inifdef)
@@ -403,100 +403,100 @@ let visitor_info_of_tok f = function
 
   | TAction               (i) -> TAction             (f i)
 
-  | TComment             (i) -> TComment             (f i) 
-  | TCommentSpace        (i) -> TCommentSpace        (f i) 
-  | TCommentNewline      (i) -> TCommentNewline      (f i) 
-  | TCommentCpp          (cppkind, i) -> TCommentCpp (cppkind, f i) 
-  | TCommentMisc         (i) -> TCommentMisc         (f i) 
+  | TComment             (i) -> TComment             (f i)
+  | TCommentSpace        (i) -> TCommentSpace        (f i)
+  | TCommentNewline      (i) -> TCommentNewline      (f i)
+  | TCommentCpp          (cppkind, i) -> TCommentCpp (cppkind, f i)
+  | TCommentMisc         (i) -> TCommentMisc         (f i)
 
-  | TCommentSkipTagStart         (i) -> TCommentSkipTagStart         (f i) 
-  | TCommentSkipTagEnd         (i) -> TCommentSkipTagEnd         (f i) 
+  | TCommentSkipTagStart         (i) -> TCommentSkipTagStart         (f i)
+  | TCommentSkipTagEnd         (i) -> TCommentSkipTagEnd         (f i)
 
-  | TIfdef               (t, i) -> TIfdef               (t, f i) 
-  | TIfdefelse           (t, i) -> TIfdefelse           (t, f i) 
-  | TIfdefelif           (t, i) -> TIfdefelif           (t, f i) 
-  | TEndif               (t, i) -> TEndif               (t, f i) 
-  | TIfdefBool           (b, t, i) -> TIfdefBool        (b, t, f i) 
-  | TIfdefMisc           (b, t, i) -> TIfdefMisc        (b, t, f i) 
-  | TIfdefVersion        (b, t, i) -> TIfdefVersion     (b, t, f i) 
+  | TIfdef               (t, i) -> TIfdef               (t, f i)
+  | TIfdefelse           (t, i) -> TIfdefelse           (t, f i)
+  | TIfdefelif           (t, i) -> TIfdefelif           (t, f i)
+  | TEndif               (t, i) -> TEndif               (t, f i)
+  | TIfdefBool           (b, t, i) -> TIfdefBool        (b, t, f i)
+  | TIfdefMisc           (b, t, i) -> TIfdefMisc        (b, t, f i)
+  | TIfdefVersion        (b, t, i) -> TIfdefVersion     (b, t, f i)
 
-  | TOPar                (i) -> TOPar                (f i) 
-  | TCPar                (i) -> TCPar                (f i) 
-  | TOBrace              (i) -> TOBrace              (f i) 
-  | TCBrace              (i) -> TCBrace              (f i) 
-  | TOCro                (i) -> TOCro                (f i) 
-  | TCCro                (i) -> TCCro                (f i) 
-  | TDot                 (i) -> TDot                 (f i) 
-  | TComma               (i) -> TComma               (f i) 
-  | TPtrOp               (i) -> TPtrOp               (f i) 
-  | TInc                 (i) -> TInc                 (f i) 
-  | TDec                 (i) -> TDec                 (f i) 
-  | TEq                  (i) -> TEq                  (f i) 
-  | TWhy                 (i) -> TWhy                 (f i) 
-  | TTilde               (i) -> TTilde               (f i) 
-  | TBang                (i) -> TBang                (f i) 
-  | TEllipsis            (i) -> TEllipsis            (f i) 
-  | TDotDot              (i) -> TDotDot              (f i) 
-  | TPtVirg              (i) -> TPtVirg              (f i) 
-  | TOrLog               (i) -> TOrLog               (f i) 
-  | TAndLog              (i) -> TAndLog              (f i) 
-  | TOr                  (i) -> TOr                  (f i) 
-  | TXor                 (i) -> TXor                 (f i) 
-  | TAnd                 (i) -> TAnd                 (f i) 
-  | TEqEq                (i) -> TEqEq                (f i) 
-  | TNotEq               (i) -> TNotEq               (f i) 
-  | TInf                 (i) -> TInf                 (f i) 
-  | TSup                 (i) -> TSup                 (f i) 
-  | TInfEq               (i) -> TInfEq               (f i) 
-  | TSupEq               (i) -> TSupEq               (f i) 
-  | TShl                 (i) -> TShl                 (f i) 
-  | TShr                 (i) -> TShr                 (f i) 
-  | TPlus                (i) -> TPlus                (f i) 
-  | TMinus               (i) -> TMinus               (f i) 
-  | TMul                 (i) -> TMul                 (f i) 
-  | TDiv                 (i) -> TDiv                 (f i) 
-  | TMod                 (i) -> TMod                 (f i) 
-  | Tchar                (i) -> Tchar                (f i) 
-  | Tshort               (i) -> Tshort               (f i) 
-  | Tint                 (i) -> Tint                 (f i) 
-  | Tdouble              (i) -> Tdouble              (f i) 
-  | Tfloat               (i) -> Tfloat               (f i) 
-  | Tlong                (i) -> Tlong                (f i) 
-  | Tunsigned            (i) -> Tunsigned            (f i) 
-  | Tsigned              (i) -> Tsigned              (f i) 
-  | Tvoid                (i) -> Tvoid                (f i) 
-  | Tauto                (i) -> Tauto                (f i) 
-  | Tregister            (i) -> Tregister            (f i) 
-  | Textern              (i) -> Textern              (f i) 
-  | Tstatic              (i) -> Tstatic              (f i) 
-  | Tconst               (i) -> Tconst               (f i) 
-  | Tvolatile            (i) -> Tvolatile            (f i) 
+  | TOPar                (i) -> TOPar                (f i)
+  | TCPar                (i) -> TCPar                (f i)
+  | TOBrace              (i) -> TOBrace              (f i)
+  | TCBrace              (i) -> TCBrace              (f i)
+  | TOCro                (i) -> TOCro                (f i)
+  | TCCro                (i) -> TCCro                (f i)
+  | TDot                 (i) -> TDot                 (f i)
+  | TComma               (i) -> TComma               (f i)
+  | TPtrOp               (i) -> TPtrOp               (f i)
+  | TInc                 (i) -> TInc                 (f i)
+  | TDec                 (i) -> TDec                 (f i)
+  | TEq                  (i) -> TEq                  (f i)
+  | TWhy                 (i) -> TWhy                 (f i)
+  | TTilde               (i) -> TTilde               (f i)
+  | TBang                (i) -> TBang                (f i)
+  | TEllipsis            (i) -> TEllipsis            (f i)
+  | TDotDot              (i) -> TDotDot              (f i)
+  | TPtVirg              (i) -> TPtVirg              (f i)
+  | TOrLog               (i) -> TOrLog               (f i)
+  | TAndLog              (i) -> TAndLog              (f i)
+  | TOr                  (i) -> TOr                  (f i)
+  | TXor                 (i) -> TXor                 (f i)
+  | TAnd                 (i) -> TAnd                 (f i)
+  | TEqEq                (i) -> TEqEq                (f i)
+  | TNotEq               (i) -> TNotEq               (f i)
+  | TInf                 (i) -> TInf                 (f i)
+  | TSup                 (i) -> TSup                 (f i)
+  | TInfEq               (i) -> TInfEq               (f i)
+  | TSupEq               (i) -> TSupEq               (f i)
+  | TShl                 (i) -> TShl                 (f i)
+  | TShr                 (i) -> TShr                 (f i)
+  | TPlus                (i) -> TPlus                (f i)
+  | TMinus               (i) -> TMinus               (f i)
+  | TMul                 (i) -> TMul                 (f i)
+  | TDiv                 (i) -> TDiv                 (f i)
+  | TMod                 (i) -> TMod                 (f i)
+  | Tchar                (i) -> Tchar                (f i)
+  | Tshort               (i) -> Tshort               (f i)
+  | Tint                 (i) -> Tint                 (f i)
+  | Tdouble              (i) -> Tdouble              (f i)
+  | Tfloat               (i) -> Tfloat               (f i)
+  | Tlong                (i) -> Tlong                (f i)
+  | Tunsigned            (i) -> Tunsigned            (f i)
+  | Tsigned              (i) -> Tsigned              (f i)
+  | Tvoid                (i) -> Tvoid                (f i)
+  | Tauto                (i) -> Tauto                (f i)
+  | Tregister            (i) -> Tregister            (f i)
+  | Textern              (i) -> Textern              (f i)
+  | Tstatic              (i) -> Tstatic              (f i)
+  | Tconst               (i) -> Tconst               (f i)
+  | Tvolatile            (i) -> Tvolatile            (f i)
 
-  | Trestrict            (i) -> Trestrict            (f i) 
+  | Trestrict            (i) -> Trestrict            (f i)
 
-  | Tstruct              (i) -> Tstruct              (f i) 
-  | Tenum                (i) -> Tenum                (f i) 
-  | Ttypedef             (i) -> Ttypedef             (f i) 
-  | Tunion               (i) -> Tunion               (f i) 
-  | Tbreak               (i) -> Tbreak               (f i) 
-  | Telse                (i) -> Telse                (f i) 
-  | Tswitch              (i) -> Tswitch              (f i) 
-  | Tcase                (i) -> Tcase                (f i) 
-  | Tcontinue            (i) -> Tcontinue            (f i) 
-  | Tfor                 (i) -> Tfor                 (f i) 
-  | Tdo                  (i) -> Tdo                  (f i) 
-  | Tif                  (i) -> Tif                  (f i) 
-  | Twhile               (i) -> Twhile               (f i) 
-  | Treturn              (i) -> Treturn              (f i) 
-  | Tgoto                (i) -> Tgoto                (f i) 
-  | Tdefault             (i) -> Tdefault             (f i) 
-  | Tsizeof              (i) -> Tsizeof              (f i) 
-  | Tasm                 (i) -> Tasm                 (f i) 
-  | Tattribute           (i) -> Tattribute           (f i) 
-  | Tinline              (i) -> Tinline              (f i) 
-  | Ttypeof              (i) -> Ttypeof              (f i) 
-  | EOF                  (i) -> EOF                  (f i) 
-  
+  | Tstruct              (i) -> Tstruct              (f i)
+  | Tenum                (i) -> Tenum                (f i)
+  | Ttypedef             (i) -> Ttypedef             (f i)
+  | Tunion               (i) -> Tunion               (f i)
+  | Tbreak               (i) -> Tbreak               (f i)
+  | Telse                (i) -> Telse                (f i)
+  | Tswitch              (i) -> Tswitch              (f i)
+  | Tcase                (i) -> Tcase                (f i)
+  | Tcontinue            (i) -> Tcontinue            (f i)
+  | Tfor                 (i) -> Tfor                 (f i)
+  | Tdo                  (i) -> Tdo                  (f i)
+  | Tif                  (i) -> Tif                  (f i)
+  | Twhile               (i) -> Twhile               (f i)
+  | Treturn              (i) -> Treturn              (f i)
+  | Tgoto                (i) -> Tgoto                (f i)
+  | Tdefault             (i) -> Tdefault             (f i)
+  | Tsizeof              (i) -> Tsizeof              (f i)
+  | Tasm                 (i) -> Tasm                 (f i)
+  | Tattribute           (i) -> Tattribute           (f i)
+  | Tinline              (i) -> Tinline              (f i)
+  | Ttypeof              (i) -> Ttypeof              (f i)
+  | EOF                  (i) -> EOF                  (f i)
+
 
 (*****************************************************************************)
 (* Accessors *)
@@ -525,8 +525,8 @@ let is_abstract x =
 (*****************************************************************************)
 (* Helpers *)
 (*****************************************************************************)
-let is_same_line_or_close line tok = 
-  line_of_tok tok =|= line || 
+let is_same_line_or_close line tok =
+  line_of_tok tok =|= line ||
   line_of_tok tok =|= line - 1 ||
   line_of_tok tok =|= line - 2
 

--- a/parsing_c/token_helpers.mli
+++ b/parsing_c/token_helpers.mli
@@ -29,7 +29,7 @@ val is_ident_like: Parser_c.token -> bool
 
 val info_of_tok : Parser_c.token -> Ast_c.info
 
-val visitor_info_of_tok : 
+val visitor_info_of_tok :
   (Ast_c.info -> Ast_c.info) -> Parser_c.token -> Parser_c.token
 
 val linecol_of_tok : Parser_c.token -> int * int

--- a/parsing_c/token_views_c.ml
+++ b/parsing_c/token_views_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2007, 2008 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -14,16 +14,16 @@
 
 open Common
 
-module TH = Token_helpers 
+module TH = Token_helpers
 
-open Parser_c 
+open Parser_c
 
 (*****************************************************************************)
 (* Some debugging functions  *)
 (*****************************************************************************)
 
-let pr2 s = 
-  if !Flag_parsing_c.verbose_parsing 
+let pr2 s =
+  if !Flag_parsing_c.verbose_parsing
   then Common.pr2 s
 
 
@@ -47,15 +47,15 @@ let pr2 s =
  * indexed by the charpos, there could have been some problems:
  * how my fake_pos interact with the way I tag and adjust token ?
  * because I base my tagging on the position of the token ! so sometimes
- * could tag another fakeInfo that should not be tagged ? 
+ * could tag another fakeInfo that should not be tagged ?
  * fortunately I don't use anymore this technique.
  *)
 
 (* update: quite close to the Place_c.Inxxx *)
-type context = 
+type context =
   InFunction | InEnum | InStruct | InInitializer | NoContext
 
-type token_extended = { 
+type token_extended = {
   mutable tok: Parser_c.token;
   mutable where: context;
 
@@ -63,43 +63,43 @@ type token_extended = {
   mutable new_tokens_before : Parser_c.token list;
 
   (* line x col  cache, more easily accessible, of the info in the token *)
-  line: int; 
+  line: int;
   col : int;
 }
 
-let set_as_comment cppkind x = 
-  if TH.is_eof x.tok 
+let set_as_comment cppkind x =
+  if TH.is_eof x.tok
   then () (* otherwise parse_c will be lost if don't find a EOF token *)
-  else 
+  else
     x.tok <- TCommentCpp (cppkind, TH.info_of_tok x.tok)
 
-let mk_token_extended x = 
+let mk_token_extended x =
   let (line, col) = TH.linecol_of_tok x in
-  { tok = x; 
-    line = line; col = col; 
-    where = NoContext; 
+  { tok = x;
+    line = line; col = col;
+    where = NoContext;
     new_tokens_before = [];
   }
 
 
-let rebuild_tokens_extented toks_ext = 
+let rebuild_tokens_extented toks_ext =
   let _tokens = ref [] in
-  toks_ext +> List.iter (fun tok -> 
+  toks_ext +> List.iter (fun tok ->
     tok.new_tokens_before +> List.iter (fun x -> Common.push x _tokens);
-    Common.push tok.tok _tokens 
+    Common.push tok.tok _tokens
   );
   let tokens = List.rev !_tokens in
   (tokens +> Common2.acc_map mk_token_extended)
 
 
 
-(* x list list, because x list separated by ',' *) 
-type paren_grouped = 
+(* x list list, because x list separated by ',' *)
+type paren_grouped =
   | Parenthised   of paren_grouped list list * token_extended list
   | PToken of token_extended
 
-type brace_grouped = 
-  | Braceised   of 
+type brace_grouped =
+  | Braceised   of
       brace_grouped list list * token_extended * token_extended option
   | BToken of token_extended
 
@@ -108,20 +108,20 @@ type brace_grouped =
  * and so when we want to comment a ifdef, we don't know which endif
  * we must also comment. Especially true for the #if 0 which sometimes
  * have a #else part.
- * 
- * x list list, because x list separated by #else or #elif 
- *) 
-type ifdef_grouped = 
+ *
+ * x list list, because x list separated by #else or #elif
+ *)
+type ifdef_grouped =
   | Ifdef     of ifdef_grouped list list * token_extended list
   | Ifdefbool of bool * ifdef_grouped list list * token_extended list
   | NotIfdefLine of token_extended list
 
 
-type 'a line_grouped = 
+type 'a line_grouped =
   Line of 'a list
 
 
-type body_function_grouped = 
+type body_function_grouped =
   | BodyFunction of token_extended list
   | NotBodyLine  of token_extended list
 
@@ -130,118 +130,118 @@ type body_function_grouped =
 (* view builders  *)
 (* ------------------------------------------------------------------------- *)
 
-(* todo: synchro ! use more indentation 
+(* todo: synchro ! use more indentation
  * if paren not closed and same indentation level, certainly because
  * part of a mid-ifdef-expression.
 *)
-let rec mk_parenthised xs = 
+let rec mk_parenthised xs =
   match xs with
   | [] -> []
-  | x::xs -> 
-      (match x.tok with 
-      | TOPar _ | TOParDefine _ -> 
+  | x::xs ->
+      (match x.tok with
+      | TOPar _ | TOParDefine _ ->
           let body, extras, xs = mk_parameters [x] [] xs in
           Parenthised (body,extras)::mk_parenthised xs
-      | _ -> 
+      | _ ->
           PToken x::mk_parenthised xs
       )
 
 (* return the body of the parenthised expression and the rest of the tokens *)
-and mk_parameters extras acc_before_sep  xs = 
+and mk_parameters extras acc_before_sep  xs =
   match xs with
-  | [] -> 
+  | [] ->
       (* maybe because of #ifdef which "opens" '(' in 2 branches *)
       pr2 "PB: not found closing paren in fuzzy parsing";
       [List.rev acc_before_sep], List.rev extras, []
-  | x::xs -> 
-      (match x.tok with 
+  | x::xs ->
+      (match x.tok with
       (* synchro *)
-      | TOBrace _ when x.col =|= 0 -> 
+      | TOBrace _ when x.col =|= 0 ->
           pr2 "PB: found synchro point } in paren";
           [List.rev acc_before_sep], List.rev (extras), (x::xs)
 
-      | TCPar _ | TCParEOL _ -> 
+      | TCPar _ | TCParEOL _ ->
           [List.rev acc_before_sep], List.rev (x::extras), xs
-      | TOPar _ | TOParDefine _ -> 
+      | TOPar _ | TOParDefine _ ->
           let body, extrasnest, xs = mk_parameters [x] [] xs in
-          mk_parameters extras 
-            (Parenthised (body,extrasnest)::acc_before_sep) 
+          mk_parameters extras
+            (Parenthised (body,extrasnest)::acc_before_sep)
             xs
-      | TComma _ -> 
+      | TComma _ ->
           let body, extras, xs = mk_parameters (x::extras) [] xs in
-          (List.rev acc_before_sep)::body, extras, xs 
-      | _ -> 
+          (List.rev acc_before_sep)::body, extras, xs
+      | _ ->
           mk_parameters extras (PToken x::acc_before_sep) xs
       )
 
 
 
 
-let rec mk_braceised xs = 
+let rec mk_braceised xs =
   match xs with
   | [] -> []
-  | x::xs -> 
-      (match x.tok with 
-      | TOBrace _ -> 
+  | x::xs ->
+      (match x.tok with
+      | TOBrace _ ->
           let body, endbrace, xs = mk_braceised_aux [] xs in
           Braceised (body, x, endbrace)::mk_braceised xs
-      | TCBrace _ -> 
+      | TCBrace _ ->
           pr2 "PB: found closing brace alone in fuzzy parsing";
           BToken x::mk_braceised xs
-      | _ -> 
+      | _ ->
           BToken x::mk_braceised xs
       )
 
 (* return the body of the parenthised expression and the rest of the tokens *)
-and mk_braceised_aux acc xs = 
+and mk_braceised_aux acc xs =
   match xs with
-  | [] -> 
+  | [] ->
       (* maybe because of #ifdef which "opens" '(' in 2 branches *)
       pr2 "PB: not found closing brace in fuzzy parsing";
       [List.rev acc], None, []
-  | x::xs -> 
-      (match x.tok with 
+  | x::xs ->
+      (match x.tok with
       | TCBrace _ -> [List.rev acc], Some x, xs
-      | TOBrace _ -> 
+      | TOBrace _ ->
           let body, endbrace, xs = mk_braceised_aux [] xs in
           mk_braceised_aux  (Braceised (body,x, endbrace)::acc) xs
-      | _ -> 
+      | _ ->
           mk_braceised_aux (BToken x::acc) xs
       )
 
-          
 
 
-let rec mk_ifdef xs = 
+
+let rec mk_ifdef xs =
   match xs with
   | [] -> []
-  | x::xs -> 
-      (match x.tok with 
-      | TIfdef _ -> 
+  | x::xs ->
+      (match x.tok with
+      | TIfdef _ ->
           let body, extra, xs = mk_ifdef_parameters [x] [] xs in
           Ifdef (body, extra)::mk_ifdef xs
-      | TIfdefBool (b,_, _) -> 
+      | TIfdefBool (b,_, _) ->
           let body, extra, xs = mk_ifdef_parameters [x] [] xs in
-          
+
           (* if not passing, then consider a #if 0 as an ordinary #ifdef *)
           if !Flag_parsing_c.if0_passing
           then Ifdefbool (b, body, extra)::mk_ifdef xs
           else Ifdef(body, extra)::mk_ifdef xs
 
-      | TIfdefMisc (b,_,_) | TIfdefVersion (b,_,_) -> 
+      | TIfdefMisc (b,_,_) | TIfdefVersion (b,_,_) ->
           let body, extra, xs = mk_ifdef_parameters [x] [] xs in
           Ifdefbool (b, body, extra)::mk_ifdef xs
 
-          
-      | _ -> 
+
+      | _ ->
           (* todo? can have some Ifdef in the line ? *)
           let line, xs = Common.span (fun y -> y.line =|= x.line) (x::xs) in
-          NotIfdefLine line::mk_ifdef xs 
+          NotIfdefLine line::mk_ifdef xs
       )
 
-and mk_ifdef_parameters extras acc_before_sep xs = 
+and mk_ifdef_parameters extras acc_before_sep xs =
   match xs with
-  | [] -> 
+  | [] ->
       (* Note that mk_ifdef is assuming that CPP instruction are alone
        * on their line. Because I do a span (fun x -> is_same_line ...)
        * I might take with me a #endif if this one is mixed on a line
@@ -249,37 +249,37 @@ and mk_ifdef_parameters extras acc_before_sep xs =
        *)
       pr2 "PB: not found closing ifdef in fuzzy parsing";
       [List.rev acc_before_sep], List.rev extras, []
-  | x::xs -> 
-      (match x.tok with 
-      | TEndif _ -> 
+  | x::xs ->
+      (match x.tok with
+      | TEndif _ ->
           [List.rev acc_before_sep], List.rev (x::extras), xs
-      | TIfdef _ -> 
+      | TIfdef _ ->
           let body, extrasnest, xs = mk_ifdef_parameters [x] [] xs in
-          mk_ifdef_parameters 
+          mk_ifdef_parameters
             extras (Ifdef (body, extrasnest)::acc_before_sep) xs
 
-      | TIfdefBool (b,_,_) -> 
+      | TIfdefBool (b,_,_) ->
           let body, extrasnest, xs = mk_ifdef_parameters [x] [] xs in
 
           if !Flag_parsing_c.if0_passing
           then
-            mk_ifdef_parameters 
+            mk_ifdef_parameters
               extras (Ifdefbool (b, body, extrasnest)::acc_before_sep) xs
-          else 
-            mk_ifdef_parameters 
+          else
+            mk_ifdef_parameters
               extras (Ifdef (body, extrasnest)::acc_before_sep) xs
 
 
-      | TIfdefMisc (b,_,_) | TIfdefVersion (b,_,_) -> 
+      | TIfdefMisc (b,_,_) | TIfdefVersion (b,_,_) ->
           let body, extrasnest, xs = mk_ifdef_parameters [x] [] xs in
-          mk_ifdef_parameters 
+          mk_ifdef_parameters
             extras (Ifdefbool (b, body, extrasnest)::acc_before_sep) xs
 
-      | TIfdefelse _ 
-      | TIfdefelif _ -> 
+      | TIfdefelse _
+      | TIfdefelif _ ->
           let body, extras, xs = mk_ifdef_parameters (x::extras) [] xs in
-          (List.rev acc_before_sep)::body, extras, xs 
-      | _ -> 
+          (List.rev acc_before_sep)::body, extras, xs
+      | _ ->
           let line, xs = Common.span (fun y -> y.line =|= x.line) (x::xs) in
           mk_ifdef_parameters extras (NotIfdefLine line::acc_before_sep) xs
       )
@@ -288,7 +288,7 @@ and mk_ifdef_parameters extras acc_before_sep xs =
 
 let line_of_paren = function
   | PToken x -> x.line
-  | Parenthised (xxs, info_parens) -> 
+  | Parenthised (xxs, info_parens) ->
       (match info_parens with
       | [] -> raise Impossible
       | x::xs -> x.line
@@ -297,52 +297,52 @@ let line_of_paren = function
 
 let rec span_line_paren line = function
   | [] -> [],[]
-  | x::xs -> 
+  | x::xs ->
       (match x with
-      | PToken tok when TH.is_eof tok.tok -> 
+      | PToken tok when TH.is_eof tok.tok ->
           [], x::xs
-      | _ -> 
-        if line_of_paren x =|= line 
+      | _ ->
+        if line_of_paren x =|= line
         then
           let (l1, l2) = span_line_paren line xs in
           (x::l1, l2)
         else ([], x::xs)
       )
-        
 
-let rec mk_line_parenthised xs = 
+
+let rec mk_line_parenthised xs =
   match xs with
   | [] -> []
-  | x::xs -> 
+  | x::xs ->
       let line_no = line_of_paren x in
       let line, xs = span_line_paren line_no xs in
       Line (x::line)::mk_line_parenthised xs
 
 
 (* --------------------------------------- *)
-let rec mk_body_function_grouped xs = 
-  match xs with 
+let rec mk_body_function_grouped xs =
+  match xs with
   | [] -> []
-  | x::xs -> 
+  | x::xs ->
       (match x with
-      | {tok = TOBrace _; col = 0} -> 
-          let is_closing_brace = function 
-            | {tok = TCBrace _; col = 0 } -> true 
-            | _ -> false 
+      | {tok = TOBrace _; col = 0} ->
+          let is_closing_brace = function
+            | {tok = TCBrace _; col = 0 } -> true
+            | _ -> false
           in
           let body, xs = Common.span (fun x -> not (is_closing_brace x)) xs in
           (match xs with
-          | ({tok = TCBrace _; col = 0 })::xs -> 
+          | ({tok = TCBrace _; col = 0 })::xs ->
               BodyFunction body::mk_body_function_grouped xs
-          | [] -> 
+          | [] ->
               pr2 "PB:not found closing brace in fuzzy parsing";
               [NotBodyLine body]
           | _ -> raise Impossible
           )
-          
-      | _ -> 
+
+      | _ ->
           let line, xs = Common.span (fun y -> y.line =|= x.line) (x::xs) in
-          NotBodyLine line::mk_body_function_grouped xs 
+          NotBodyLine line::mk_body_function_grouped xs
       )
 
 
@@ -350,27 +350,27 @@ let rec mk_body_function_grouped xs =
 (* view iterators  *)
 (* ------------------------------------------------------------------------- *)
 
-let rec iter_token_paren f xs = 
+let rec iter_token_paren f xs =
   xs +> List.iter (function
   | PToken tok -> f tok;
-  | Parenthised (xxs, info_parens) -> 
+  | Parenthised (xxs, info_parens) ->
       info_parens +> List.iter f;
       xxs +> List.iter (fun xs -> iter_token_paren f xs)
   )
 
-let rec iter_token_brace f xs = 
+let rec iter_token_brace f xs =
   xs +> List.iter (function
   | BToken tok -> f tok;
-  | Braceised (xxs, tok1, tok2opt) -> 
+  | Braceised (xxs, tok1, tok2opt) ->
       f tok1; do_option f tok2opt;
       xxs +> List.iter (fun xs -> iter_token_brace f xs)
   )
 
-let rec iter_token_ifdef f xs = 
+let rec iter_token_ifdef f xs =
   xs +> List.iter (function
   | NotIfdefLine xs -> xs +> List.iter f;
-  | Ifdefbool (_, xxs, info_ifdef) 
-  | Ifdef (xxs, info_ifdef) -> 
+  | Ifdefbool (_, xxs, info_ifdef)
+  | Ifdef (xxs, info_ifdef) ->
       info_ifdef +> List.iter f;
       xxs +> List.iter (iter_token_ifdef f)
   )
@@ -378,23 +378,23 @@ let rec iter_token_ifdef f xs =
 
 
 
-let tokens_of_paren xs = 
+let tokens_of_paren xs =
   let g = ref [] in
   xs +> iter_token_paren (fun tok -> Common.push tok g);
   List.rev !g
 
 
-let tokens_of_paren_ordered xs = 
+let tokens_of_paren_ordered xs =
   let g = ref [] in
 
   let rec aux_tokens_ordered = function
     | PToken tok -> Common.push tok g;
-    | Parenthised (xxs, info_parens) -> 
-        let (opar, cpar, commas) = 
+    | Parenthised (xxs, info_parens) ->
+        let (opar, cpar, commas) =
           match info_parens with
-          | opar::xs -> 
+          | opar::xs ->
               (match List.rev xs with
-              | cpar::xs -> 
+              | cpar::xs ->
                   opar, cpar, List.rev xs
               | _ -> raise Impossible
               )
@@ -408,7 +408,7 @@ let tokens_of_paren_ordered xs =
     match xxs, commas with
     | [], [] -> ()
     | [xs], [] -> xs +> List.iter aux_tokens_ordered
-    | xs::ys::xxs, comma::commas -> 
+    | xs::ys::xxs, comma::commas ->
         xs +> List.iter aux_tokens_ordered;
         Common.push comma g;
         aux_args (ys::xxs, commas)
@@ -426,8 +426,8 @@ let tokens_of_paren_ordered xs =
 (* ------------------------------------------------------------------------- *)
 
 
-let rec set_in_function_tag xs = 
- (* could try: ) { } but it can be the ) of a if or while, so 
+let rec set_in_function_tag xs =
+ (* could try: ) { } but it can be the ) of a if or while, so
   * better to base the heuristic on the position in column zero.
   * Note that some struct or enum or init put also their { in first column
   * but set_in_other will overwrite the previous InFunction tag.
@@ -435,66 +435,66 @@ let rec set_in_function_tag xs =
   match xs with
   | [] -> ()
   (* ) { and the closing } is in column zero, then certainly a function *)
-  | BToken ({tok = TCPar _ })::(Braceised (body, tok1, Some tok2))::xs 
-      when tok1.col <> 0 && tok2.col =|= 0 -> 
-      body +> List.iter (iter_token_brace (fun tok -> 
+  | BToken ({tok = TCPar _ })::(Braceised (body, tok1, Some tok2))::xs
+      when tok1.col <> 0 && tok2.col =|= 0 ->
+      body +> List.iter (iter_token_brace (fun tok ->
         tok.where <- InFunction
       ));
       set_in_function_tag xs
 
   | (BToken x)::xs -> set_in_function_tag xs
 
-  | (Braceised (body, tok1, Some tok2))::xs 
-      when tok1.col =|= 0 && tok2.col =|= 0 -> 
-      body +> List.iter (iter_token_brace (fun tok -> 
+  | (Braceised (body, tok1, Some tok2))::xs
+      when tok1.col =|= 0 && tok2.col =|= 0 ->
+      body +> List.iter (iter_token_brace (fun tok ->
         tok.where <- InFunction
       ));
       set_in_function_tag xs
-  | Braceised (body, tok1, tok2)::xs -> 
+  | Braceised (body, tok1, tok2)::xs ->
       set_in_function_tag xs
-  
 
-let rec set_in_other xs = 
-  match xs with 
+
+let rec set_in_other xs =
+  match xs with
   | [] -> ()
   (* enum x { } *)
   | BToken ({tok = Tenum _})::BToken ({tok = TIdent _})
-    ::Braceised(body, tok1, tok2)::xs 
+    ::Braceised(body, tok1, tok2)::xs
   | BToken ({tok = Tenum _})
-    ::Braceised(body, tok1, tok2)::xs 
-    -> 
-      body +> List.iter (iter_token_brace (fun tok -> 
+    ::Braceised(body, tok1, tok2)::xs
+    ->
+      body +> List.iter (iter_token_brace (fun tok ->
         tok.where <- InEnum;
       ));
       set_in_other xs
 
   (* struct x { } *)
   | BToken ({tok = Tstruct _})::BToken ({tok = TIdent _})
-    ::Braceised(body, tok1, tok2)::xs -> 
-      body +> List.iter (iter_token_brace (fun tok -> 
+    ::Braceised(body, tok1, tok2)::xs ->
+      body +> List.iter (iter_token_brace (fun tok ->
         tok.where <- InStruct;
       ));
       set_in_other xs
   (* = { } *)
   | BToken ({tok = TEq _})
-    ::Braceised(body, tok1, tok2)::xs -> 
-      body +> List.iter (iter_token_brace (fun tok -> 
+    ::Braceised(body, tok1, tok2)::xs ->
+      body +> List.iter (iter_token_brace (fun tok ->
         tok.where <- InInitializer;
       ));
       set_in_other xs
 
   | BToken _::xs -> set_in_other xs
 
-  | Braceised(body, tok1, tok2)::xs -> 
+  | Braceised(body, tok1, tok2)::xs ->
       body +> List.iter set_in_other;
       set_in_other xs
 
-      
-      
 
-let set_context_tag xs = 
+
+
+let set_context_tag xs =
   begin
     set_in_function_tag xs;
     set_in_other xs;
   end
-  
+

--- a/parsing_c/type_annoter_c.ml
+++ b/parsing_c/type_annoter_c.ml
@@ -1,12 +1,12 @@
 (* Yoann Padioleau
- * 
- * Copyright (C) 2007, 2008 Ecole des Mines de Nantes, 
+ *
+ * Copyright (C) 2007, 2008 Ecole des Mines de Nantes,
  * Copyright (C) 2009 University of Urbana Champaign
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -22,19 +22,19 @@ module Lib = Lib_parsing_c
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
-(* History: 
+(* History:
  *  - Done a first type checker in 2002, cf typing-semantic/, but
  *    was assuming that have all type info, and so was assuming had called
  *    cpp and everything was right.
- *  - Wrote this file, in 2006?, as we added pattern matching on type 
+ *  - Wrote this file, in 2006?, as we added pattern matching on type
  *    in coccinelle. Partial type annotater.
- *  - Julia extended it in 2008? to have localvar/notlocalvar and 
+ *  - Julia extended it in 2008? to have localvar/notlocalvar and
  *    test/notest information, again used by coccinelle.
- *  - I extended it in Fall 2008 to have more type information for the 
+ *  - I extended it in Fall 2008 to have more type information for the
  *    global analysis. I also added some optimisations to process
  *    included code faster.
- * 
- *  
+ *
+ *
  * Design choices. Can either do:
  *  - a kind of inferer
  *     - can first do a simple inferer, that just pass context
@@ -43,62 +43,62 @@ module Lib = Lib_parsing_c
  *
  *  - extract the information from the .h files
  *    (so no inference at all needed)
- * 
+ *
  * Difference with julia's code in parsing_cocci/type_infer.ml:
  *  - She handles just the variable namespace. She does not type
  *    field access or enum or macros. This is because cocci programs are
  *     usually simple and have no structure definition or macro definitions
  *     that we need to type anyway.
  *  - She does more propagation.
- *  - She does not have to handle the typedef isomorphism which force me 
+ *  - She does not have to handle the typedef isomorphism which force me
  *    to use those typedef_fix and type_unfold_one_step
  *  - She does not handle I think the function pointer C isomorphism.
- * 
- *  - She has a cleaner type_cocci without any info. In my case 
+ *
+ *  - She has a cleaner type_cocci without any info. In my case
  *    I need to do those ugly al_type, or generate fake infos.
- *  - She has more compact code. Perhaps because she does not have to 
+ *  - She has more compact code. Perhaps because she does not have to
  *    handle the extra exp_info that she added on me :) So I need those
  *    do_with_type, make_info_xxx, etc.
- * 
+ *
  * Note: if need to debug this annotater, use -show_trace_profile, it can
  * help. You can also set the typedef_debug flag below.
- * 
- * 
- * 
+ *
+ *
+ *
  * todo: expression contain types, and statements,   which in turn can contain
- * expression, so need recurse. Need define an annote_statement and 
+ * expression, so need recurse. Need define an annote_statement and
  * annotate_type.
- * 
+ *
  * todo: how deal with typedef isomorphisms ? How store them in Ast_c ?
  * store all posible variations in ast_c ? a list of type instead of just
  * the type ?
- * 
+ *
  * todo: how to handle multiple possible definitions for entities like
- * struct or typedefs ? Because of ifdef, we should store list of 
+ * struct or typedefs ? Because of ifdef, we should store list of
  * possibilities sometimes.
- * 
+ *
  * todo: define a new type ? like type_cocci ? where have a bool ?
- * 
- * semi: How handle scope ? When search for type of field, we return 
+ *
+ * semi: How handle scope ? When search for type of field, we return
  * a type, but this type makes sense only in a certain scope.
- * We could add a tag to each typedef, structUnionName to differentiate 
+ * We could add a tag to each typedef, structUnionName to differentiate
  * them and also associate in ast_c to the type the scope
  * of this type, the env that were used to define this type.
- * 
- * todo: handle better the search in previous env, the env'. Cf the 
+ *
+ * todo: handle better the search in previous env, the env'. Cf the
  * termination problem in typedef_fix when I was searching in the same
  * env.
- * 
+ *
  *)
 
 (*****************************************************************************)
 (* Wrappers *)
 (*****************************************************************************)
-let pr2 s = 
+let pr2 s =
   if !Flag_parsing_c.verbose_type
   then Common.pr2 s
 
-let pr2_once s = 
+let pr2_once s =
   if !Flag_parsing_c.verbose_type
   then Common.pr2_once s
 
@@ -107,28 +107,28 @@ let pr2_once s =
 (*****************************************************************************)
 
 (* The different namespaces from stdC manual:
- * 
+ *
  * You introduce two new name spaces with every block that you write.
- * 
- * One name space includes all 
- *  - functions, 
- *  - objects, 
+ *
+ * One name space includes all
+ *  - functions,
+ *  - objects,
  *  - type definitions,
- *  - and enumeration constants 
- * that you declare or define within the  block. 
- * 
- * The other name space includes all 
- *  - enumeration, 
- *  - structure, 
- *  - and union 
+ *  - and enumeration constants
+ * that you declare or define within the  block.
+ *
+ * The other name space includes all
+ *  - enumeration,
+ *  - structure,
+ *  - and union
  *  *tags* that you define within the block.
- * 
+ *
  * You introduce a new member name space with every structure or union
  * whose content you define. You identify a member name space by the
  * type of left operand that you write for a member selection
  * operator, as in x.y or p->y. A member name space ends with the end
  * of the block in which you declare it.
- * 
+ *
  * You introduce a new goto label name space with every function
  * definition you write. Each goto label name space ends with its
  * function definition.
@@ -136,8 +136,8 @@ let pr2_once s =
 
 (* But I don't try to do a type-checker, I try to "resolve" type of var
  * so don't need make difference between namespaces here.
- * 
- * But, why not make simply a (string, kindstring) assoc ? 
+ *
+ * But, why not make simply a (string, kindstring) assoc ?
  * Because we dont want that a variable shadow a struct definition, because
  * they are still in 2 different namespace. But could for typedef,
  * because VarOrFunc and Typedef are in the same namespace.
@@ -146,18 +146,18 @@ let pr2_once s =
 
 
 (* This type contains all "ident" like notion of C. Each time in Ast_c
- * you have a string type (as in expression, function name, fields) 
+ * you have a string type (as in expression, function name, fields)
  * then you need to manage the scope of this ident.
- * 
+ *
  * The wrap for StructUnionNameDef contain the whole ii, the i for
  * the string, the structUnion and the structType.
- * 
+ *
  * Put Macro here ? after all the scoping rules for cpp macros is different
  * and so does not vanish after the closing '}'.
- * 
+ *
  * todo: EnumDef
  *)
-type namedef = 
+type namedef =
   | VarOrFunc of string * Ast_c.exp_type
   | EnumConstant of string * string option
 
@@ -174,25 +174,25 @@ type namedef =
  *
  * opti? use a hash to accelerate ? hmm but may have some problems
  * with hash to handle recursive lookup. For instance for the typedef
- * example where have mutually recursive definition of the type, 
- * we must take care to not loop by starting the second search 
- * from the previous environment. With the list scheme in 
+ * example where have mutually recursive definition of the type,
+ * we must take care to not loop by starting the second search
+ * from the previous environment. With the list scheme in
  * lookup_env below it's quite easy to do. With hash it may be
  * more complicated.
 *)
-type environment = namedef list list 
+type environment = namedef list list
 
 
 (* ------------------------------------------------------------ *)
-(* can be modified by the init_env function below, by 
- * the file environment_unix.h 
+(* can be modified by the init_env function below, by
+ * the file environment_unix.h
  *)
 let initial_env = ref [
   [VarOrFunc("NULL",
             (Lib.al_type (Parse_c.type_of_string "void *"),
 	    Ast_c.NotLocalVar));
 
-  (*   
+  (*
    VarOrFunc("malloc",
             (Lib.al_type(Parse_c.type_of_string "void* (*)(int size)"),
 	    Ast_c.NotLocalVar));
@@ -204,27 +204,27 @@ let initial_env = ref [
 ]
 
 
-let typedef_debug = ref false 
+let typedef_debug = ref false
 
 
 (* ------------------------------------------------------------ *)
 (* generic, lookup and also return remaining env for further lookup *)
-let rec lookup_env2 f env = 
-  match env with 
+let rec lookup_env2 f env =
+  match env with
   | [] -> raise Not_found
   | []::zs -> lookup_env2 f zs
-  | (x::xs)::zs -> 
+  | (x::xs)::zs ->
       (match f x with
       | None -> lookup_env2 f (xs::zs)
       | Some y -> y, xs::zs
       )
-let lookup_env a b = 
+let lookup_env a b =
   Common.profile_code "TAC.lookup_env" (fun () -> lookup_env2  a b)
 
 
 
-let member_env lookupf env = 
-  try 
+let member_env lookupf env =
+  try
     let _ = lookupf env in
     true
   with Not_found -> false
@@ -235,14 +235,14 @@ let member_env lookupf env =
 (* ------------------------------------------------------------ *)
 
 
-let lookup_var s env = 
+let lookup_var s env =
   let f = function
     | VarOrFunc (s2, typ) -> if s2 =$= s then Some typ else None
     | _ -> None
   in
   lookup_env f env
 
-let lookup_typedef s env = 
+let lookup_typedef s env =
   if !typedef_debug then pr2 ("looking for: " ^ s);
   let f = function
     | TypeDef (s2, typ) -> if s2 =$= s then Some typ else None
@@ -257,14 +257,14 @@ let lookup_structunion (_su, s) env =
   in
   lookup_env f env
 
-let lookup_macro s env = 
+let lookup_macro s env =
   let f = function
     | Macro (s2, typ) -> if s2 =$= s then Some typ else None
     | _ -> None
   in
   lookup_env f env
 
-let lookup_enum s env = 
+let lookup_enum s env =
   let f = function
     | EnumConstant (s2, typ) -> if s2 =$= s then Some typ else None
     | _ -> None
@@ -272,7 +272,7 @@ let lookup_enum s env =
   lookup_env f env
 
 
-let lookup_typedef a b = 
+let lookup_typedef a b =
   Common.profile_code "TAC.lookup_typedef" (fun () -> lookup_typedef  a b)
 
 
@@ -285,7 +285,7 @@ let lookup_typedef a b =
  * x.foo. Sometimes the type of x is a typedef or a structName in which
  * case we must look in environment to find the complete type, here
  * structUnion that contains the information.
- * 
+ *
  * Because in C one can redefine in nested blocks some typedefs,
  * struct, or variables, we have a static scoping resolving process.
  * So, when we look for the type of a var, if this var is in an
@@ -296,86 +296,86 @@ let lookup_typedef a b =
  * where the next search must be performed. *)
 
 (*
-let rec find_final_type ty env = 
+let rec find_final_type ty env =
 
-  match Ast_c.unwrap_typeC ty with 
+  match Ast_c.unwrap_typeC ty with
   | BaseType x  -> (BaseType x) +> Ast_c.rewrap_typeC ty
-      
+
   | Pointer t -> (Pointer (find_final_type t env))  +> Ast_c.rewrap_typeC ty
   | Array (e, t) -> Array (e, find_final_type t env) +> Ast_c.rewrap_typeC ty
-      
+
   | StructUnion (sopt, su) -> StructUnion (sopt, su)  +> Ast_c.rewrap_typeC ty
-      
+
   | FunctionType t -> (FunctionType t) (* todo ? *) +> Ast_c.rewrap_typeC ty
   | Enum  (s, enumt) -> (Enum  (s, enumt)) (* todo? *) +> Ast_c.rewrap_typeC ty
   | EnumName s -> (EnumName s) (* todo? *) +> Ast_c.rewrap_typeC ty
-      
-  | StructUnionName (su, s) -> 
-      (try 
+
+  | StructUnionName (su, s) ->
+      (try
           let ((structtyp,ii), env') = lookup_structunion (su, s) env in
           Ast_c.nQ, (StructUnion (Some s, structtyp), ii)
-          (* old: +> Ast_c.rewrap_typeC ty 
+          (* old: +> Ast_c.rewrap_typeC ty
            * but must wrap with good ii, otherwise pretty_print_c
            * will be lost and raise some Impossible
            *)
-       with Not_found -> 
+       with Not_found ->
          ty
       )
-      
-  | TypeName s -> 
-      (try 
+
+  | TypeName s ->
+      (try
           let (t', env') = lookup_typedef s env in
           find_final_type t' env'
-        with Not_found -> 
+        with Not_found ->
           ty
       )
-      
+
   | ParenType t -> find_final_type t env
   | Typeof e -> failwith "typeof"
-*)  
+*)
 
 
 
 
 (* ------------------------------------------------------------ *)
-let rec type_unfold_one_step ty env = 
+let rec type_unfold_one_step ty env =
 
-  match Ast_c.unwrap_typeC ty with 
+  match Ast_c.unwrap_typeC ty with
   | BaseType x    -> ty
   | Pointer t     -> ty
   | Array (e, t)  -> ty
 
   | StructUnion (sopt, su, fields) -> ty
-      
+
   | FunctionType t   -> ty
   | Enum  (s, enumt) -> ty
 
   | EnumName s       -> ty (* todo: look in env when will have EnumDef *)
-      
-  | StructUnionName (su, s) -> 
-      (try 
+
+  | StructUnionName (su, s) ->
+      (try
           let (((su,fields),ii), env') = lookup_structunion (su, s) env in
           Ast_c.nQ, (StructUnion (su, Some s, fields), ii)
-          (* old: +> Ast_c.rewrap_typeC ty 
+          (* old: +> Ast_c.rewrap_typeC ty
            * but must wrap with good ii, otherwise pretty_print_c
            * will be lost and raise some Impossible
            *)
-       with Not_found -> 
+       with Not_found ->
          ty
       )
-      
-  | TypeName (name, _typ) -> 
+
+  | TypeName (name, _typ) ->
       let s = Ast_c.str_of_name name in
-      (try 
+      (try
           if !typedef_debug then pr2 "type_unfold_one_step: lookup_typedef";
           let (t', env') = lookup_typedef s env in
           type_unfold_one_step t' env'
-       with Not_found -> 
+       with Not_found ->
           ty
       )
-      
+
   | ParenType t -> type_unfold_one_step t env
-  | TypeOfExpr e -> 
+  | TypeOfExpr e ->
       pr2_once ("Type_annoter: not handling typeof");
       ty
   | TypeOfType t -> type_unfold_one_step t env
@@ -388,43 +388,43 @@ let rec type_unfold_one_step ty env =
 
 
 
-(* normalizer. can be seen as the opposite of the previous function as 
+(* normalizer. can be seen as the opposite of the previous function as
  * we "fold" at least for the structUnion. Should return something that
  * Type_c.is_completed_fullType likes, something that makes it easier
  * for the programmer to work on, that has all the needed information
  * for most tasks.
  *)
-let rec typedef_fix ty env = 
-  match Ast_c.unwrap_typeC ty with 
-  | BaseType x  ->  
+let rec typedef_fix ty env =
+  match Ast_c.unwrap_typeC ty with
+  | BaseType x  ->
       ty
-  | Pointer t ->    
+  | Pointer t ->
       Pointer (typedef_fix t env)  +> Ast_c.rewrap_typeC ty
-  | Array (e, t) -> 
+  | Array (e, t) ->
       Array (e, typedef_fix t env) +> Ast_c.rewrap_typeC ty
-  | StructUnion (su, sopt, fields) -> 
-      (* normalize, fold. 
-       * todo? but what if correspond to a nested struct def ? 
+  | StructUnion (su, sopt, fields) ->
+      (* normalize, fold.
+       * todo? but what if correspond to a nested struct def ?
        *)
       Type_c.structdef_to_struct_name ty
-  | FunctionType ft -> 
+  | FunctionType ft ->
       (FunctionType ft) (* todo ? *) +> Ast_c.rewrap_typeC ty
-  | Enum  (s, enumt) -> 
+  | Enum  (s, enumt) ->
       (Enum  (s, enumt)) (* todo? *) +> Ast_c.rewrap_typeC ty
-  | EnumName s -> 
+  | EnumName s ->
       (EnumName s) (* todo? *) +> Ast_c.rewrap_typeC ty
 
   (* we prefer StructUnionName to StructUnion when it comes to typed metavar *)
   | StructUnionName (su, s) -> ty
 
   (* keep the typename but complete with more information *)
-  | TypeName (name, typ) -> 
+  | TypeName (name, typ) ->
       let s = Ast_c.str_of_name name in
       (match typ with
-      | Some _ -> 
+      | Some _ ->
           pr2 ("typedef value already there:" ^ s);
           ty
-      | None -> 
+      | None ->
         (try
           if !typedef_debug then pr2 "typedef_fix: lookup_typedef";
           let (t', env') = lookup_typedef s env in
@@ -434,18 +434,18 @@ let rec typedef_fix ty env =
            * each new type alias search for its mutual def.
            *)
           TypeName (name, Some (typedef_fix t' env')) +> Ast_c.rewrap_typeC ty
-        with Not_found -> 
+        with Not_found ->
           ty
       ))
 
   (* remove paren for better matching with typed metavar. kind of iso again *)
-  | ParenType t -> 
+  | ParenType t ->
       typedef_fix t env
-  | TypeOfExpr e -> 
+  | TypeOfExpr e ->
       pr2_once ("Type_annoter: not handling typeof");
       ty
 
-  | TypeOfType t -> 
+  | TypeOfType t ->
       typedef_fix t env
 
 
@@ -453,9 +453,9 @@ let rec typedef_fix ty env =
 (* Helpers, part 1 *)
 (*****************************************************************************)
 
-let type_of_s2 s = 
+let type_of_s2 s =
   (Lib.al_type (Parse_c.type_of_string s))
-let type_of_s a = 
+let type_of_s a =
   Common.profile_code "Type_c.type_of_s" (fun () -> type_of_s2 a)
 
 
@@ -469,29 +469,29 @@ let type_of_s a =
  *)
 let offset (_,(ty,iis)) =
   match ty, iis with
-  | TypeName (name, _typ), [] -> 
+  | TypeName (name, _typ), [] ->
       (match name with
       | RegularName (s, [ii]) -> ii.Ast_c.pinfo
       | _ -> raise Todo
       )
   | _, ii::_ -> ii.Ast_c.pinfo
   | _ -> failwith "type has no text; need to think again"
-  
 
 
-let rec is_simple_expr expr = 
+
+let rec is_simple_expr expr =
   match Ast_c.unwrap_expr expr with
-  (* todo? handle more special cases ? *) 
-  
-  | Ident _ -> 
+  (* todo? handle more special cases ? *)
+
+  | Ident _ ->
       true
-  | Constant (_)         -> 
+  | Constant (_)         ->
       true
-  | Unary (op, e) -> 
+  | Unary (op, e) ->
       true
-  | Binary (e1, op, e2) -> 
+  | Binary (e1, op, e2) ->
       true
-  | Cast (t, e) -> 
+  | Cast (t, e) ->
       true
   | ParenExpr (e) -> is_simple_expr e
 
@@ -514,10 +514,10 @@ let _scoped_env = ref !initial_env
 (* memoise unnanoted var, to avoid too much warning messages *)
 let _notyped_var = ref (Hashtbl.create 100)
 
-let new_scope() = _scoped_env := []::!_scoped_env 
+let new_scope() = _scoped_env := []::!_scoped_env
 let del_scope() = _scoped_env := List.tl !_scoped_env
 
-let do_in_new_scope f = 
+let do_in_new_scope f =
   begin
     new_scope();
     let res = f() in
@@ -539,109 +539,109 @@ let islocal info =
   else Ast_c.LocalVar info
 
 (* ------------------------------------------------------------ *)
-(* the warning argument is here to allow some binding to overwrite an 
+(* the warning argument is here to allow some binding to overwrite an
  * existing one. With function, we first have the prototype and then the def,
  * and the def binding with the same string is not an error.
- * 
+ *
  * todo?: but if we define two times the same function, then we will not
- * detect it :( it would require to make a diff between adding a binding 
+ * detect it :( it would require to make a diff between adding a binding
  * from a prototype and from a definition.
- * 
- * opti: disabling the check_annotater flag have some important 
+ *
+ * opti: disabling the check_annotater flag have some important
  * performance benefit.
- * 
+ *
  *)
-let add_binding2 namedef warning = 
+let add_binding2 namedef warning =
   let (current_scope, _older_scope) = Common2.uncons !_scoped_env in
 
   if !Flag_parsing_c.check_annotater then begin
     (match namedef with
-    | VarOrFunc (s, typ) -> 
+    | VarOrFunc (s, typ) ->
         if Hashtbl.mem !_notyped_var s
         then pr2 ("warning: found typing information for a variable that was" ^
                      "previously unknown:" ^ s);
     | _ -> ()
     );
-    
-    let (memberf, s) = 
+
+    let (memberf, s) =
       (match namedef with
-      | VarOrFunc (s, typ) -> 
+      | VarOrFunc (s, typ) ->
           member_env (lookup_var s), s
-      | TypeDef   (s, typ) -> 
+      | TypeDef   (s, typ) ->
           member_env (lookup_typedef s), s
-      | StructUnionNameDef (s, (su, typ)) -> 
+      | StructUnionNameDef (s, (su, typ)) ->
           member_env (lookup_structunion (su, s)), s
-      | Macro (s, body) -> 
+      | Macro (s, body) ->
           member_env (lookup_macro s), s
-      | EnumConstant (s, body) -> 
+      | EnumConstant (s, body) ->
           member_env (lookup_enum s), s
       ) in
-    
+
     if  memberf [current_scope] && warning
-    then pr2 ("Type_annoter: warning, " ^ s ^ 
+    then pr2 ("Type_annoter: warning, " ^ s ^
                  " is already in current binding" ^ "\n" ^
                  " so there is a weird shadowing");
   end;
   add_in_scope namedef
 
-let add_binding namedef warning = 
+let add_binding namedef warning =
   Common.profile_code "TAC.add_binding" (fun () -> add_binding2 namedef warning)
-  
+
 
 
 (*****************************************************************************)
 (* Helpers, part 2 *)
 (*****************************************************************************)
 
-let lookup_opt_env lookupf s = 
+let lookup_opt_env lookupf s =
   Common2.optionise (fun () ->
     lookupf s !_scoped_env
   )
 
-let unwrap_unfold_env2 typ = 
-  Ast_c.unwrap_typeC 
-    (type_unfold_one_step typ !_scoped_env) 
-let unwrap_unfold_env typ = 
+let unwrap_unfold_env2 typ =
+  Ast_c.unwrap_typeC
+    (type_unfold_one_step typ !_scoped_env)
+let unwrap_unfold_env typ =
   Common.profile_code "TAC.unwrap_unfold_env" (fun () -> unwrap_unfold_env2 typ)
 
-let typedef_fix a b = 
+let typedef_fix a b =
   Common.profile_code "TAC.typedef_fix" (fun () -> typedef_fix a b)
 
-let make_info_def_fix x = 
-  Type_c.make_info_def (typedef_fix x !_scoped_env)  
+let make_info_def_fix x =
+  Type_c.make_info_def (typedef_fix x !_scoped_env)
 
 let make_info_fix (typ, local) =
   Type_c.make_info ((typedef_fix typ !_scoped_env),local)
 
-      
-let make_info_def = Type_c.make_info_def 
+
+let make_info_def = Type_c.make_info_def
 
 (*****************************************************************************)
 (* Main typer code, put later in a visitor *)
 (*****************************************************************************)
 
-let annotater_expr_visitor_subpart = (fun (k,bigf) expr -> 
+let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
 
-  let ty = 
+  let ty =
     match Ast_c.unwrap_expr expr with
-    
+
     (* -------------------------------------------------- *)
     (* todo: should analyse the 's' for int to know if unsigned or not *)
     | Constant (String (s,kind)) -> make_info_def (type_of_s "char *")
     | Constant MultiString _  -> make_info_def (type_of_s "char *")
     | Constant (Char   (s,kind)) -> make_info_def (type_of_s "char")
     | Constant (Int (s))         -> make_info_def (type_of_s "int")
-    | Constant (Float (s,kind)) -> 
+    | Constant (Float (s,kind)) ->
         let fake = Ast_c.fakeInfo (Parse_info.fake_parse_info) in
         let fake = Ast_c.rewrap_str "float" fake in
         let iinull = [fake] in
         make_info_def
 	  (Ast_c.nQ, (BaseType (FloatType kind), iinull))
-          
-          
+
+
     (* -------------------------------------------------- *)
-    (* note: could factorize this code with the code for Ident 
-     * and the other code for Funcall below. But as the Ident can be 
+    (* note: could factorize this code with the code for Ident
+     * and the other code for Funcall below. But as the Ident can be
      * a macro-func, I prefer to handle it separately. So
      * this rule can handle the macro-func, the Ident-rule can handle
      * the macro-var, and the other FunCall-rule the regular
@@ -649,17 +649,17 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
      * Also as I don't want a warning on the Ident that are a FunCall,
      * easier to have a rule separate from the Ident rule.
      *)
-    | FunCall (((Ident (ident), typ), _ii) as e1, args) -> 
-        
+    | FunCall (((Ident (ident), typ), _ii) as e1, args) ->
+
         (* recurse *)
-        args +> List.iter (fun (e,ii) -> 
+        args +> List.iter (fun (e,ii) ->
           (* could typecheck if arguments agree with prototype *)
           Visitor_c.vk_argument bigf e
         );
         let s = Ast_c.str_of_name ident in
         (match lookup_opt_env lookup_var s with
-        | Some ((typ,local),_nextenv) -> 
-            
+        | Some ((typ,local),_nextenv) ->
+
             (* set type for ident *)
             let tyinfo = make_info_fix (typ, local) in
             Ast_c.set_type_expr e1 tyinfo;
@@ -667,33 +667,33 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
             (match unwrap_unfold_env typ  with
             | FunctionType (ret, params) -> make_info_def ret
 
-            (* can be function pointer, C have an iso for that, 
+            (* can be function pointer, C have an iso for that,
              * same pfn() syntax than regular function call.
              *)
-            | Pointer (typ2) -> 
+            | Pointer (typ2) ->
                 (match unwrap_unfold_env typ2 with
                 | FunctionType (ret, params) -> make_info_def ret
                 | _ -> Type_c.noTypeHere
                 )
             | _ -> Type_c.noTypeHere
             )
-        | None  -> 
+        | None  ->
 
             (match lookup_opt_env lookup_macro s with
-            | Some ((defkind, defval), _nextenv) -> 
+            | Some ((defkind, defval), _nextenv) ->
                 (match defkind, defval with
-                | DefineFunc _, DefineExpr e -> 
+                | DefineFunc _, DefineExpr e ->
                     let rettype = Ast_c.get_onlytype_expr e in
 
                     (* todo: could also set type for ident ?
                        have return type and at least type of concrete
                        parameters so can generate a fake FunctionType
                     *)
-                    let macrotype_opt = 
+                    let macrotype_opt =
                       Type_c.fake_function_type rettype args
                     in
 
-                    macrotype_opt +> Common.do_option (fun t -> 
+                    macrotype_opt +> Common.do_option (fun t ->
                       pr2 ("Type_annotater: generate fake function type" ^
                               "for macro: " ^ s);
                       let tyinfo = make_info_def_fix t in
@@ -701,29 +701,29 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
                     );
 
                     Ast_c.get_type_expr e
-                | DefineVar, _ -> 
+                | DefineVar, _ ->
                     pr2 ("Type_annoter: not a macro-func: " ^ s);
                     Type_c.noTypeHere
-                | DefineFunc _, _ -> 
+                | DefineFunc _, _ ->
                     (* normally the FunCall case should have catch it *)
                     pr2 ("Type_annoter: not a macro-func-expr: " ^ s);
                     Type_c.noTypeHere
                 )
-            | None -> 
+            | None ->
                 pr2_once ("type_annotater: no type for function ident: " ^ s);
                 Type_c.noTypeHere
             )
         )
 
 
-    | FunCall (e, args) -> 
+    | FunCall (e, args) ->
         k expr;
-        
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun typ -> 
-          (* copy paste of above *)   
+
+        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun typ ->
+          (* copy paste of above *)
           (match unwrap_unfold_env typ with
           | FunctionType (ret, params) -> make_info_def ret
-          | Pointer (typ) -> 
+          | Pointer (typ) ->
               (match unwrap_unfold_env typ with
               | FunctionType (ret, params) -> make_info_def ret
               | _ -> Type_c.noTypeHere
@@ -734,73 +734,73 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
 
 
     (* -------------------------------------------------- *)
-    | Ident (ident) -> 
+    | Ident (ident) ->
         let s = Ast_c.str_of_name ident in
         (match lookup_opt_env lookup_var s with
-        | Some ((typ,local),_nextenv) -> 
+        | Some ((typ,local),_nextenv) ->
             make_info_fix (typ,local)
-        | None  -> 
+        | None  ->
             (match lookup_opt_env lookup_macro s with
-            | Some ((defkind, defval), _nextenv) -> 
+            | Some ((defkind, defval), _nextenv) ->
                 (match defkind, defval with
-                | DefineVar, DefineExpr e -> 
+                | DefineVar, DefineExpr e ->
                     Ast_c.get_type_expr e
-                | DefineVar, _ -> 
+                | DefineVar, _ ->
                     pr2 ("Type_annoter: not a expression: " ^ s);
                     Type_c.noTypeHere
-                | DefineFunc _, _ -> 
+                | DefineFunc _, _ ->
                     (* normally the FunCall case should have catch it *)
                     pr2 ("Type_annoter: not a macro-var: " ^ s);
                     Type_c.noTypeHere
                 )
-            | None -> 
+            | None ->
                 (match lookup_opt_env lookup_enum s with
-                | Some (_, _nextenv) -> 
-                    make_info_def (type_of_s "int")                       
-                | None -> 
+                | Some (_, _nextenv) ->
+                    make_info_def (type_of_s "int")
+                | None ->
                     if not (s =~ "[A-Z_]+") (* if macro then no warning *)
-                    then 
-                      if !Flag_parsing_c.check_annotater then 
+                    then
+                      if !Flag_parsing_c.check_annotater then
                         if not (Hashtbl.mem !_notyped_var s)
-                        then begin 
+                        then begin
                           pr2 ("Type_annoter: not finding type for: " ^ s);
                           Hashtbl.add !_notyped_var s true;
                         end
                         else ()
-                      else 
+                      else
                         pr2 ("Type_annoter: not finding type for: " ^ s)
                     ;
                     Type_c.noTypeHere
                 )
             )
         )
-          
+
     (* -------------------------------------------------- *)
     (* C isomorphism on type on array and pointers *)
     | Unary (e, DeRef)
     | ArrayAccess (e, _) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
 
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t -> 
+        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t ->
           (* todo: maybe not good env !! *)
           match unwrap_unfold_env t with
-          | Pointer x  
-          | Array (_, x) -> 
+          | Pointer x
+          | Array (_, x) ->
               make_info_def_fix x
           | _ -> Type_c.noTypeHere
 
         )
 
-    | Unary (e, GetRef) -> 
+    | Unary (e, GetRef) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
 
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t -> 
-          (* must generate an element so that '=' can be used 
+        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t ->
+          (* must generate an element so that '=' can be used
            * to compare type ?
            *)
           let fake = Ast_c.fakeInfo Parse_info.fake_parse_info in
           let fake = Ast_c.rewrap_str "*" fake in
-          
+
           let ft = (Ast_c.nQ, (Pointer t, [fake])) in
           make_info_def_fix ft
         )
@@ -808,134 +808,134 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
 
     (* -------------------------------------------------- *)
     (* fields *)
-    | RecordAccess  (e, namefld) 
-    | RecordPtAccess (e, namefld) as x -> 
+    | RecordAccess  (e, namefld)
+    | RecordPtAccess (e, namefld) as x ->
 
         let fld = Ast_c.str_of_name namefld in
 
         k expr; (* recurse to set the types-ref of sub expressions *)
-        
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t -> 
 
-          let topt = 
+        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t ->
+
+          let topt =
             match x with
             | RecordAccess _ -> Some t
-            | RecordPtAccess _ -> 
-                (match unwrap_unfold_env t with 
+            | RecordPtAccess _ ->
+                (match unwrap_unfold_env t with
                 | Pointer (t) -> Some t
                 | _ -> None
                 )
             | _ -> raise Impossible
-                
+
           in
           (match topt with
           | None -> Type_c.noTypeHere
-          | Some t -> 
+          | Some t ->
               match unwrap_unfold_env t with
-              | StructUnion (su, sopt, fields) -> 
-                  (try 
+              | StructUnion (su, sopt, fields) ->
+                  (try
                       (* todo: which env ? *)
-                      make_info_def_fix 
+                      make_info_def_fix
                         (Type_c.type_field fld (su, fields))
-                    with 
-                    | Not_found -> 
-                        pr2 (spf 
+                    with
+                    | Not_found ->
+                        pr2 (spf
                                 "TYPE-ERROR: field '%s' does not belong in struct %s"
                                 fld (match sopt with Some s -> s |_ -> "<anon>"));
                         Type_c.noTypeHere
-                    | Multi_found -> 
+                    | Multi_found ->
                         pr2 "TAC:MultiFound";
                         Type_c.noTypeHere
                   )
               | _ -> Type_c.noTypeHere
           )
         )
-         
+
 
 
     (* -------------------------------------------------- *)
-    | Cast (t, e) -> 
+    | Cast (t, e) ->
         k expr;
         (* todo: if infer, can "push" info ? add_types_expr [t] e ? *)
         make_info_def_fix (Lib.al_type t)
 
     (* todo? lub, hmm maybe not, cos type must be e1 *)
-    | Assignment (e1, op, e2) -> 
-        k expr; 
+    | Assignment (e1, op, e2) ->
+        k expr;
         (* value of an assignment is the value of the RHS expression *)
         Ast_c.get_type_expr e2
-    | Sequence (e1, e2) -> 
-        k expr; 
+    | Sequence (e1, e2) ->
+        k expr;
         Ast_c.get_type_expr e2
-          
+
     (* todo: lub *)
-    | Binary (e1, op, e2) -> 
+    | Binary (e1, op, e2) ->
         k expr;
         Type_c.lub (Type_c.get_opt_type e1) (Type_c.get_opt_type e2)
 
-    | CondExpr (cond, e1opt, e2) -> 
+    | CondExpr (cond, e1opt, e2) ->
         k expr;
         Ast_c.get_type_expr e2
 
 
-    | ParenExpr e -> 
+    | ParenExpr e ->
         k expr;
         Ast_c.get_type_expr e
 
-    | Infix (e, op)  | Postfix (e, op) -> 
+    | Infix (e, op)  | Postfix (e, op) ->
         k expr;
         Ast_c.get_type_expr e
-          
+
     (* pad: julia wrote this ? *)
-    | Unary (e, UnPlus) -> 
+    | Unary (e, UnPlus) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         make_info_def (type_of_s "int")
           (* todo? can convert from unsigned to signed if UnMinus ? *)
-    | Unary (e, UnMinus) -> 
+    | Unary (e, UnMinus) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         make_info_def (type_of_s "int")
-          
-    | SizeOfType _|SizeOfExpr _ -> 
+
+    | SizeOfType _|SizeOfExpr _ ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         make_info_def (type_of_s "int")
-          
-    | Constructor (ft, ini) -> 
+
+    | Constructor (ft, ini) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         make_info_def (Lib.al_type ft)
-          
-    | Unary (e, Not) -> 
+
+    | Unary (e, Not) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         Ast_c.get_type_expr e
-    | Unary (e, Tilde) -> 
+    | Unary (e, Tilde) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         Ast_c.get_type_expr e
-          
+
     (* -------------------------------------------------- *)
     (* todo *)
-    | Unary (_, GetRefLabel) -> 
+    | Unary (_, GetRefLabel) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         pr2_once "Type annotater:not handling GetRefLabel";
         Type_c.noTypeHere
           (* todo *)
-    | StatementExpr _ ->  
+    | StatementExpr _ ->
         k expr; (* recurse to set the types-ref of sub expressions *)
         pr2_once "Type annotater:not handling GetRefLabel";
         Type_c.noTypeHere
           (*
             | _ -> k expr; Type_c.noTypeHere
           *)
-          
+
   in
   Ast_c.set_type_expr expr ty
 
 )
 
-      
+
 (*****************************************************************************)
 (* Visitor *)
 (*****************************************************************************)
 
-let save_excursion reference f = 
+let save_excursion reference f =
   let old = !reference in
   let res = f() in
   reference := old;
@@ -946,77 +946,77 @@ let save_excursion reference f =
  * big. But for such includes the only thing we really want is to modify
  * the environment to have enough type information. We don't need
  * to type the expressions inside those includes (they will be typed
- * when we process the include file directly). Here the goal is 
+ * when we process the include file directly). Here the goal is
  * to not recurse.
- * 
+ *
  * Note that as usually header files contain mostly structure
  * definitions and defines, that means we still have to do lots of work.
- * We only win on function definition bodies, but usually header files 
+ * We only win on function definition bodies, but usually header files
  * have just prototypes, or inline function definitions which anyway have
  * usually a small body. But still, we win. It also makes clearer
  * that when processing include as we just need the environment, the caller
- * of this module can do further optimisations such as memorising the 
+ * of this module can do further optimisations such as memorising the
  * state of the environment after each header files.
- * 
- * 
+ *
+ *
  * For sparse its makes the annotating speed goes from 9s to 4s
  * For Linux the speedup is even better, from ??? to ???.
- * 
+ *
  * Because There would be some copy paste with annotate_program, it is
  * better to factorize code hence the just_add_in_env parameter below.
- * 
+ *
  * todo? alternative optimisation for the include problem:
  *  - processing all headers files one time and construct big env
  *  - use hashtbl for env (but apparently not biggest problem)
  *)
-    
-let rec visit_toplevel ~just_add_in_env ~depth elem = 
+
+let rec visit_toplevel ~just_add_in_env ~depth elem =
   let need_annotate_body = not just_add_in_env in
 
-  let bigf = { Visitor_c.default_visitor_c with 
+  let bigf = { Visitor_c.default_visitor_c with
 
     (* ------------------------------------------------------------ *)
-    Visitor_c.kcppdirective = (fun (k, bigf) directive -> 
+    Visitor_c.kcppdirective = (fun (k, bigf) directive ->
       match directive with
       (* do error messages for type annotater only for the real body of the
        * file, not inside include.
        *)
-      | Include {i_content = opt} -> 
-          opt +> Common.do_option (fun (filename, program) -> 
-            save_excursion Flag_parsing_c.verbose_type (fun () -> 
+      | Include {i_content = opt} ->
+          opt +> Common.do_option (fun (filename, program) ->
+            save_excursion Flag_parsing_c.verbose_type (fun () ->
               Flag_parsing_c.verbose_type := false;
 
-              (* old: Visitor_c.vk_program bigf program; 
+              (* old: Visitor_c.vk_program bigf program;
                * opti: set the just_add_in_env
                *)
-              program +> List.iter (fun elem -> 
+              program +> List.iter (fun elem ->
                 visit_toplevel ~just_add_in_env:true ~depth:(depth+1) elem
               )
             )
           )
 
-      | Define ((s,ii), (defkind, defval)) -> 
+      | Define ((s,ii), (defkind, defval)) ->
 
 
           (* even if we are in a just_add_in_env phase, such as when
-           * we process include, as opposed to the body of functions, 
-           * with macros we still to type the body of the macro as 
+           * we process include, as opposed to the body of functions,
+           * with macros we still to type the body of the macro as
            * the macro has no type and so we infer its type from its
            * body (and one day later maybe from its use).
            *)
           (match defval with
           (* can try to optimize and recurse only when the define body
-           * is simple ? 
+           * is simple ?
            *)
 
-          | DefineExpr expr -> 
+          | DefineExpr expr ->
               if is_simple_expr expr
              (* even if not need_annotate_body, still recurse*)
-              then k directive 
-              else 
+              then k directive
+              else
                 if need_annotate_body
                 then k directive;
-          | _ -> 
+          | _ ->
               if need_annotate_body
               then k directive;
           );
@@ -1033,17 +1033,17 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
     Visitor_c.kexpr = annotater_expr_visitor_subpart;
 
     (* ------------------------------------------------------------ *)
-    Visitor_c.kstatement = (fun (k, bigf) st -> 
-      match st with 
+    Visitor_c.kstatement = (fun (k, bigf) st ->
+      match st with
       | Compound statxs, ii -> do_in_new_scope (fun () -> k st);
       | _ -> k st
     );
     (* ------------------------------------------------------------ *)
-    Visitor_c.kdecl = (fun (k, bigf) d -> 
+    Visitor_c.kdecl = (fun (k, bigf) d ->
       (match d with
-      | (DeclList (xs, ii)) -> 
+      | (DeclList (xs, ii)) ->
           xs +> List.iter (fun ({v_namei = var; v_type = t;
-                                 v_storage = sto; v_local = local}, iicomma) -> 
+                                 v_storage = sto; v_local = local}, iicomma) ->
 
             (* to add possible definition in type found in Decl *)
             Visitor_c.vk_type bigf t;
@@ -1052,59 +1052,59 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
 	    let local =
 	      match local with
 	      | Ast_c.NotLocalDecl -> Ast_c.NotLocalVar
-	      |	Ast_c.LocalDecl -> Ast_c.LocalVar (offset t) 
+	      |	Ast_c.LocalDecl -> Ast_c.LocalVar (offset t)
             in
-            
-            var +> Common.do_option (fun (name, iniopt) -> 
+
+            var +> Common.do_option (fun (name, iniopt) ->
               let s = Ast_c.str_of_name name in
 
-              match sto with 
-              | StoTypedef, _inline -> 
+              match sto with
+              | StoTypedef, _inline ->
                   add_binding (TypeDef (s,Lib.al_type t)) true;
-              | _ -> 
+              | _ ->
                   add_binding (VarOrFunc (s, (Lib.al_type t, local))) true;
 
 
                   if need_annotate_body then begin
                     (* int x = sizeof(x) is legal so need process ini *)
-                    iniopt +> Common.do_option (fun (info, ini) -> 
+                    iniopt +> Common.do_option (fun (info, ini) ->
                       Visitor_c.vk_ini bigf ini
                     );
                   end
             );
           );
-      | MacroDecl _ -> 
+      | MacroDecl _ ->
           if need_annotate_body
           then k d
       );
-        
+
     );
 
     (* ------------------------------------------------------------ *)
-    Visitor_c.ktype = (fun (k, bigf) typ -> 
-      (* bugfix: have a 'Lib.al_type typ' before, but because we can 
+    Visitor_c.ktype = (fun (k, bigf) typ ->
+      (* bugfix: have a 'Lib.al_type typ' before, but because we can
        * have enum with possible expression, we don't want to change
-       * the ref of abstract-lined types, but the real one, so 
+       * the ref of abstract-lined types, but the real one, so
        * don't al_type here
        *)
       let (_q, t) = typ in
-      match t with 
-      | StructUnion  (su, Some s, structType),ii -> 
-          let structType' = Lib.al_fields structType in 
+      match t with
+      | StructUnion  (su, Some s, structType),ii ->
+          let structType' = Lib.al_fields structType in
           let ii' = Lib.al_ii ii in
           add_binding (StructUnionNameDef (s, ((su, structType'),ii')))  true;
 
           if need_annotate_body
           then k typ (* todo: restrict ? new scope so use do_in_scope ? *)
 
-      | Enum (sopt, enums), ii -> 
+      | Enum (sopt, enums), ii ->
 
-          enums +> List.iter (fun ((name, eopt), iicomma) -> 
+          enums +> List.iter (fun ((name, eopt), iicomma) ->
 
             let s = Ast_c.str_of_name name in
 
             if need_annotate_body
-            then eopt +> Common.do_option (fun (ieq, e) -> 
+            then eopt +> Common.do_option (fun (ieq, e) ->
               Visitor_c.vk_expr bigf e
             );
             add_binding (EnumConstant (s, sopt)) true;
@@ -1114,96 +1114,96 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
       (* TODO: if have a TypeName, then maybe can fill the option
        * information.
        *)
-      | _ -> 
+      | _ ->
           if need_annotate_body
           then k typ
-          
-    );    
+
+    );
 
     (* ------------------------------------------------------------ *)
-    Visitor_c.ktoplevel = (fun (k, bigf) elem -> 
+    Visitor_c.ktoplevel = (fun (k, bigf) elem ->
       _notyped_var := Hashtbl.create 100;
       match elem with
-      | Definition def -> 
+      | Definition def ->
           let {f_name = name;
                f_type = ((returnt, (paramst, b)) as ftyp);
                f_storage = sto;
                f_body = statxs;
                f_old_c_style = oldstyle;
-               },ii 
+               },ii
             = def
           in
-          let (i1, i2) = 
-            match ii with 
-            | iifunc1::iifunc2::ibrace1::ibrace2::ifakestart::isto -> 
+          let (i1, i2) =
+            match ii with
+            | iifunc1::iifunc2::ibrace1::ibrace2::ifakestart::isto ->
                 iifunc1, iifunc2
             | _ -> raise Impossible
           in
           let funcs = Ast_c.str_of_name name in
 
-          (match oldstyle with 
-          | None -> 
-              let typ' = 
+          (match oldstyle with
+          | None ->
+              let typ' =
                 Lib.al_type (Ast_c.nQ, (FunctionType ftyp, [i1;i2])) in
 
-              add_binding (VarOrFunc (funcs, (typ',islocal i1.Ast_c.pinfo))) 
+              add_binding (VarOrFunc (funcs, (typ',islocal i1.Ast_c.pinfo)))
                 false;
 
               if need_annotate_body then
-                do_in_new_scope (fun () -> 
-                  paramst +> List.iter (fun ({p_namei= nameopt; p_type= t},_)-> 
-                    match nameopt with 
+                do_in_new_scope (fun () ->
+                  paramst +> List.iter (fun ({p_namei= nameopt; p_type= t},_)->
+                    match nameopt with
                     | Some name ->
                         let s = Ast_c.str_of_name name in
 		        let local = Ast_c.LocalVar (offset t) in
 		        add_binding (VarOrFunc (s,(Lib.al_type t,local))) true
-                    | None -> 
+                    | None ->
                     pr2 "no type, certainly because Void type ?"
                   );
                   (* recurse *)
                   k elem
                 );
-          | Some oldstyle -> 
+          | Some oldstyle ->
               (* generate regular function type *)
 
-              pr2 "TODO generate type for function"; 
+              pr2 "TODO generate type for function";
               (* add bindings *)
               if need_annotate_body then
-                do_in_new_scope (fun () -> 
+                do_in_new_scope (fun () ->
                   (* recurse. should naturally call the kdecl visitor and
-                   * add binding 
+                   * add binding
                    *)
                   k elem;
                 );
 
           );
-      | CppTop x -> 
+      | CppTop x ->
           (match x with
-          | Define ((s,ii), (DefineVar, DefineType t)) -> 
+          | Define ((s,ii), (DefineVar, DefineType t)) ->
               add_binding (TypeDef (s,Lib.al_type t)) true;
           | _ -> k elem
-          )   
+          )
 
       | Declaration _
 
 
 
       | IfdefTop _
-      | MacroTop _ 
+      | MacroTop _
       | EmptyDef _
       | NotParsedCorrectly _
       | FinalDef _
-          -> 
+          ->
           k elem
     );
-  } 
+  }
   in
   if just_add_in_env
-  then 
-    if depth > 1 
+  then
+    if depth > 1
     then Visitor_c.vk_toplevel bigf elem
-    else 
-      Common.profile_code "TAC.annotate_only_included" (fun () -> 
+    else
+      Common.profile_code "TAC.annotate_only_included" (fun () ->
         Visitor_c.vk_toplevel bigf elem
       )
   else Visitor_c.vk_toplevel bigf elem
@@ -1214,15 +1214,15 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
 (* catch all the decl to grow the environment *)
 
 
-let rec (annotate_program2 : 
+let rec (annotate_program2 :
   environment -> toplevel list -> (toplevel * environment Common2.pair) list) =
  fun env prog ->
 
-  (* globals (re)initialialisation *) 
+  (* globals (re)initialialisation *)
   _scoped_env := env;
   _notyped_var := (Hashtbl.create 100);
 
-  prog +> List.map (fun elem -> 
+  prog +> List.map (fun elem ->
     let beforeenv = !_scoped_env in
     visit_toplevel ~just_add_in_env:false ~depth:0 elem;
     let afterenv = !_scoped_env in
@@ -1236,7 +1236,7 @@ let rec (annotate_program2 :
 (* Annotate test *)
 (*****************************************************************************)
 
-(* julia: for coccinelle *)    
+(* julia: for coccinelle *)
 let annotate_test_expressions prog =
   let rec propagate_test e =
     let ((e_term,info),_) = e in
@@ -1258,7 +1258,7 @@ let annotate_test_expressions prog =
       k expr
     );
     Visitor_c.kstatement = (fun (k, bigf) st ->
-      match unwrap st with 
+      match unwrap st with
 	Selection(s) ->
 	  (match s with If(e1,s1,s2) -> propagate_test e1 | _ -> ());
 	  k st;
@@ -1271,9 +1271,9 @@ let annotate_test_expressions prog =
 	  | _ -> ());
 	  k st
       | _ -> k st
-    ) 
+    )
   } in
-  (prog +> List.iter (fun elem -> 
+  (prog +> List.iter (fun elem ->
     Visitor_c.vk_toplevel bigf elem
   ))
 
@@ -1282,7 +1282,7 @@ let annotate_test_expressions prog =
 (*****************************************************************************)
 (* Annotate types *)
 (*****************************************************************************)
-let annotate_program env prog = 
+let annotate_program env prog =
   Common.profile_code "TAC.annotate_program"
     (fun () ->
       let res = annotate_program2 env prog in
@@ -1290,14 +1290,14 @@ let annotate_program env prog =
       res
     )
 
-let annotate_type_and_localvar env prog = 
+let annotate_type_and_localvar env prog =
   Common.profile_code "TAC.annotate_type"
     (fun () -> annotate_program2 env prog)
 
 
 (*****************************************************************************)
 (* changing default typing environment, do concatenation *)
-let init_env filename = 
+let init_env filename =
   pr2 ("init_env: " ^ filename);
   let (ast2, _stat) = Parse_c.parse_c_and_cpp filename in
   let ast = Parse_c.program_of_program2 ast2 in
@@ -1305,7 +1305,7 @@ let init_env filename =
   let res = annotate_type_and_localvar !initial_env ast in
   match List.rev res with
   | [] -> pr2 "empty environment"
-  | (_top,(env1,env2))::xs -> 
+  | (_top,(env1,env2))::xs ->
       initial_env := !initial_env @ env2;
       ()
 

--- a/parsing_c/type_annoter_c.mli
+++ b/parsing_c/type_annoter_c.mli
@@ -1,4 +1,4 @@
-type namedef = 
+type namedef =
   | VarOrFunc    of string * Ast_c.exp_type
   | EnumConstant of string * string option
 
@@ -9,7 +9,7 @@ type namedef =
   | Macro of string * (Ast_c.define_kind * Ast_c.define_val)
 
 (* have nested scope, so nested list*)
-type environment = namedef list list 
+type environment = namedef list list
 
 (* can be set with init_env *)
 val initial_env : environment ref
@@ -18,20 +18,20 @@ val init_env : Common.filename -> unit
 
 
 
-val annotate_type_and_localvar : 
-  environment -> Ast_c.toplevel list -> 
+val annotate_type_and_localvar :
+  environment -> Ast_c.toplevel list ->
   (Ast_c.toplevel * environment Common2.pair) list
 
 (* julia: cocci *)
-val annotate_test_expressions : 
+val annotate_test_expressions :
   Ast_c.toplevel list -> unit
 
 
 
-(* !!Annotate via side effects!!. Fill in the type  
+(* !!Annotate via side effects!!. Fill in the type
  * information that was put to None during parsing.
  *)
-val annotate_program : 
-  environment -> Ast_c.toplevel list -> 
+val annotate_program :
+  environment -> Ast_c.toplevel list ->
   (Ast_c.toplevel * environment Common2.pair) list
 

--- a/parsing_c/type_c.ml
+++ b/parsing_c/type_c.ml
@@ -1,11 +1,11 @@
-(* Yoann Padioleau 
+(* Yoann Padioleau
  *
  * Copyright (C) 2007, 2008, 2009 University of Urbana Champaign
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -34,15 +34,15 @@ open Ast_c
  * field that we need that information, but the type_annotater has
  * already done this job so no need in the parent expression to know
  * the full definition of the structure. But for typedef, this is different.
- * 
+ *
  * So really the finalType we want, the completed_type notion below,
  * corresponds to a type we think is useful enough to work on, to do
  * pattern matching on, and one where we have all the needed information
  * and we don't need to look again somewhere else to get the information.
  *
- * 
- * 
- * 
+ *
+ *
+ *
  * todo? define a new clean fulltype ? as julia did with type_cocci.ml
  * without the parsing info, with some normalization (for instance have
  * only structUnionName and enumName, and remove the ParenType), some
@@ -51,9 +51,9 @@ open Ast_c
  * or PartialFunctionType (when don't have type of return when infer
  * the type of function call not based on type of function but on the
  * type of its arguments).
- * 
- * 
- * 
+ *
+ *
+ *
  *)
 
 type finalType = Ast_c.fullType
@@ -67,54 +67,54 @@ type removed_typedef = Ast_c.fullType
 (* normally if the type annotated has done a good job, this should always
  * return true. Cf type_annotater_c.typedef_fix.
  *)
-let rec is_completed_and_simplified ty = 
-  match Ast_c.unwrap_typeC ty with 
+let rec is_completed_and_simplified ty =
+  match Ast_c.unwrap_typeC ty with
   | BaseType x  -> true
   | Pointer t -> is_completed_and_simplified t
   | Array (e, t) -> is_completed_and_simplified t
-  | StructUnion (su, sopt, fields) -> 
-      (* recurse fields ? Normally actually don't want, 
+  | StructUnion (su, sopt, fields) ->
+      (* recurse fields ? Normally actually don't want,
        * prefer to have a StructUnionName when it's possible *)
       (match sopt with
       | None -> true
       | Some _ -> false (* should have transformed it in a StructUnionName *)
       )
-  | FunctionType ft -> 
+  | FunctionType ft ->
       (* todo? return type is completed ? params completed ? *)
       true
-  | Enum  (s, enumt) -> 
+  | Enum  (s, enumt) ->
       true
-  | EnumName s -> 
+  | EnumName s ->
       true
 
   (* we prefer StructUnionName to StructUnion when it comes to typed metavar *)
   | StructUnionName (su, s) -> true
 
   (* should have completed with more information *)
-  | TypeName (_name, typ) -> 
+  | TypeName (_name, typ) ->
       (match typ with
       | None -> false
-      | Some t -> 
+      | Some t ->
           (* recurse cos what if it's an alias of an alias ? *)
           is_completed_and_simplified t
       )
 
   (* should have removed paren, for better matching with typed metavar.
    * kind of iso again *)
-  | ParenType t -> 
+  | ParenType t ->
       false
   (* same *)
-  | TypeOfType t -> 
+  | TypeOfType t ->
       false
 
-  | TypeOfExpr e -> 
+  | TypeOfExpr e ->
       true (* well we don't handle it, so can't really say it's completed *)
 
 
-let is_completed_typedef_fullType x = raise Todo  
+let is_completed_typedef_fullType x = raise Todo
 
 let is_removed_typedef_fullType x = raise Todo
-  
+
 (*****************************************************************************)
 (* more "virtual" fulltype, the fullType_with_no_typename *)
 (*****************************************************************************)
@@ -124,34 +124,34 @@ let remove_typedef x = raise Todo
 (* expression exp_info annotation vs finalType *)
 (*****************************************************************************)
 
-(* builders, needed because julia added gradually more information in 
+(* builders, needed because julia added gradually more information in
  * the expression reference annotation in ast_c.
  *)
 
-let make_info x = 
+let make_info x =
   (Some x, Ast_c.NotTest)
 
-let make_exp_type t = 
+let make_exp_type t =
   (t, Ast_c.NotLocalVar)
 
-let make_info_def t = 
+let make_info_def t =
   make_info (make_exp_type t)
 
 
 
-let noTypeHere = 
+let noTypeHere =
   (None, Ast_c.NotTest)
 
 
 
 
 
-let do_with_type f (t,_test) = 
+let do_with_type f (t,_test) =
   match t with
   | None -> noTypeHere
   | Some (t,_local) -> f t
 
-let get_opt_type e = 
+let get_opt_type e =
   match Ast_c.get_type_expr e with
   | Some (t,_), _test -> Some t
   | None, _test -> None
@@ -163,14 +163,14 @@ let get_opt_type e =
 (*****************************************************************************)
 
 
-let structdef_to_struct_name ty = 
-  match ty with 
-  | qu, (StructUnion (su, sopt, fields), iis) -> 
+let structdef_to_struct_name ty =
+  match ty with
+  | qu, (StructUnion (su, sopt, fields), iis) ->
       (match sopt,iis with
       (* todo? but what if correspond to a nested struct def ? *)
-      | Some s , [i1;i2;i3;i4] -> 
+      | Some s , [i1;i2;i3;i4] ->
           qu, (StructUnionName (su, s), [i1;i2])
-      | None, _ -> 
+      | None, _ ->
           ty
       | x -> raise Impossible
       )
@@ -182,8 +182,8 @@ let structdef_to_struct_name ty =
 (*****************************************************************************)
 
 
-let type_of_function (def,ii) = 
-  let ftyp = def.f_type in 
+let type_of_function (def,ii) =
+  let ftyp = def.f_type in
 
   (* could use the info in the 'ii' ? *)
 
@@ -196,41 +196,41 @@ let type_of_function (def,ii) =
 
 
 (* pre: only a single variable *)
-let type_of_decl decl = 
+let type_of_decl decl =
   match decl with
-  | Ast_c.DeclList (xs,ii1) -> 
+  | Ast_c.DeclList (xs,ii1) ->
       (match xs with
       | [] -> raise Impossible
-          
+
       (* todo? for other xs ? *)
-      | (x,ii2)::xs -> 
+      | (x,ii2)::xs ->
           let {v_namei = _var; v_type = v_type;
                v_storage = (_storage,_inline)} = x in
 
           (* TODO normalize ? what if nested structure definition ? *)
           v_type
       )
-  | Ast_c.MacroDecl _ -> 
+  | Ast_c.MacroDecl _ ->
       pr2_once "not handling MacroDecl type yet";
       raise Todo
 
 
 
 (* pre: it is indeed a struct def decl, and only a single variable *)
-let structdef_of_decl decl = 
+let structdef_of_decl decl =
 
   match decl with
-  | Ast_c.DeclList (xs,ii1) -> 
+  | Ast_c.DeclList (xs,ii1) ->
       (match xs with
       | [] -> raise Impossible
-          
+
       (* todo? for other xs ? *)
-      | (x,ii2)::xs -> 
+      | (x,ii2)::xs ->
           let {v_namei = var; v_type = v_type;
                v_storage = (storage,inline)} = x in
-          
+
           (match Ast_c.unwrap_typeC v_type with
-          | Ast_c.StructUnion (su, _must_be_some, fields) -> 
+          | Ast_c.StructUnion (su, _must_be_some, fields) ->
               (su, fields)
           | _ -> raise Impossible
           )
@@ -244,8 +244,8 @@ let structdef_of_decl decl =
 (* Type builder  *)
 (*****************************************************************************)
 
-let (fake_function_type: 
-   fullType option -> argument wrap2 list -> fullType option) = 
+let (fake_function_type:
+   fullType option -> argument wrap2 list -> fullType option) =
  fun rettype args ->
 
   let fake = Ast_c.fakeInfo (Parse_info.fake_parse_info) in
@@ -253,13 +253,13 @@ let (fake_function_type:
   let fake = Ast_c.fakeInfo (Parse_info.fake_parse_info) in
   let fake_cparen = Ast_c.rewrap_str ")" fake in
 
-  let (tyargs: parameterType wrap2 list) = 
-    args +> Common.map_filter (fun (arg,ii) -> 
+  let (tyargs: parameterType wrap2 list) =
+    args +> Common.map_filter (fun (arg,ii) ->
       match arg with
-      | Left e -> 
+      | Left e ->
           (match Ast_c.get_onlytype_expr e with
-          | Some ft -> 
-              let paramtype = 
+          | Some ft ->
+              let paramtype =
                 { Ast_c.p_namei = None;
                   p_register = false, Ast_c.noii;
                   p_type = ft;
@@ -274,10 +274,10 @@ let (fake_function_type:
   if List.length args <> List.length tyargs
   then None
   else
-    rettype +> Common2.map_option (fun rettype -> 
+    rettype +> Common2.map_option (fun rettype ->
       let (ftyp: functionType) = (rettype, (tyargs, (false,[]))) in
-      let (t: fullType) = 
-        (Ast_c.nQ, (FunctionType ftyp, [fake_oparen;fake_cparen]))  
+      let (t: fullType) =
+        (Ast_c.nQ, (FunctionType ftyp, [fake_oparen;fake_cparen]))
       in
       t
     )
@@ -290,35 +290,35 @@ let (fake_function_type:
 
 (* todo: the rules are far more complex, but I prefer to simplify for now.
  * todo: should take operator as a parameter.
- * 
+ *
  * todo: Also need handle pointer arithmetic! the type of 'pt + 2'
  * is still the type of pt. cf parsing_cocci/type_infer.ml
- * 
+ *
  * (* pad: in pointer arithmetic, as in ptr+1, the lub must be ptr *)
  * | (T.Pointer(ty1),T.Pointer(ty2)) ->
  * T.Pointer(loop(ty1,ty2))
  * | (ty1,T.Pointer(ty2)) -> T.Pointer(ty2)
  * | (T.Pointer(ty1),ty2) -> T.Pointer(ty1)
- * 
+ *
 *)
-let lub t1 t2 = 
-  let ftopt = 
+let lub t1 t2 =
+  let ftopt =
     match t1, t2 with
     | None, None -> None
     | Some t, None -> Some t
     | None, Some t -> Some t
-    (* check equal ? no cos can have pointer arithmetic so t2 can be <> t1 
-     * 
-     * todo: right now I favor the first term because usually pointer 
+    (* check equal ? no cos can have pointer arithmetic so t2 can be <> t1
+     *
+     * todo: right now I favor the first term because usually pointer
      * arithmetic are written with the pointer in the first position.
-     * 
-     * Also when an expression contain a typedef, as in 
+     *
+     * Also when an expression contain a typedef, as in
      * 'dma_addr + 1' where dma_addr was declared as a varialbe
      * of type dma_addr_t, then again I want to have in the lub
      * the typedef and it is often again in the first position.
-     * 
+     *
     *)
-    | Some t1, Some t2 -> 
+    | Some t1, Some t2 ->
         let t1bis = Ast_c.unwrap_typeC t1 in
         let t2bis = Ast_c.unwrap_typeC t2 in
         (match t1bis, t2bis with
@@ -337,65 +337,65 @@ let lub t1 t2 =
 (* type lookup *)
 (*****************************************************************************)
 
-(* old: was using some nested find_some, but easier use ref 
+(* old: was using some nested find_some, but easier use ref
  * update: handling union (used a lot in sparse)
- * note: it is independent of the environment. 
+ * note: it is independent of the environment.
 *)
-let (type_field: 
-  string -> (Ast_c.structUnion * Ast_c.structType) -> Ast_c.fullType) = 
- fun fld (su, fields) -> 
+let (type_field:
+  string -> (Ast_c.structUnion * Ast_c.structType) -> Ast_c.fullType) =
+ fun fld (su, fields) ->
 
   let res = ref [] in
-    
-  let rec aux_fields fields = 
-    fields +> List.iter (fun x -> 
+
+  let rec aux_fields fields =
+    fields +> List.iter (fun x ->
       match x with
-      | DeclarationField (FieldDeclList (onefield_multivars, iiptvirg)) -> 
-          onefield_multivars +> List.iter (fun (fieldkind, iicomma) -> 
+      | DeclarationField (FieldDeclList (onefield_multivars, iiptvirg)) ->
+          onefield_multivars +> List.iter (fun (fieldkind, iicomma) ->
             match fieldkind with
-            | Simple (Some name, t) | BitField (Some name, t, _, _) -> 
+            | Simple (Some name, t) | BitField (Some name, t, _, _) ->
                 let s = Ast_c.str_of_name name in
-                if s =$= fld 
+                if s =$= fld
                 then Common.push t res
                 else ()
-                  
-            | Simple (None, t) -> 
+
+            | Simple (None, t) ->
                 (match Ast_c.unwrap_typeC t with
 
                 (* union *)
-                | StructUnion (Union, _, fields) -> 
+                | StructUnion (Union, _, fields) ->
                     aux_fields fields
-                      
-                (* Special case of nested structure definition inside 
-                 * structure without associated field variable as in 
+
+                (* Special case of nested structure definition inside
+                 * structure without associated field variable as in
                  * struct top = { ... struct xx { int subfield1; ... }; ... }
                  * cf sparse source, where can access subfields directly.
                  * It can also be used in conjunction with union.
                  *)
-                | StructUnion (Struct, _, fields) -> 
+                | StructUnion (Struct, _, fields) ->
                     aux_fields fields
-                      
+
                 | _ -> ()
                 )
             | _ -> ()
           )
-            
+
       | EmptyField info -> ()
       | MacroDeclField _ -> pr2_once "DeclTodo"; ()
-          
+
       | CppDirectiveStruct _
-      | IfdefStruct _ -> pr2_once "StructCpp"; 
+      | IfdefStruct _ -> pr2_once "StructCpp";
     )
   in
   aux_fields fields;
   match !res with
   | [t] -> t
-  | [] -> 
+  | [] ->
       raise Not_found
-  | x::y::xs -> 
+  | x::y::xs ->
       pr2 ("MultiFound field: " ^ fld) ;
       x
-    
+
 
 
 (*****************************************************************************)
@@ -405,23 +405,23 @@ let (type_field:
 
 (* was in aliasing_function_c.ml before*)
 
-(* assume normalized/completed ? so no ParenType handling to do ? 
+(* assume normalized/completed ? so no ParenType handling to do ?
 *)
-let rec is_function_type x = 
+let rec is_function_type x =
   match Ast_c.unwrap_typeC x with
   | FunctionType _ -> true
   | _ -> false
 
 
 (* assume normalized/completed ? so no ParenType handling to do ? *)
-let rec function_pointer_type_opt x = 
+let rec function_pointer_type_opt x =
   match Ast_c.unwrap_typeC x with
-  | Pointer y -> 
+  | Pointer y ->
       (match Ast_c.unwrap_typeC y with
       | FunctionType ft -> Some ft
 
       (* fix *)
-      | TypeName (_name, Some ft2) -> 
+      | TypeName (_name, Some ft2) ->
           (match Ast_c.unwrap_typeC ft2 with
           | FunctionType ft -> Some ft
           | _ -> None
@@ -429,14 +429,14 @@ let rec function_pointer_type_opt x =
 
       | _ -> None
       )
-  (* bugfix: for many fields in structure, the field is a typename 
-   * like irq_handler_t to a function pointer 
+  (* bugfix: for many fields in structure, the field is a typename
+   * like irq_handler_t to a function pointer
    *)
-  | TypeName (_name, Some ft) -> 
+  | TypeName (_name, Some ft) ->
       function_pointer_type_opt ft
   (* bugfix: in field, usually it has some ParenType *)
 
-  | ParenType ft -> 
+  | ParenType ft ->
       function_pointer_type_opt ft
 
   | _ -> None

--- a/parsing_c/type_c.mli
+++ b/parsing_c/type_c.mli
@@ -16,21 +16,21 @@ val remove_typedef: completed_typedef -> removed_typedef
 
 
 (* lookup *)
-val type_field: 
+val type_field:
   string -> (Ast_c.structUnion * Ast_c.structType) -> Ast_c.fullType
 
 (* typing rules *)
-val lub: 
+val lub:
   finalType option -> finalType option -> Ast_c.exp_info
 
 (* helpers *)
-val structdef_to_struct_name: 
+val structdef_to_struct_name:
   finalType -> finalType
-val fake_function_type: 
+val fake_function_type:
   finalType option -> Ast_c.argument Ast_c.wrap2 list -> finalType option
 
 (* return normalize types ? *)
-val type_of_function: 
+val type_of_function:
   Ast_c.definition -> finalType
 val type_of_decl:
   Ast_c.declaration -> finalType
@@ -44,9 +44,9 @@ val make_info: Ast_c.exp_type -> Ast_c.exp_info
 
 val noTypeHere: Ast_c.exp_info
 
-val do_with_type: 
+val do_with_type:
   (finalType -> Ast_c.exp_info) -> Ast_c.exp_info -> Ast_c.exp_info
-val get_opt_type: 
+val get_opt_type:
   Ast_c.expression -> finalType option
 
 (* helpers bis *)

--- a/parsing_c/type_cocci.ml
+++ b/parsing_c/type_cocci.ml
@@ -3,12 +3,12 @@
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
- * 
+ *
  * This file was part of Coccinelle.
  *)
 

--- a/parsing_c/unparse_c.ml
+++ b/parsing_c/unparse_c.ml
@@ -1,17 +1,17 @@
 (* Yoann Padioleau, Julia Lawall
- * 
+ *
  * Copyright (C) 2006, 2007, 2008, 2009 Ecole des Mines de Nantes and DIKU
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * file license.txt for more details.
- * 
- * 
+ *
+ *
  * Modifications by Julia Lawall for better newline handling.
  *)
 open Common
@@ -32,7 +32,7 @@ labels found in the control-flow graph *)
 (* Types used during the intermediate phases of the unparsing *)
 (*****************************************************************************)
 
-type token1 = 
+type token1 =
   | Fake1 of info
   | T1 of Parser_c.token
 
@@ -41,12 +41,12 @@ type token1 =
  * token and get something simpler ? because we need to know if the
  * info is a TCommentCpp or TCommentSpace, etc for some of the further
  * analysis so easier to keep with the token.
- * 
+ *
  * This type contains the whole information. Have all the tokens with this
  * type.
  *)
-type token2 = 
-  | T2 of Parser_c.token * bool (* minus *) * 
+type token2 =
+  | T2 of Parser_c.token * bool (* minus *) *
           int option (* orig index, abstracting away comments and space *)
   | Fake2
   | Cocci2 of string
@@ -55,7 +55,7 @@ type token2 =
   | Unindent_cocci2
 
 (* not used yet *)
-type token3 = 
+type token3 =
   | T3 of Parser_c.token
   | Cocci3 of string
   | C3 of string
@@ -75,7 +75,7 @@ type token_extended = {
 (* Helpers *)
 (*****************************************************************************)
 
-let info_of_token1 t = 
+let info_of_token1 t =
   match t with
   | Fake1 info -> info
   | T1 tok -> TH.info_of_tok tok
@@ -106,22 +106,22 @@ let str_of_token3 = function
 
 
 
-let mk_token_extended x = 
-  let origidx = 
+let mk_token_extended x =
+  let origidx =
     match x with
-    | T2 (_,_, idx) -> idx 
+    | T2 (_,_, idx) -> idx
     | _ -> None
   in
-  { tok2 = x; 
+  { tok2 = x;
     str = str_of_token2 x;
     idx = origidx;
     new_tokens_before = [];
     remove = false;
   }
 
-let rebuild_tokens_extented toks_ext = 
+let rebuild_tokens_extented toks_ext =
   let _tokens = ref [] in
-  toks_ext +> List.iter (fun tok -> 
+  toks_ext +> List.iter (fun tok ->
     tok.new_tokens_before +> List.iter (fun x -> Common.push x _tokens);
     if not tok.remove then Common.push tok.tok2 _tokens;
   );
@@ -137,7 +137,7 @@ let mcode_contain_plus = function
   | Ast_cocci.MINUS (_,x::xs) -> true
   | Ast_cocci.PLUS -> raise Impossible
 
-let contain_plus info = 
+let contain_plus info =
   let mck = Ast_c.mcode_of_info info in
   mcode_contain_plus mck
 
@@ -145,14 +145,14 @@ let contain_plus info =
 (* Last fix on the ast *)
 (*****************************************************************************)
 
-(* Because of the ugly trick to handle initialiser, I generate fake ',' 
+(* Because of the ugly trick to handle initialiser, I generate fake ','
  * for the last initializer element, but if there is nothing around it,
  * I don't want in the end to print it.
  *)
 
-let remove_useless_fakeInfo_struct program = 
+let remove_useless_fakeInfo_struct program =
   let bigf = { Visitor_c.default_visitor_c_s with
-    Visitor_c.kini_s = (fun (k,bigf) ini -> 
+    Visitor_c.kini_s = (fun (k,bigf) ini ->
       match k ini with
       | InitList args, ii ->
           (match ii with
@@ -163,7 +163,7 @@ let remove_useless_fakeInfo_struct program =
                  (* sometimes the guy put a normal iicommaopt *)
               then InitList args, [i1;i2]
               else InitList args, [i1;i2;iicommaopt]
-          | [i1;i2;iicommaopt;end_comma_opt] -> 
+          | [i1;i2;iicommaopt;end_comma_opt] ->
 	      (* only in #define. end_comma_opt canot be fake *)
 	      (* not sure if this will be considered ambiguous with a previous
 		 case? *)
@@ -184,23 +184,23 @@ let remove_useless_fakeInfo_struct program =
 (* Tokens1 generation *)
 (*****************************************************************************)
 
-let get_fakeInfo_and_tokens celem toks = 
-  let toks_in  = ref toks in 
+let get_fakeInfo_and_tokens celem toks =
+  let toks_in  = ref toks in
   let toks_out = ref [] in
 
   (* todo? verify good order of position ? *)
-  let pr_elem info = 
+  let pr_elem info =
     match Ast_c.pinfo_of_info info with
-    | FakeTok _ -> 
+    | FakeTok _ ->
         Common.push (Fake1 info) toks_out
-    | OriginTok _ | ExpandedTok _ -> 
+    | OriginTok _ | ExpandedTok _ ->
         (* get the associated comments/space/cppcomment tokens *)
-        let (before, x, after) = !toks_in +> Common2.split_when (fun tok -> 
+        let (before, x, after) = !toks_in +> Common2.split_when (fun tok ->
 	  info =*= TH.info_of_tok tok)
         in
         assert(info =*= TH.info_of_tok x);
         (*old: assert(before +> List.for_all (TH.is_comment)); *)
-        before +> List.iter (fun x -> 
+        before +> List.iter (fun x ->
           if not (TH.is_comment x)
           then pr2 ("WEIRD: not a comment:" ^ TH.str_of_tok x)
           (* case such as  int asm d3("x"); not yet in ast *)
@@ -208,11 +208,11 @@ let get_fakeInfo_and_tokens celem toks =
         before +> List.iter (fun x -> Common.push (T1 x) toks_out);
         Common.push (T1 x) toks_out;
         toks_in := after;
-    | AbstractLineTok _ -> 
+    | AbstractLineTok _ ->
         (* can be called on type info when for instance use -type_c *)
         if !Flag_parsing_c.pretty_print_type_info
         then Common.push (Fake1 info) toks_out
-        else raise Impossible (* at this stage *) 
+        else raise Impossible (* at this stage *)
   in
 
   let pr_space _ = () in (* use the spacing that is there already *)
@@ -243,7 +243,7 @@ let displace_fake_nodes toks =
     match fake_info with
       Some(bef,((Fake1 info) as fake),aft) ->
 	(match !(info.cocci_tag) with
-        | Some x -> 
+        | Some x ->
           (match x with
 	  (Ast_cocci.CONTEXT(_,Ast_cocci.BEFORE _),_) ->
 	    (* move the fake node forwards *)
@@ -262,7 +262,7 @@ let displace_fake_nodes toks =
 	    failwith "fake node should not be before-after"
 	| _ -> bef @ fake :: (loop aft) (* old: was removed when have simpler yacfe *)
         )
-        | None -> 
+        | None ->
             bef @ fake :: (loop aft)
         )
     | None -> toks
@@ -278,25 +278,25 @@ let comment2t2 = function
       C2("\n"^info.Parse_info.str^"\n")
   | x -> failwith (Printf.sprintf "unexpected comment %s" (Common.dump x))
 
-let expand_mcode toks = 
+let expand_mcode toks =
   let toks_out = ref [] in
 
   let index = ref 0 in
 
-  let add_elem t minus = 
+  let add_elem t minus =
     match t with
-    | Fake1 info -> 
+    | Fake1 info ->
         let str = Ast_c.str_of_info info in
         if str =$= ""
         then Common.push (Fake2) toks_out
         (* perhaps the fake ',' *)
         else Common.push (C2 str) toks_out
-          
-  
-    | T1 tok -> 
+
+
+    | T1 tok ->
 	(*let (a,b) = !((TH.info_of_tok tok).cocci_tag) in*)
         (* no tag on expandedTok ! *)
-        (if (TH.is_expanded tok && 
+        (if (TH.is_expanded tok &&
             !((TH.info_of_tok tok).cocci_tag) <> Ast_c.emptyAnnot)
 	then
 	  failwith
@@ -304,11 +304,11 @@ let expand_mcode toks =
 	       "expanded token %s on line %d is either modified or stored in a metavariable"
 	       (TH.str_of_tok tok) (TH.line_of_tok tok)));
 
-        let tok' = tok +> TH.visitor_info_of_tok (fun i -> 
+        let tok' = tok +> TH.visitor_info_of_tok (fun i ->
           { i with cocci_tag = ref Ast_c.emptyAnnot; }
         ) in
 
-        let optindex = 
+        let optindex =
           if TH.is_origin tok && not (TH.is_real_comment tok)
           then begin
               incr index;
@@ -320,14 +320,14 @@ let expand_mcode toks =
         Common.push (T2 (tok', minus, optindex)) toks_out
   in
 
-  let expand_info t = 
-    let (mcode,env) = 
+  let expand_info t =
+    let (mcode,env) =
       Ast_c.mcode_and_env_of_cocciref ((info_of_token1 t).cocci_tag) in
 
-    let pr_cocci s = 
-      Common.push (Cocci2 s) toks_out 
+    let pr_cocci s =
+      Common.push (Cocci2 s) toks_out
     in
-    let pr_c info = 
+    let pr_c info =
       (match Ast_c.pinfo_of_info info with
 	Ast_c.AbstractLineTok _ ->
 	  Common.push (C2 (Ast_c.str_of_info info)) toks_out
@@ -348,30 +348,30 @@ let expand_mcode toks =
 
     let args_pp = (env, pr_cocci, pr_c, pr_space, indent, unindent) in
 
-    (* old: when for yacfe with partial cocci: 
-     *    add_elem t false; 
+    (* old: when for yacfe with partial cocci:
+     *    add_elem t false;
     *)
 
     (* patch: when need full coccinelle transformation *)
     let unparser = Unparse_cocci.pp_list_list_any args_pp false in
     match mcode with
-    | Ast_cocci.MINUS (_,any_xxs) -> 
+    | Ast_cocci.MINUS (_,any_xxs) ->
         (* Why adding ? because I want to have all the information, the whole
-         * set of tokens, so I can then process and remove the 
+         * set of tokens, so I can then process and remove the
          * is_between_two_minus for instance *)
         add_elem t true;
         unparser any_xxs Unparse_cocci.InPlace
-    | Ast_cocci.CONTEXT (_,any_befaft) -> 
+    | Ast_cocci.CONTEXT (_,any_befaft) ->
         (match any_befaft with
-        | Ast_cocci.NOTHING -> 
+        | Ast_cocci.NOTHING ->
             add_elem t false
-        | Ast_cocci.BEFORE xxs -> 
+        | Ast_cocci.BEFORE xxs ->
             unparser xxs Unparse_cocci.Before;
             add_elem t false
-        | Ast_cocci.AFTER xxs -> 
+        | Ast_cocci.AFTER xxs ->
             add_elem t false;
             unparser xxs Unparse_cocci.After;
-        | Ast_cocci.BEFOREAFTER (xxs, yys) -> 
+        | Ast_cocci.BEFOREAFTER (xxs, yys) ->
             unparser xxs Unparse_cocci.Before;
             add_elem t false;
             unparser yys Unparse_cocci.After;
@@ -382,20 +382,20 @@ let expand_mcode toks =
 
   toks +> List.iter expand_info;
   List.rev !toks_out
-        
+
 
 (*****************************************************************************)
 (* Tokens2 processing, filtering, adjusting *)
 (*****************************************************************************)
 
 let is_minusable_comment = function
-  | (T2 (t,_b,_i)) -> 
+  | (T2 (t,_b,_i)) ->
       (match t with
       | Parser_c.TCommentSpace _   (* only whitespace *)
-      (* patch: coccinelle *)      
+      (* patch: coccinelle *)
       | Parser_c.TCommentNewline _ (* newline plus whitespace *)
-      | Parser_c.TComment _ 
-      | Parser_c.TCommentCpp (Token_c.CppAttr, _) 
+      | Parser_c.TComment _
+      | Parser_c.TCommentCpp (Token_c.CppAttr, _)
       | Parser_c.TCommentCpp (Token_c.CppMacro, _)
       | Parser_c.TCommentCpp (Token_c.CppDirective, _) (* result was false *)
         -> true
@@ -406,7 +406,7 @@ let is_minusable_comment = function
 
       | _ -> false
       )
-  | _ -> false 
+  | _ -> false
 
 let all_coccis = function
     Cocci2 _ | C2 _ | Indent_cocci2 | Unindent_cocci2 -> true
@@ -416,24 +416,24 @@ let all_coccis = function
 let is_minusable_comment_or_plus x = is_minusable_comment x || all_coccis x
 
 let set_minus_comment = function
-  | T2 (t,false,idx) -> 
+  | T2 (t,false,idx) ->
       let str = TH.str_of_tok t in
       (match t with
       | Parser_c.TCommentSpace _
-(* patch: coccinelle *)      
+(* patch: coccinelle *)
       | Parser_c.TCommentNewline _ -> ()
 
-      | Parser_c.TComment _ 
-      | Parser_c.TCommentCpp (Token_c.CppAttr, _) 
+      | Parser_c.TComment _
+      | Parser_c.TCommentCpp (Token_c.CppAttr, _)
       | Parser_c.TCommentCpp (Token_c.CppMacro, _)
       | Parser_c.TCommentCpp (Token_c.CppDirective, _)
-        -> 
+        ->
           pr2 (Printf.sprintf "%d: ERASING_COMMENTS: %s"
 		 (TH.line_of_tok t) str)
       | _ -> raise Impossible
       );
       T2 (t, true, idx)
-(* patch: coccinelle *)   
+(* patch: coccinelle *)
   | T2 (Parser_c.TCommentNewline _,true,idx) as x -> x
   | _ -> raise Impossible
 
@@ -444,7 +444,7 @@ let set_minus_comment_or_plus = function
 let remove_minus_and_between_and_expanded_and_fake xs =
 
   (* get rid of exampled and fake tok *)
-  let xs = xs +> Common.exclude (function 
+  let xs = xs +> Common.exclude (function
     | T2 (t,_,_) when TH.is_expanded t -> true
     | Fake2 -> true
 
@@ -509,7 +509,7 @@ let remove_minus_and_between_and_expanded_and_fake xs =
   let rec adjust_between_minus xs =
     match xs with
     | [] -> []
-    | (T2 (t1,true,idx1))::xs -> 
+    | (T2 (t1,true,idx1))::xs ->
 
         let (between_comments, rest) =
 	  Common.span is_minusable_comment_or_plus xs in
@@ -555,11 +555,11 @@ let adjust_before_semicolon toks =
 
 let is_ident_like s = (s ==~ Common2.regexp_alpha)
 
-let rec add_space xs = 
+let rec add_space xs =
   match xs with
   | [] -> []
   | [x] -> [x]
-  | x::y::xs -> 
+  | x::y::xs ->
       let sx = str_of_token2 x in
       let sy = str_of_token2 y in
       if is_ident_like sx && is_ident_like sy
@@ -572,12 +572,12 @@ let rec add_space xs =
  * code at the right place, with the good indentation. So each time we
  * encounter some spacing info, with some newline, we maintain the
  * current indentation level used.
- * 
+ *
  * TODO problems: not accurate. ex: TODO
- * 
+ *
  * TODO: if in #define region, should add a \ \n
  *)
-let new_tabbing2 space = 
+let new_tabbing2 space =
   (list_of_string space)
     +> List.rev
     +> Common2.take_until (fun c -> c =<= '\n')
@@ -585,11 +585,11 @@ let new_tabbing2 space =
     +> List.map string_of_char
     +> String.concat ""
 
-let new_tabbing a = 
+let new_tabbing a =
   Common.profile_code "C unparsing.new_tabbing" (fun () -> new_tabbing2 a)
 
 
-let rec adjust_indentation xs = 
+let rec adjust_indentation xs =
   let _current_tabbing = ref "" in
   let tabbing_unit = ref None in
 
@@ -630,7 +630,7 @@ let rec adjust_indentation xs =
     | x::xs -> find_first_tab started xs in
   find_first_tab false xs;
 
-  let rec aux started xs = 
+  let rec aux started xs =
     match xs with
     | [] ->  []
 (* patch: coccinelle *)
@@ -639,7 +639,7 @@ let rec adjust_indentation xs =
 	(* to be done for if, etc, but not for a function header *)
 	x::(Cocci2 " {")::(aux started xs)
     | ((T2 (Parser_c.TCommentNewline s, _, _)) as x)::xs ->
-	let old_tabbing = !_current_tabbing in 
+	let old_tabbing = !_current_tabbing in
         str_of_token2 x +> new_tabbing +> (fun s -> _current_tabbing := s);
 	(* only trust the indentation after the first { *)
 	(if started then adjust_tabbing_unit old_tabbing !_current_tabbing);
@@ -671,9 +671,9 @@ let rec adjust_indentation xs =
     (* starting the body of the function *)
     | ((T2 (tok,_,_)) as x)::xs when str_of_token2 x =$= "{" ->  x::aux true xs
     | (Cocci2 "{")::xs -> (Cocci2 "{")::aux true xs
-    | ((Cocci2 "\n") as x)::xs -> 
+    | ((Cocci2 "\n") as x)::xs ->
             (* dont inline in expr because of weird eval order of ocaml *)
-        let s = !_current_tabbing in 
+        let s = !_current_tabbing in
         x::Cocci2 (s)::aux started xs
     | x::xs -> x::aux started xs in
   aux false xs
@@ -684,34 +684,34 @@ let rec find_paren_comma = function
 
   (* do nothing if was like this in original file *)
   | ({ str = "("; idx = Some p1 } as _x1)::({ str = ","; idx = Some p2} as x2)
-    ::xs when p2 =|= p1 + 1 -> 
+    ::xs when p2 =|= p1 + 1 ->
       find_paren_comma (x2::xs)
 
   | ({ str = ","; idx = Some p1 } as _x1)::({ str = ","; idx = Some p2} as x2)
-    ::xs when p2 =|= p1 + 1 -> 
+    ::xs when p2 =|= p1 + 1 ->
       find_paren_comma (x2::xs)
 
   | ({ str = ","; idx = Some p1 } as _x1)::({ str = ")"; idx = Some p2} as x2)
-    ::xs when p2 =|= p1 + 1 -> 
+    ::xs when p2 =|= p1 + 1 ->
       find_paren_comma (x2::xs)
 
   (* otherwise yes can adjust *)
-  | ({ str = "(" } as _x1)::({ str = ","} as x2)::xs -> 
+  | ({ str = "(" } as _x1)::({ str = ","} as x2)::xs ->
       x2.remove <- true;
       find_paren_comma (x2::xs)
-  | ({ str = "," } as x1)::({ str = ","} as x2)::xs -> 
+  | ({ str = "," } as x1)::({ str = ","} as x2)::xs ->
       x1.remove <- true;
       find_paren_comma (x2::xs)
 
-  | ({ str = "," } as x1)::({ str = ")"} as x2)::xs -> 
+  | ({ str = "," } as x1)::({ str = ")"} as x2)::xs ->
       x1.remove <- true;
       find_paren_comma (x2::xs)
 
-  | x::xs -> 
+  | x::xs ->
       find_paren_comma xs
-  
 
-let fix_tokens toks = 
+
+let fix_tokens toks =
   let toks = toks +> List.map mk_token_extended in
 
   let cleaner = toks +> Common.exclude (function
@@ -744,12 +744,12 @@ let kind_of_token2 = function
       | AbstractLineTok _ -> raise Impossible (* now a KC *)
       )
   | Unindent_cocci2 | Indent_cocci2 -> raise Impossible
-  
+
 let end_mark = "!"
 
 let start_mark = function
   | KFake -> "!F!"
-  | KCocci -> "!S!" 
+  | KCocci -> "!S!"
   | KC -> "!A!"
   | KExpanded -> "!E!"
   | KOrigin -> ""
@@ -758,7 +758,7 @@ let print_all_tokens2 pr xs =
   if !Flag_parsing_c.debug_unparsing
   then
     let current_kind = ref KOrigin in
-    xs +> List.iter (fun t -> 
+    xs +> List.iter (fun t ->
       let newkind = kind_of_token2 t in
       if newkind =*= !current_kind
       then pr (str_of_token2 t)
@@ -769,9 +769,9 @@ let print_all_tokens2 pr xs =
         current_kind := newkind
       end
     );
-  else 
+  else
     xs +> List.iter (fun x -> pr (str_of_token2 x))
-          
+
 
 
 
@@ -786,8 +786,8 @@ let print_all_tokens2 pr xs =
  * fancy stuff when a function was not modified at all. Just need to
  * print the list of token as-is. But now pretty_print_c.ml handles
  * almost everything so maybe less useful. Maybe PPviatok allows to
- * optimize a little the pretty printing. 
- * 
+ * optimize a little the pretty printing.
+ *
  * update: now have PPviastr which goes even faster than PPviatok, so
  * PPviatok has disappeared.
  *)
@@ -798,38 +798,38 @@ type ppmethod = PPnormal | PPviastr
 
 
 (* The pp_program function will call pretty_print_c.ml with a special
- * function to print the leaf components, the tokens. When we want to 
+ * function to print the leaf components, the tokens. When we want to
  * print a token, we need to print also maybe the space and comments that
- * were close to it in the original file (and that was omitted during the 
+ * were close to it in the original file (and that was omitted during the
  * parsing phase), and honor what the cocci-info attached to the token says.
  * Maybe we will not print the token if it's a MINUS-token, and maybe we will
- * print it and also print some cocci-code attached in a PLUS to it. 
+ * print it and also print some cocci-code attached in a PLUS to it.
  * So we will also maybe call unparse_cocci. Because the cocci-code may
  * contain metavariables, unparse_cocci will in fact sometimes call back
  * pretty_print_c (which will this time don't call back again unparse_cocci)
  *)
 
-let pp_program2 xs outfile  = 
-  Common.with_open_outfile outfile (fun (pr,chan) -> 
-    let pr s = 
-      if !Flag_parsing_c.debug_unparsing 
+let pp_program2 xs outfile  =
+  Common.with_open_outfile outfile (fun (pr,chan) ->
+    let pr s =
+      if !Flag_parsing_c.debug_unparsing
       then begin pr2_no_nl s; flush stderr end
-      else pr s  
+      else pr s
         (* flush chan; *)
         (* Common.pr2 ("UNPARSING: >" ^ s ^ "<"); *)
     in
-    
-    xs +> List.iter (fun ((e,(str, toks_e)), ppmethod) -> 
+
+    xs +> List.iter (fun ((e,(str, toks_e)), ppmethod) ->
 
       (* here can still work on ast *)
       let e = remove_useless_fakeInfo_struct e in
-      
+
       match ppmethod with
-      | PPnormal -> 
+      | PPnormal ->
           (* now work on tokens *)
 
           (* phase1: just get all the tokens, all the information *)
-          assert(toks_e +> List.for_all (fun t -> 
+          assert(toks_e +> List.for_all (fun t ->
 	    TH.is_origin t || TH.is_expanded t
           ));
           let toks = get_fakeInfo_and_tokens e toks_e in
@@ -838,7 +838,7 @@ let pp_program2 xs outfile  =
           let toks = expand_mcode toks in
           (* assert Origin;ExpandedTok; + Cocci + C (was AbstractLineTok)
            * and no tag information, just NOTHING. *)
-	  
+
           (* phase2: can now start to filter and adjust *)
           let toks = adjust_indentation toks in
           let toks = remove_minus_and_between_and_expanded_and_fake toks in
@@ -847,7 +847,7 @@ let pp_program2 xs outfile  =
           let toks = add_space toks in
           let toks = fix_tokens toks in
 
-          (* in theory here could reparse and rework the ast! or 
+          (* in theory here could reparse and rework the ast! or
            * apply some SP. Not before cos julia may have generated
            * not parsable file. Need do unparsing_tricks call before being
            * ready to reparse. *)
@@ -857,10 +857,10 @@ let pp_program2 xs outfile  =
     )
   )
 
-let pp_program a b = 
+let pp_program a b =
   Common.profile_code "C unparsing" (fun () -> pp_program2 a b)
 
 
-let pp_program_default xs outfile = 
+let pp_program_default xs outfile =
   let xs' = xs +> List.map (fun x -> x, PPnormal) in
   pp_program xs' outfile

--- a/parsing_c/unparse_c.mli
+++ b/parsing_c/unparse_c.mli
@@ -2,8 +2,8 @@ open Common
 
 type ppmethod = PPnormal | PPviastr
 
-(* program -> output filename (often "/tmp/output.c") -> unit *) 
-val pp_program : 
+(* program -> output filename (often "/tmp/output.c") -> unit *)
+val pp_program :
   (Parse_c.toplevel2 * ppmethod) list -> filename -> unit
 
 val pp_program_default: Parse_c.program2 -> filename -> unit

--- a/parsing_c/unparse_cocci.ml
+++ b/parsing_c/unparse_cocci.ml
@@ -1,7 +1,7 @@
 open Common
 
 (*****************************************************************************)
-(* mostly a copy paste of parsing_cocci/pretty_print_cocci.ml 
+(* mostly a copy paste of parsing_cocci/pretty_print_cocci.ml
  * todo?: try to factorize ?
  *)
 (*****************************************************************************)
@@ -10,8 +10,8 @@ module Ast = Ast_cocci
 
 let term s = Ast.unwrap_mcode s
 
-(* or perhaps can have in plus, for instance a Disj, but those Disj must be 
- *  handled by interactive tool (by proposing alternatives) 
+(* or perhaps can have in plus, for instance a Disj, but those Disj must be
+ *  handled by interactive tool (by proposing alternatives)
  *)
 exception CantBeInPlus
 
@@ -180,23 +180,23 @@ in
 let rec ident i =
   match Ast.unwrap i with
     Ast.Id(name) -> mcode print_string name
-  | Ast.MetaId(name,_,_,_) -> 
+  | Ast.MetaId(name,_,_,_) ->
       handle_metavar name (function
         | (Ast_c.MetaIdVal id) -> pr id
         | _ -> raise Impossible
-        ) 
-  | Ast.MetaFunc(name,_,_,_) -> 
+        )
+  | Ast.MetaFunc(name,_,_,_) ->
       handle_metavar name (function
         | (Ast_c.MetaFuncVal id) -> pr id
         | _ -> raise Impossible
-        ) 
-  | Ast.MetaLocalFunc(name,_,_,_) -> 
+        )
+  | Ast.MetaLocalFunc(name,_,_,_) ->
       handle_metavar name (function
         | (Ast_c.MetaLocalFuncVal id) -> pr id
         | _ -> raise Impossible
         )
 
-  | Ast.OptIdent(_) | Ast.UniqueIdent(_) -> 
+  | Ast.OptIdent(_) | Ast.UniqueIdent(_) ->
       raise CantBeInPlus
 
 in
@@ -256,19 +256,19 @@ let rec expression e =
       mcode print_string rp
   | Ast.TypeExp(ty) -> fullType ty
 
-  | Ast.MetaErr(name,_,_,_) -> 
+  | Ast.MetaErr(name,_,_,_) ->
       failwith "metaErr not handled"
 
   | Ast.MetaExpr (name,_,_,_typedontcare,_formdontcare,_) ->
       handle_metavar name  (function
-        | Ast_c.MetaExprVal exp -> 
+        | Ast_c.MetaExprVal exp ->
             pretty_print_c.Pretty_print_c.expression exp
         | _ -> raise Impossible
       )
 
-  | Ast.MetaExprList (name,_,_,_) -> 
+  | Ast.MetaExprList (name,_,_,_) ->
       handle_metavar name  (function
-        | Ast_c.MetaExprListVal args -> 
+        | Ast_c.MetaExprListVal args ->
             pretty_print_c.Pretty_print_c.arg_list args
         | _ -> raise Impossible
       )
@@ -302,7 +302,7 @@ let rec expression e =
       then mcode print_string dots
       else raise CantBeInPlus
 
-  | Ast.OptExp(exp) | Ast.UniqueExp(exp) -> 
+  | Ast.OptExp(exp) | Ast.UniqueExp(exp) ->
       raise CantBeInPlus
 
 and  unaryOp = function
@@ -401,9 +401,9 @@ and typeC ty =
       dots force_newline declaration decls;
       mcode print_string rb
   | Ast.TypeName(name)-> mcode print_string name
-  | Ast.MetaType(name,_,_) -> 
+  | Ast.MetaType(name,_,_) ->
       handle_metavar name  (function
-          Ast_c.MetaTypeVal exp -> 
+          Ast_c.MetaTypeVal exp ->
             pretty_print_c.Pretty_print_c.ty exp
         | _ -> raise Impossible)
 
@@ -512,7 +512,7 @@ and declaration d =
       mcode print_string sem
   | Ast.DisjDecl(_) | Ast.MetaDecl(_,_,_) -> raise CantBeInPlus
   | Ast.Ddots(_,_) -> raise CantBeInPlus
-  | Ast.OptDecl(decl)  | Ast.UniqueDecl(decl) -> 
+  | Ast.OptDecl(decl)  | Ast.UniqueDecl(decl) ->
       raise CantBeInPlus
 
 (* --------------------------------------------------------------------- *)
@@ -520,7 +520,7 @@ and declaration d =
 
 and initialiser nlcomma i =
   match Ast.unwrap i with
-    Ast.MetaInit(name,_,_) -> 
+    Ast.MetaInit(name,_,_) ->
       handle_metavar name  (function
           Ast_c.MetaInitVal ini ->
             pretty_print_c.Pretty_print_c.init ini
@@ -564,9 +564,9 @@ and parameterTypeDef p =
   | Ast.Param(ty,Some id) -> print_named_type ty id
   | Ast.Param(ty,None) -> fullType ty
 
-  | Ast.MetaParam(name,_,_) -> 
+  | Ast.MetaParam(name,_,_) ->
       failwith "not handling MetaParam"
-  | Ast.MetaParamList(name,_,_,_) -> 
+  | Ast.MetaParamList(name,_,_,_) ->
       failwith "not handling MetaParamList"
 
   | Ast.PComma(cm) -> mcode print_string cm; print_space()
@@ -660,7 +660,7 @@ and rule_elem arity re =
   | Ast.Goto(goto,l,sem) ->
       mcode print_string goto; ident l; mcode print_string sem
   | Ast.Return(ret,sem) ->
-      print_string arity; mcode print_string ret; 
+      print_string arity; mcode print_string ret;
       mcode print_string sem
   | Ast.ReturnExpr(ret,exp,sem) ->
       print_string arity; mcode print_string ret; print_string " ";
@@ -673,7 +673,7 @@ and rule_elem arity re =
   | Ast.Include(inc,s) ->
       mcode print_string inc; print_string " "; mcode inc_file s
   | Ast.DefineHeader(def,id,params) ->
-      mcode print_string def; print_string " "; ident id; 
+      mcode print_string def; print_string " "; ident id;
       print_define_parameters params
   | Ast.Default(def,colon) ->
       mcode print_string def; mcode print_string colon; print_string " "
@@ -818,7 +818,7 @@ let rec statement arity s =
 	 force_newline())
       else raise CantBeInPlus
 
-  | Ast.OptStm(s) | Ast.UniqueStm(s) -> 
+  | Ast.OptStm(s) | Ast.UniqueStm(s) ->
       raise CantBeInPlus
 
 and whencode notfn alwaysfn = function
@@ -853,7 +853,7 @@ let top_level t =
   | Ast.ERRORWORDS(exps) -> raise CantBeInPlus
 in
 
-(*    
+(*
 let rule =
   print_between (function _ -> force_newline(); force_newline()) top_level
 in
@@ -894,7 +894,7 @@ let rec pp_any = function
   | Ast.ConstVolTag(x) -> const_vol x; false
   | Ast.Pragma(xs) -> print_between force_newline print_string xs; false
   | Ast.Token(x,None) -> print_string x; if_open_brace x
-  | Ast.Token(x,Some info) -> 
+  | Ast.Token(x,Some info) ->
       mcode
 	(function x ->
 	  (match x with
@@ -911,7 +911,7 @@ let rec pp_any = function
 
   | Ast.Code(x) -> let _ = top_level x in false
 
-  (* this is not '...', but a list of expr/statement/params, and 
+  (* this is not '...', but a list of expr/statement/params, and
      normally there should be no '...' inside them *)
   | Ast.ExprDotsTag(x) -> dots (function _ -> ()) expression x; false
   | Ast.ParamDotsTag(x) -> parameter_list x; false
@@ -929,7 +929,7 @@ in
   (* todo? imitate what is in pretty_print_cocci ? *)
   match xxs with
     [] -> ()
-  | x::xs -> 
+  | x::xs ->
       (* for many tags, we must not do a newline before the first '+' *)
       let isfn s =
 	match Ast.unwrap s with Ast.FunDecl _ -> true | _ -> false in

--- a/parsing_c/unparse_cocci.mli
+++ b/parsing_c/unparse_cocci.mli
@@ -3,9 +3,9 @@ exception CantBeInPlus
 type pos = Before | After | InPlace
 
 val pp_list_list_any :
-  Ast_c.metavars_binding * 
+  Ast_c.metavars_binding *
   (string -> unit) (* pr cocci *) * Pretty_print_c.pr_elem_func (* pr c *) *
     (unit -> unit) (* pr space *) *
-    (unit -> unit) (* indent *) * (unit -> unit) (* unindent *) -> 
+    (unit -> unit) (* indent *) * (unit -> unit) (* unindent *) ->
   bool (*true if generating*) -> Ast_cocci.anything list list -> pos ->
   unit

--- a/parsing_c/unparse_hrule.ml
+++ b/parsing_c/unparse_hrule.ml
@@ -152,13 +152,13 @@ let rewrap_str s ii =
     | Ast_c.AbstractLineTok pi ->
 	Ast_c.AbstractLineTok { pi with Common.str = s;})}
 
-let rewrap_prefix_name prefix name = 
+let rewrap_prefix_name prefix name =
   match name with
-  | Ast_c.RegularName (s, iiname) -> 
-      let iis = Common.tuple_of_list1 iiname in 
+  | Ast_c.RegularName (s, iiname) ->
+      let iis = Common.tuple_of_list1 iiname in
       let iis' = rewrap_str (prefix^s) iis in
       Ast_c.RegularName (prefix ^ s, [iis'])
-  | Ast_c.CppConcatenatedName _ | Ast_c.CppVariadicName _ 
+  | Ast_c.CppConcatenatedName _ | Ast_c.CppVariadicName _
   | Ast_c.CppIdentBuilder _
       -> raise Common.Todo
 
@@ -172,7 +172,7 @@ let print_metavar pr = function
       pr ("expression "^prefix); pr param
   | ({Ast_c.p_namei = Some name; p_type = (_,ty)} : Ast_c.parameterType) ->
 
-      let name' = rewrap_prefix_name prefix name in 
+      let name' = rewrap_prefix_name prefix name in
 
       print_typedef pr ty;
 
@@ -202,7 +202,7 @@ let make_exp = function
 let print_extra_typedefs pr env =
   let bigf =
     { Visitor_c.default_visitor_c with
-      Visitor_c.ktype = (fun (k, bigf) ty -> 
+      Visitor_c.ktype = (fun (k, bigf) ty ->
 	match ty with
 	  (_,((Ast_c.TypeName(_,_),_) as ty)) -> print_typedef pr ty
 	| _ -> k ty) } in
@@ -224,14 +224,14 @@ let print_extra_typedefs pr env =
     env
 
 let rename argids env =
-  let argenv = List.map (function name -> 
+  let argenv = List.map (function name ->
     let arg = Ast_c.str_of_name name in
     (arg,prefix^arg)
   ) argids in
   let lookup x = try List.assoc x argenv with Not_found -> x in
   let bigf =
     { Visitor_c.default_visitor_c_s with
-    Visitor_c.kexpr_s = (fun (k,bigf) e -> 
+    Visitor_c.kexpr_s = (fun (k,bigf) e ->
       match e with
 	((Ast_c.Ident (name), info), []) ->
 
@@ -271,7 +271,7 @@ let print_one_type pr env = function
     (Type_cocci.MetaType(name,keep,inherited)) as ty ->
       (try
 	match List.assoc name env with
-	  Ast_c.MetaTypeVal ty -> 
+	  Ast_c.MetaTypeVal ty ->
 	    Pretty_print_c.pp_type_gen
 	      (function x -> pr (Ast_c.str_of_info x))
 	      (function _ -> pr " ")

--- a/parsing_c/unparse_hrule.mli
+++ b/parsing_c/unparse_hrule.mli
@@ -1,7 +1,7 @@
 open Common
 
-(* program -> output filename (often "/tmp/output.c") -> unit *) 
-val pp_rule : 
+(* program -> output filename (often "/tmp/output.c") -> unit *)
+val pp_rule :
     Ast_cocci.metavar list (* local metavars only *) ->
       Ast_cocci.rule -> Ast_c.metavars_binding -> filename -> unit
 

--- a/parsing_c/visitor_c.ml
+++ b/parsing_c/visitor_c.ml
@@ -1,11 +1,11 @@
 (* Yoann Padioleau
- * 
+ *
  * Copyright (C) 2006, 2007, 2008, 2009 Ecole des Mines de Nantes
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License (GPL)
  * version 2 as published by the Free Software Foundation.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -29,63 +29,63 @@ module F = Control_flow_c
 (* Functions to visit the Ast, and now also the CFG nodes *)
 (*****************************************************************************)
 
-(* Why this module ? 
- *  
- * The problem is that we manipulate the AST of C programs 
- * and some of our analysis need only to specify an action for 
+(* Why this module ?
+ *
+ * The problem is that we manipulate the AST of C programs
+ * and some of our analysis need only to specify an action for
  * specific cases, such as the function call case, and recurse
- * for the other cases. 
- * Here is a simplification of our AST: 
- *  
- * type ctype = 
+ * for the other cases.
+ * Here is a simplification of our AST:
+ *
+ * type ctype =
  *  | Basetype of ...
  *  | Pointer of ctype
  *  | Array of expression option * ctype
  *  | ...
- * and expression = 
+ * and expression =
  *  | Ident of string
  *  | FunCall of expression * expression list
  *  | Postfix of ...
  *  | RecordAccess of ..
  *  | ...
- * and statement = 
+ * and statement =
  *  ...
  * and declaration =
  *  ...
- * and program = 
+ * and program =
  *  ...
  *
- * What we want is really write code like 
- * 
- *  let my_analysis program = 
+ * What we want is really write code like
+ *
+ *  let my_analysis program =
  *    analyze_all_expressions program (fun expr ->
  *      match expr with
  *      | FunCall (e, es) -> do_something()
- *      | _ -> <find_a_way_to_recurse_for_all_the_other_cases> 
+ *      | _ -> <find_a_way_to_recurse_for_all_the_other_cases>
  *      )
- * 
+ *
  * The problem is how to write analyze_all_expressions
  * and find_a_way_to_recurse_for_all_the_other_cases.
- * 
- * Our solution is to mix the ideas of visitor, pattern matching, 
+ *
+ * Our solution is to mix the ideas of visitor, pattern matching,
  * and continuation. Here is how it looks like
- * using our hybrid-visitor API: 
- * 
- *     let my_analysis program = 
+ * using our hybrid-visitor API:
+ *
+ *     let my_analysis program =
  *      Visitor.visit_iter program {
- *        Visitor.kexpr = (fun k e -> 
+ *        Visitor.kexpr = (fun k e ->
  *         match e with
  *         | FunCall (e, es) -> do_something()
  *         | _ -> k e
  *        );
  *       }
- * 
- * You can of course also give action "hooks" for 
+ *
+ * You can of course also give action "hooks" for
  * kstatement, ktype, or kdeclaration. But we don't overuse
  * visitors and so it would be stupid to provide
  * kfunction_call, kident, kpostfix hooks as one can just
  * use pattern matching with kexpr to achieve the same effect.
- * 
+ *
  * Note: when want to apply recursively, always apply the continuator
  * on the toplevel expression, otherwise may miss some intermediate steps.
  * Do
@@ -101,10 +101,10 @@ module F = Control_flow_c
  *         | FunCall (e, es) -> ...
  *             k e
  *
- * 
- * 
- * 
- * 
+ *
+ *
+ *
+ *
  * Alternatives: from the caml mailing list:
  *  "You should have a look at the Camlp4 metaprogramming facilities :
  *   http://brion.inria.fr/gallium/index.php/Camlp4MapGenerator
@@ -116,33 +116,33 @@ module F = Control_flow_c
  *       | FunCall (e, es) -> do_something (); self
  *       | other -> super#expr other
  *      end in analysis#expr
- * 
- * The problem is that you don't have control about what is generated 
+ *
+ * The problem is that you don't have control about what is generated
  * and in our case we sometimes dont want to visit too much. For instance
  * our visitor don't recurse on the type annotation of expressions
- * Ok, this could be worked around, but the pb remains, you 
+ * Ok, this could be worked around, but the pb remains, you
  * don't have control and at some point you may want. In the same
  * way we want to enforce a certain order in the visit (ok this is not good,
  * but it's convenient) of ast elements. For instance first
  * processing the left part 'e' of a Funcall(e,es), then the arguments 'es'.
- * 
+ *
  *)
 
-(* Visitor based on continuation. Cleaner than the one based on mutable 
- * pointer functions that I had before. 
+(* Visitor based on continuation. Cleaner than the one based on mutable
+ * pointer functions that I had before.
  * src: based on a (vague) idea from Remy Douence.
- * 
- * 
- * 
+ *
+ *
+ *
  * Diff with Julia's visitor ? She does:
- * 
+ *
  * let ident r k i =
  *  ...
  * let expression r k e =
- *  ... 
+ *  ...
  *   ... (List.map r.V0.combiner_expression expr_list) ...
  *  ...
- * let res = V0.combiner bind option_default 
+ * let res = V0.combiner bind option_default
  *   mcode mcode mcode mcode mcode mcode mcode mcode mcode mcode mcode
  *   donothing donothing donothing donothing
  *   ident expression typeC donothing parameter declaration statement
@@ -150,46 +150,46 @@ module F = Control_flow_c
  * ...
  * collect_unitary_nonunitary
  *   (List.concat (List.map res.V0.combiner_top_level t))
- * 
- * 
- * 
+ *
+ *
+ *
  * So she has to remember at which position you must put the 'expression'
- * function. I use record which is easier. 
- * 
+ * function. I use record which is easier.
+ *
  * When she calls recursively, her res.V0.combiner_xxx does not take bigf
- * in param whereas I do 
- *   | F.Decl decl -> Visitor_c.vk_decl bigf decl 
+ * in param whereas I do
+ *   | F.Decl decl -> Visitor_c.vk_decl bigf decl
  * And with the record she gets, she does not have to do my
  * multiple defs of function such as 'let al_type = V0.vk_type_s bigf'
- * 
+ *
  * The code of visitor.ml is cleaner with julia because mutual recursive calls
  * are clean such as ... 'expression e' ... and not  'f (k, bigf) e'
  * or 'vk_expr bigf e'.
- * 
+ *
  * So it is very dual:
  * - I give a record but then I must handle bigf.
  * - She gets a record, and gives a list of function
- * 
- *) 
+ *
+ *)
 
- 
-(* old: first version (only visiting expr) 
+
+(* old: first version (only visiting expr)
 
 let (iter_expr:((expression -> unit) -> expression -> unit) -> expression -> unit)
  = fun f expr ->
-  let rec k e = 
+  let rec k e =
     match e with
     | Constant c -> ()
     | FunCall  (e, es)         ->  f k e; List.iter (f k) es
     | CondExpr (e1, e2, e3)    -> f k e1; f k e2; f k e3
     | Sequence (e1, e2)        -> f k e1; f k e2;
     | Assignment (e1, op, e2)  -> f k e1; f k e2;
-        
+
     | Postfix  (e, op) -> f k e
     | Infix    (e, op) -> f k e
     | Unary    (e, op) -> f k e
     | Binary   (e1, op, e2) -> f k e1; f k  e2;
-        
+
     | ArrayAccess    (e1, e2) -> f k e1; f k e2;
     | RecordAccess   (e, s) -> f k e
     | RecordPtAccess (e, s) -> f k e
@@ -200,14 +200,14 @@ let (iter_expr:((expression -> unit) -> expression -> unit) -> expression -> uni
 
   in f k expr
 
-let ex1 = Sequence (Sequence (Constant (Ident "1"), Constant (Ident "2")), 
+let ex1 = Sequence (Sequence (Constant (Ident "1"), Constant (Ident "2")),
                              Constant (Ident "4"))
-let test = 
+let test =
   iter_expr (fun k e ->  match e with
   | Constant (Ident x) -> Common.pr2 x
   | rest -> k rest
-  ) ex1 
-==> 
+  ) ex1
+==>
 1
 2
 4
@@ -219,23 +219,23 @@ let test =
 (*****************************************************************************)
 
 (* Visitors for all langage concept,  not just for expression.
- * 
+ *
  * Note that I don't visit necesserally in the order of the token
  * found in the original file. So don't assume such hypothesis!
- * 
+ *
  * todo? parameter ? onedecl ?
  *)
-type visitor_c = 
- { 
+type visitor_c =
+ {
    kexpr:      (expression  -> unit) * visitor_c -> expression  -> unit;
    kstatement: (statement   -> unit) * visitor_c -> statement   -> unit;
    ktype:      (fullType    -> unit) * visitor_c -> fullType    -> unit;
 
    kdecl:      (declaration -> unit) * visitor_c -> declaration -> unit;
-   kdef:       (definition  -> unit) * visitor_c -> definition  -> unit; 
+   kdef:       (definition  -> unit) * visitor_c -> definition  -> unit;
    kname     : (name -> unit)        * visitor_c -> name       -> unit;
 
-   kini:       (initialiser  -> unit) * visitor_c -> initialiser  -> unit; 
+   kini:       (initialiser  -> unit) * visitor_c -> initialiser  -> unit;
    kfield: (field -> unit) * visitor_c -> field -> unit;
 
    kcppdirective: (cpp_directive -> unit) * visitor_c -> cpp_directive -> unit;
@@ -249,9 +249,9 @@ type visitor_c =
    ktoplevel: (toplevel -> unit) * visitor_c -> toplevel -> unit;
 
    kinfo: (info -> unit) * visitor_c -> info -> unit;
- } 
+ }
 
-let default_visitor_c = 
+let default_visitor_c =
   { kexpr         = (fun (k,_) e  -> k e);
     kstatement    = (fun (k,_) st -> k st);
     ktype         = (fun (k,_) t  -> k t);
@@ -266,7 +266,7 @@ let default_visitor_c =
     kdefineval    = (fun (k,_) p  -> k p);
     kstatementseq = (fun (k,_) p  -> k p);
     kfield        = (fun (k,_) p  -> k p);
-  } 
+  }
 
 
 (* ------------------------------------------------------------------------ *)
@@ -277,24 +277,24 @@ let rec vk_expr = fun bigf expr ->
 
   let rec exprf e = bigf.kexpr (k,bigf) e
   (* !!! dont go in _typ !!! *)
-  and k ((e,_typ), ii) = 
+  and k ((e,_typ), ii) =
     iif ii;
     match e with
     | Ident (name) -> vk_name bigf name
     | Constant (c) -> ()
-    | FunCall  (e, es)         -> 
-        exprf e;  
+    | FunCall  (e, es)         ->
+        exprf e;
         vk_argument_list bigf es;
-    | CondExpr (e1, e2, e3)    -> 
+    | CondExpr (e1, e2, e3)    ->
         exprf e1; do_option (exprf) e2; exprf e3
     | Sequence (e1, e2)        -> exprf e1; exprf e2;
     | Assignment (e1, op, e2)  -> exprf e1; exprf e2;
-        
+
     | Postfix  (e, op) -> exprf e
     | Infix    (e, op) -> exprf e
     | Unary    (e, op) -> exprf e
     | Binary   (e1, op, e2) -> exprf e1; exprf  e2;
-        
+
     | ArrayAccess    (e1, e2) -> exprf e1; exprf e2;
     | RecordAccess   (e, name) -> exprf e; vk_name bigf name
     | RecordPtAccess (e, name) -> exprf e; vk_name bigf name
@@ -303,21 +303,21 @@ let rec vk_expr = fun bigf expr ->
     | SizeOfType  (t) -> vk_type bigf t
     | Cast    (t, e) -> vk_type bigf t; exprf e
 
-    (* old: | StatementExpr (((declxs, statxs), is)), is2 -> 
-     *          List.iter (vk_decl bigf) declxs; 
-     *          List.iter (vk_statement bigf) statxs 
+    (* old: | StatementExpr (((declxs, statxs), is)), is2 ->
+     *          List.iter (vk_decl bigf) declxs;
+     *          List.iter (vk_statement bigf) statxs
      *)
-    | StatementExpr ((statxs, is)) -> 
+    | StatementExpr ((statxs, is)) ->
         iif is;
         statxs +> List.iter (vk_statement_sequencable bigf);
 
-    | Constructor (t, initxs) -> 
+    | Constructor (t, initxs) ->
         vk_type bigf t;
-        initxs +> List.iter (fun (ini, ii) -> 
+        initxs +> List.iter (fun (ini, ii) ->
           vk_ini bigf ini;
           vk_ii bigf ii;
-        ) 
-          
+        )
+
     | ParenExpr (e) -> exprf e
 
 
@@ -325,22 +325,22 @@ let rec vk_expr = fun bigf expr ->
 
 
 (* ------------------------------------------------------------------------ *)
-and vk_name = fun bigf ident -> 
+and vk_name = fun bigf ident ->
   let iif ii = vk_ii bigf ii in
 
-  let rec namef x = bigf.kname (k,bigf) x 
-  and k id = 
+  let rec namef x = bigf.kname (k,bigf) x
+  and k id =
     match id with
     | RegularName (s, ii) -> iif ii
-    | CppConcatenatedName xs -> 
-        xs +> List.iter (fun ((x,ii1), ii2) -> 
+    | CppConcatenatedName xs ->
+        xs +> List.iter (fun ((x,ii1), ii2) ->
           iif ii2;
           iif ii1;
         );
     | CppVariadicName (s, ii) -> iif ii
-    | CppIdentBuilder ((s,iis), xs) -> 
+    | CppIdentBuilder ((s,iis), xs) ->
         iif iis;
-        xs +> List.iter (fun ((x,iix), iicomma) -> 
+        xs +> List.iter (fun ((x,iix), iicomma) ->
           iif iicomma;
           iif iix;
         )
@@ -350,78 +350,78 @@ and vk_name = fun bigf ident ->
 (* ------------------------------------------------------------------------ *)
 
 
-and vk_statement = fun bigf (st: Ast_c.statement) -> 
+and vk_statement = fun bigf (st: Ast_c.statement) ->
   let iif ii = vk_ii bigf ii in
 
-  let rec statf x = bigf.kstatement (k,bigf) x 
-  and k st = 
+  let rec statf x = bigf.kstatement (k,bigf) x
+  and k st =
     let (unwrap_st, ii) = st in
     iif ii;
     match unwrap_st with
     | Labeled (Label (s, st)) -> statf  st;
     | Labeled (Case  (e, st)) -> vk_expr bigf e; statf st;
-    | Labeled (CaseRange  (e, e2, st)) -> 
+    | Labeled (CaseRange  (e, e2, st)) ->
         vk_expr bigf e; vk_expr bigf e2; statf st;
     | Labeled (Default st) -> statf st;
 
-    | Compound statxs -> 
+    | Compound statxs ->
         statxs +> List.iter (vk_statement_sequencable bigf)
     | ExprStatement (eopt) -> do_option (vk_expr bigf) eopt;
 
-    | Selection  (If (e, st1, st2)) -> 
+    | Selection  (If (e, st1, st2)) ->
         vk_expr bigf e; statf st1; statf st2;
-    | Selection  (Switch (e, st)) -> 
+    | Selection  (Switch (e, st)) ->
         vk_expr bigf e; statf st;
-    | Iteration  (While (e, st)) -> 
+    | Iteration  (While (e, st)) ->
         vk_expr bigf e; statf st;
-    | Iteration  (DoWhile (st, e)) -> statf st; vk_expr bigf e; 
-    | Iteration  (For ((e1opt,i1), (e2opt,i2), (e3opt,i3), st)) -> 
-        statf (ExprStatement (e1opt),i1); 
-        statf (ExprStatement (e2opt),i2); 
-        statf (ExprStatement (e3opt),i3); 
+    | Iteration  (DoWhile (st, e)) -> statf st; vk_expr bigf e;
+    | Iteration  (For ((e1opt,i1), (e2opt,i2), (e3opt,i3), st)) ->
+        statf (ExprStatement (e1opt),i1);
+        statf (ExprStatement (e2opt),i2);
+        statf (ExprStatement (e3opt),i3);
         statf st;
 
-    | Iteration  (MacroIteration (s, es, st)) -> 
+    | Iteration  (MacroIteration (s, es, st)) ->
         vk_argument_list bigf es;
         statf st;
-          
+
     | Jump (Goto name) -> vk_name bigf name
     | Jump ((Continue|Break|Return)) -> ()
     | Jump (ReturnExpr e) -> vk_expr bigf e;
     | Jump (GotoComputed e) -> vk_expr bigf e;
 
-    | Decl decl -> vk_decl bigf decl 
+    | Decl decl -> vk_decl bigf decl
     | Asm asmbody -> vk_asmbody bigf asmbody
     | NestedFunc def -> vk_def bigf def
     | MacroStmt -> ()
 
   in statf st
 
-and vk_statement_sequencable = fun bigf stseq -> 
-  let f = bigf.kstatementseq in 
+and vk_statement_sequencable = fun bigf stseq ->
+  let f = bigf.kstatementseq in
 
-  let rec k stseq = 
+  let rec k stseq =
     match stseq with
     | StmtElem st -> vk_statement bigf st
-    | CppDirectiveStmt directive -> 
+    | CppDirectiveStmt directive ->
         vk_cpp_directive bigf directive
-    | IfdefStmt ifdef -> 
+    | IfdefStmt ifdef ->
         vk_ifdef_directive bigf ifdef
-    | IfdefStmt2 (ifdef, xxs) -> 
+    | IfdefStmt2 (ifdef, xxs) ->
         ifdef +> List.iter (vk_ifdef_directive bigf);
-        xxs +> List.iter (fun xs -> 
+        xxs +> List.iter (fun xs ->
           xs +> List.iter (vk_statement_sequencable bigf)
         )
-          
+
   in f (k, bigf) stseq
 
 
 
-and vk_type = fun bigf t -> 
+and vk_type = fun bigf t ->
   let iif ii = vk_ii bigf ii in
 
-  let rec typef x = bigf.ktype (k, bigf) x 
-  and k t = 
+  let rec typef x = bigf.ktype (k, bigf) x
+  and k t =
     let (q, t) = t in
     let (unwrap_q, iiq) = q in
     let (unwrap_t, iit) = t in
@@ -430,35 +430,35 @@ and vk_type = fun bigf t ->
     match unwrap_t with
     | BaseType _ -> ()
     | Pointer t -> typef t
-    | Array (eopt, t) -> 
+    | Array (eopt, t) ->
         do_option (vk_expr bigf) eopt;
-        typef t 
-    | FunctionType (returnt, paramst) -> 
+        typef t
+    | FunctionType (returnt, paramst) ->
         typef returnt;
         (match paramst with
-        | (ts, (b,iihas3dots)) -> 
+        | (ts, (b,iihas3dots)) ->
             iif iihas3dots;
             vk_param_list bigf ts
         )
 
-    | Enum  (sopt, enumt) -> 
-        enumt +> List.iter (fun ((name, eopt), iicomma) -> 
-          vk_name bigf name; 
+    | Enum  (sopt, enumt) ->
+        enumt +> List.iter (fun ((name, eopt), iicomma) ->
+          vk_name bigf name;
           iif iicomma;
-          eopt +> Common.do_option (fun (info, e) -> 
+          eopt +> Common.do_option (fun (info, e) ->
             iif [info];
             vk_expr bigf e
           )
-        );    
-        
-    | StructUnion (sopt, _su, fields) -> 
+        );
+
+    | StructUnion (sopt, _su, fields) ->
         vk_struct_fields bigf fields
 
     | StructUnionName (s, structunion) -> ()
     | EnumName  s -> ()
 
     (* dont go in _typ *)
-    | TypeName (name,_typ) -> 
+    | TypeName (name,_typ) ->
         vk_name bigf name
 
     | ParenType t -> typef t
@@ -468,63 +468,63 @@ and vk_type = fun bigf t ->
   in typef t
 
 
-and vk_attribute = fun bigf attr -> 
+and vk_attribute = fun bigf attr ->
   let iif ii = vk_ii bigf ii in
   match attr with
-  | Attribute s, ii -> 
+  | Attribute s, ii ->
       iif ii
 
 
 (* ------------------------------------------------------------------------ *)
 
-and vk_decl = fun bigf d -> 
+and vk_decl = fun bigf d ->
   let iif ii = vk_ii bigf ii in
 
-  let f = bigf.kdecl in 
-  let rec k decl = 
-    match decl with 
-    | DeclList (xs,ii) -> xs +> List.iter (fun (x,ii) -> 
+  let f = bigf.kdecl in
+  let rec k decl =
+    match decl with
+    | DeclList (xs,ii) -> xs +> List.iter (fun (x,ii) ->
         iif ii;
         vk_onedecl bigf x;
       );
-    | MacroDecl ((s, args),ii) -> 
+    | MacroDecl ((s, args),ii) ->
         iif ii;
         vk_argument_list bigf args;
-  in f (k, bigf) d 
+  in f (k, bigf) d
 
 
-and vk_onedecl = fun bigf onedecl -> 
+and vk_onedecl = fun bigf onedecl ->
   let iif ii = vk_ii bigf ii in
   match onedecl with
-  | ({v_namei = var; 
-      v_type = t; 
-      v_storage = _sto; 
-      v_attr = attrs})  -> 
+  | ({v_namei = var;
+      v_type = t;
+      v_storage = _sto;
+      v_attr = attrs})  ->
 
     vk_type bigf t;
     attrs +> List.iter (vk_attribute bigf);
-    var +> Common.do_option (fun (name, iniopt) -> 
+    var +> Common.do_option (fun (name, iniopt) ->
       vk_name bigf name;
-      iniopt +> Common.do_option (fun (info, ini) -> 
+      iniopt +> Common.do_option (fun (info, ini) ->
       iif [info];
       vk_ini bigf ini;
       );
     )
 
-and vk_ini = fun bigf ini -> 
+and vk_ini = fun bigf ini ->
   let iif ii = vk_ii bigf ii in
 
-  let rec inif x = bigf.kini (k, bigf) x 
-  and k (ini, iini) = 
+  let rec inif x = bigf.kini (k, bigf) x
+  and k (ini, iini) =
     iif iini;
     match ini with
     | InitExpr e -> vk_expr bigf e
-    | InitList initxs -> 
-        initxs +> List.iter (fun (ini, ii) -> 
+    | InitList initxs ->
+        initxs +> List.iter (fun (ini, ii) ->
           inif ini;
           iif ii;
-        ) 
-    | InitDesignators (xs, e) -> 
+        )
+    | InitDesignators (xs, e) ->
         xs +> List.iter (vk_designator bigf);
         inif e
 
@@ -536,7 +536,7 @@ and vk_ini = fun bigf ini ->
   in inif ini
 
 
-and vk_designator = fun bigf design -> 
+and vk_designator = fun bigf design ->
   let iif ii = vk_ii bigf ii in
   let (designator, ii) = design in
   iif ii;
@@ -548,58 +548,58 @@ and vk_designator = fun bigf design ->
 
 (* ------------------------------------------------------------------------ *)
 
-and vk_struct_fields = fun bigf fields -> 
+and vk_struct_fields = fun bigf fields ->
   fields +> List.iter (vk_struct_field bigf);
 
-and vk_struct_field = fun bigf field -> 
+and vk_struct_field = fun bigf field ->
   let iif ii = vk_ii bigf ii in
 
   let f = bigf.kfield in
-  let rec k field = 
+  let rec k field =
 
-    match field with 
-    | DeclarationField 
-        (FieldDeclList (onefield_multivars, iiptvirg)) -> 
+    match field with
+    | DeclarationField
+        (FieldDeclList (onefield_multivars, iiptvirg)) ->
         vk_struct_fieldkinds bigf onefield_multivars;
           iif iiptvirg;
     | EmptyField info -> iif [info]
-    | MacroDeclField ((s, args),ii) -> 
+    | MacroDeclField ((s, args),ii) ->
         iif ii;
         vk_argument_list bigf args;
 
-    | CppDirectiveStruct directive -> 
+    | CppDirectiveStruct directive ->
         vk_cpp_directive bigf directive
-    | IfdefStruct ifdef -> 
+    | IfdefStruct ifdef ->
         vk_ifdef_directive bigf ifdef
   in
   f (k, bigf) field
-  
 
-  
 
-and vk_struct_fieldkinds = fun bigf onefield_multivars -> 
+
+
+and vk_struct_fieldkinds = fun bigf onefield_multivars ->
   let iif ii = vk_ii bigf ii in
   onefield_multivars +> List.iter (fun (field, iicomma) ->
     iif iicomma;
     match field with
-    | Simple (nameopt, t) -> 
+    | Simple (nameopt, t) ->
         Common.do_option (vk_name bigf) nameopt;
         vk_type bigf t;
-    | BitField (nameopt, t, info, expr) -> 
+    | BitField (nameopt, t, info, expr) ->
         Common.do_option (vk_name bigf) nameopt;
         vk_info bigf info;
         vk_expr bigf expr;
-        vk_type bigf t 
+        vk_type bigf t
   )
 
 (* ------------------------------------------------------------------------ *)
 
 
-and vk_def = fun bigf d -> 
+and vk_def = fun bigf d ->
   let iif ii = vk_ii bigf ii in
 
   let f = bigf.kdef in
-  let rec k d = 
+  let rec k d =
     match d with
     | {f_name = s;
        f_type = (returnt, (paramst, (b, iib)));
@@ -607,49 +607,49 @@ and vk_def = fun bigf d ->
        f_body = statxs;
        f_attr = attrs;
        f_old_c_style = oldstyle;
-      }, ii 
-        -> 
+      }, ii
+        ->
         iif ii;
         iif iib;
         attrs +> List.iter (vk_attribute bigf);
         vk_type bigf returnt;
-        paramst +> List.iter (fun (param,iicomma) -> 
+        paramst +> List.iter (fun (param,iicomma) ->
           vk_param bigf param;
           iif iicomma;
         );
-        oldstyle +> Common.do_option (fun decls -> 
+        oldstyle +> Common.do_option (fun decls ->
           decls +> List.iter (vk_decl bigf);
         );
 
         statxs +> List.iter (vk_statement_sequencable bigf)
-  in f (k, bigf) d 
+  in f (k, bigf) d
 
 
 
 
-and vk_toplevel = fun bigf p -> 
+and vk_toplevel = fun bigf p ->
   let f = bigf.ktoplevel in
   let iif ii =  vk_ii bigf ii in
-  let rec k p = 
+  let rec k p =
     match p with
     | Declaration decl -> (vk_decl bigf decl)
     | Definition def -> (vk_def bigf def)
     | EmptyDef ii -> iif ii
-    | MacroTop (s, xs, ii) -> 
+    | MacroTop (s, xs, ii) ->
         vk_argument_list bigf xs;
         iif ii
 
     | CppTop top -> vk_cpp_directive bigf top
     | IfdefTop ifdefdir -> vk_ifdef_directive bigf ifdefdir
-          
+
     | NotParsedCorrectly ii -> iif ii
     | FinalDef info -> vk_info bigf info
   in f (k, bigf) p
 
-and vk_program = fun bigf xs -> 
+and vk_program = fun bigf xs ->
   xs +> List.iter (vk_toplevel bigf)
 
-and vk_ifdef_directive bigf directive = 
+and vk_ifdef_directive bigf directive =
   let iif ii =  vk_ii bigf ii in
   match directive with
   | IfdefDirective (ifkind, ii) -> iif ii
@@ -658,51 +658,51 @@ and vk_ifdef_directive bigf directive =
 and vk_cpp_directive bigf directive =
   let iif ii =  vk_ii bigf ii in
   let f = bigf.kcppdirective in
-  let rec k directive = 
+  let rec k directive =
     match directive with
     | Include {i_include = (s, ii);
                i_content = copt;
               }
-      -> 
+      ->
         (* go inside ? yes, can be useful, for instance for type_annotater.
          * The only pb may be that when we want to unparse the code we
-         * don't want to unparse the included file but the unparser 
+         * don't want to unparse the included file but the unparser
          * and pretty_print do not use visitor_c so no problem.
          *)
         iif ii;
-        copt +> Common.do_option (fun (file, asts) -> 
+        copt +> Common.do_option (fun (file, asts) ->
           vk_program bigf asts
         );
-    | Define ((s,ii), (defkind, defval)) -> 
+    | Define ((s,ii), (defkind, defval)) ->
         iif ii;
         vk_define_kind bigf defkind;
         vk_define_val bigf defval
-    | Undef (s, ii) -> 
+    | Undef (s, ii) ->
         iif ii
-    | PragmaAndCo (ii) -> 
+    | PragmaAndCo (ii) ->
         iif ii
   in f (k, bigf) directive
 
 
-and vk_define_kind bigf defkind = 
+and vk_define_kind bigf defkind =
   match defkind with
   | DefineVar -> ()
-  | DefineFunc (params, ii) -> 
+  | DefineFunc (params, ii) ->
       vk_ii bigf ii;
-      params +> List.iter (fun ((s,iis), iicomma) -> 
+      params +> List.iter (fun ((s,iis), iicomma) ->
         vk_ii bigf iis;
         vk_ii bigf iicomma;
       )
 
-and vk_define_val bigf defval = 
-  let f = bigf.kdefineval in 
+and vk_define_val bigf defval =
+  let f = bigf.kdefineval in
 
-  let rec k defval = 
+  let rec k defval =
   match defval with
-  | DefineExpr e -> 
+  | DefineExpr e ->
       vk_expr bigf e
   | DefineStmt stmt -> vk_statement bigf stmt
-  | DefineDoWhileZero ((stmt, e), ii) -> 
+  | DefineDoWhileZero ((stmt, e), ii) ->
       vk_statement bigf stmt;
       vk_expr bigf e;
       vk_ii bigf ii
@@ -712,66 +712,66 @@ and vk_define_val bigf defval =
   | DefineEmpty -> ()
   | DefineInit ini -> vk_ini bigf ini
 
-  | DefineTodo -> 
+  | DefineTodo ->
       pr2_once "DefineTodo";
       ()
   in f (k, bigf) defval
-  
 
-        
+
+
 
 (* ------------------------------------------------------------------------ *)
-(* Now keep fullstatement inside the control flow node, 
+(* Now keep fullstatement inside the control flow node,
  * so that can then get in a MetaStmtVar the fullstatement to later
- * pp back when the S is in a +. But that means that 
+ * pp back when the S is in a +. But that means that
  * Exp will match an Ifnode even if there is no such exp
  * inside the condition of the Ifnode (because the exp may
  * be deeper, in the then branch). So have to not visit
  * all inside a node anymore.
- * 
+ *
  * update: j'ai choisi d'accrocher au noeud du CFG a la
- * fois le fullstatement et le partialstatement et appeler le 
+ * fois le fullstatement et le partialstatement et appeler le
  * visiteur que sur le partialstatement.
  *)
 
-and vk_node = fun bigf node -> 
+and vk_node = fun bigf node ->
   let iif ii = vk_ii bigf ii in
   let infof info = vk_info bigf info in
 
   let f = bigf.knode in
-  let rec k n = 
+  let rec k n =
     match F.unwrap n with
 
     | F.FunHeader (def) ->
         assert(null (fst def).f_body);
         vk_def bigf def;
 
-    | F.Decl decl -> vk_decl bigf decl 
-    | F.ExprStatement (st, (eopt, ii)) ->  
+    | F.Decl decl -> vk_decl bigf decl
+    | F.ExprStatement (st, (eopt, ii)) ->
         iif ii;
         eopt +> do_option (vk_expr bigf)
 
-    | F.IfHeader (_, (e,ii)) 
+    | F.IfHeader (_, (e,ii))
     | F.SwitchHeader (_, (e,ii))
     | F.WhileHeader (_, (e,ii))
-    | F.DoWhileTail (e,ii) -> 
+    | F.DoWhileTail (e,ii) ->
         iif ii;
         vk_expr bigf e
 
-    | F.ForHeader (_st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) -> 
+    | F.ForHeader (_st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) ->
         iif i1; iif i2; iif i3;
         iif ii;
         e1opt +> do_option (vk_expr bigf);
         e2opt +> do_option (vk_expr bigf);
         e3opt +> do_option (vk_expr bigf);
-    | F.MacroIterHeader (_s, ((s,es), ii)) -> 
+    | F.MacroIterHeader (_s, ((s,es), ii)) ->
         iif ii;
         vk_argument_list bigf es;
-        
+
     | F.ReturnExpr (_st, (e,ii)) -> iif ii; vk_expr bigf e
-        
+
     | F.Case  (_st, (e,ii)) -> iif ii; vk_expr bigf e
-    | F.CaseRange (_st, ((e1, e2),ii)) -> 
+    | F.CaseRange (_st, ((e1, e2),ii)) ->
         iif ii; vk_expr bigf e1; vk_expr bigf e2
 
 
@@ -779,25 +779,25 @@ and vk_node = fun bigf node ->
 
     | F.DefineExpr e  -> vk_expr bigf e
     | F.DefineType ft  -> vk_type bigf ft
-    | F.DefineHeader ((s,ii), (defkind))  -> 
+    | F.DefineHeader ((s,ii), (defkind))  ->
         iif ii;
         vk_define_kind bigf defkind;
 
     | F.DefineDoWhileZeroHeader (((),ii)) -> iif ii
-    | F.DefineTodo -> 
+    | F.DefineTodo ->
         pr2_once "DefineTodo";
         ()
 
 
     | F.Include {i_include = (s, ii);} -> iif ii;
 
-    | F.MacroTop (s, args, ii) -> 
+    | F.MacroTop (s, args, ii) ->
         iif ii;
         vk_argument_list bigf args
 
-    | F.IfdefHeader    (info) -> vk_ifdef_directive bigf info 
-    | F.IfdefElse    (info) ->  vk_ifdef_directive bigf info 
-    | F.IfdefEndif    (info) ->  vk_ifdef_directive bigf info 
+    | F.IfdefHeader    (info) -> vk_ifdef_directive bigf info
+    | F.IfdefElse    (info) ->  vk_ifdef_directive bigf info
+    | F.IfdefEndif    (info) ->  vk_ifdef_directive bigf info
 
     | F.Break    (st,((),ii)) -> iif ii
     | F.Continue (st,((),ii)) -> iif ii
@@ -815,7 +815,7 @@ and vk_node = fun bigf node ->
     | F.SeqStart (st, i, info) -> infof info
 
     | F.MacroStmt (st, ((),ii)) -> iif ii
-    | F.Asm (st, (asmbody,ii)) -> 
+    | F.Asm (st, (asmbody,ii)) ->
         iif ii;
         vk_asmbody bigf asmbody
 
@@ -832,19 +832,19 @@ and vk_node = fun bigf node ->
   f (k, bigf) node
 
 (* ------------------------------------------------------------------------ *)
-and vk_info = fun bigf info -> 
+and vk_info = fun bigf info ->
   let rec infof ii = bigf.kinfo (k, bigf) ii
   and k i = ()
   in
   infof info
 
-and vk_ii = fun bigf ii -> 
+and vk_ii = fun bigf ii ->
   List.iter (vk_info bigf) ii
 
 
 (* ------------------------------------------------------------------------ *)
-and vk_argument = fun bigf arg -> 
-  let rec do_action = function 
+and vk_argument = fun bigf arg ->
+  let rec do_action = function
     | (ActMisc ii) -> vk_ii bigf ii
   in
   match arg with
@@ -852,9 +852,9 @@ and vk_argument = fun bigf arg ->
   | Right (ArgType param) -> vk_param bigf param
   | Right (ArgAction action) -> do_action action
 
-and vk_argument_list = fun bigf es -> 
+and vk_argument_list = fun bigf es ->
   let iif ii = vk_ii bigf ii in
-  es +> List.iter (fun (e, ii) -> 
+  es +> List.iter (fun (e, ii) ->
     iif ii;
     vk_argument bigf e
   )
@@ -868,9 +868,9 @@ and vk_param = fun bigf param  ->
   iif iib;
   vk_type bigf ft
 
-and vk_param_list = fun bigf ts -> 
+and vk_param_list = fun bigf ts ->
   let iif ii = vk_ii bigf ii in
-  ts +> List.iter (fun (param,iicomma) -> 
+  ts +> List.iter (fun (param,iicomma) ->
     vk_param bigf param;
     iif iicomma;
   )
@@ -878,17 +878,17 @@ and vk_param_list = fun bigf ts ->
 
 
 (* ------------------------------------------------------------------------ *)
-and vk_asmbody = fun bigf (string_list, colon_list) -> 
+and vk_asmbody = fun bigf (string_list, colon_list) ->
   let iif ii = vk_ii bigf ii in
 
   iif string_list;
-  colon_list +> List.iter (fun (Colon xs, ii)  -> 
+  colon_list +> List.iter (fun (Colon xs, ii)  ->
     iif ii;
-    xs +> List.iter (fun (x,iicomma) -> 
+    xs +> List.iter (fun (x,iicomma) ->
       iif iicomma;
       (match x with
-      | ColonMisc, ii -> iif ii 
-      | ColonExpr e, ii -> 
+      | ColonMisc, ii -> iif ii
+      | ColonExpr e, ii ->
           vk_expr bigf e;
           iif ii
       )
@@ -896,32 +896,32 @@ and vk_asmbody = fun bigf (string_list, colon_list) ->
 
 
 (* ------------------------------------------------------------------------ *)
-let vk_args_splitted = fun bigf args_splitted -> 
+let vk_args_splitted = fun bigf args_splitted ->
   let iif ii = vk_ii bigf ii in
-  args_splitted +> List.iter (function  
+  args_splitted +> List.iter (function
   | Left arg -> vk_argument bigf arg
   | Right ii -> iif ii
   )
 
 
-let vk_define_params_splitted = fun bigf args_splitted -> 
+let vk_define_params_splitted = fun bigf args_splitted ->
   let iif ii = vk_ii bigf ii in
-  args_splitted +> List.iter (function  
+  args_splitted +> List.iter (function
   | Left (s, iis) -> vk_ii bigf iis
   | Right ii -> iif ii
   )
 
 
 
-let vk_params_splitted = fun bigf args_splitted -> 
+let vk_params_splitted = fun bigf args_splitted ->
   let iif ii = vk_ii bigf ii in
-  args_splitted +> List.iter (function  
+  args_splitted +> List.iter (function
   | Left arg -> vk_param bigf arg
   | Right ii -> iif ii
   )
 
 (* ------------------------------------------------------------------------ *)
-let vk_cst = fun bigf (cst, ii) -> 
+let vk_cst = fun bigf (cst, ii) ->
   let iif ii = vk_ii bigf ii in
   iif ii;
   (match cst with
@@ -930,7 +930,7 @@ let vk_cst = fun bigf (cst, ii) ->
   )
 
 
-  
+
 
 (*****************************************************************************)
 (* "syntetisized attributes" style *)
@@ -938,23 +938,23 @@ let vk_cst = fun bigf (cst, ii) ->
 
 (* TODO port the xxs_s to new cpp construct too *)
 
-type 'a inout = 'a -> 'a 
+type 'a inout = 'a -> 'a
 
-(* _s for synthetizized attributes 
+(* _s for synthetizized attributes
  *
  * Note that I don't visit necesserally in the order of the token
  * found in the original file. So don't assume such hypothesis!
  *)
-type visitor_c_s = { 
+type visitor_c_s = {
   kexpr_s:      (expression inout * visitor_c_s) -> expression inout;
   kstatement_s: (statement  inout * visitor_c_s) -> statement  inout;
   ktype_s:      (fullType   inout * visitor_c_s) -> fullType   inout;
 
   kdecl_s: (declaration  inout * visitor_c_s) -> declaration inout;
-  kdef_s:  (definition   inout * visitor_c_s) -> definition  inout; 
+  kdef_s:  (definition   inout * visitor_c_s) -> definition  inout;
   kname_s: (name         inout * visitor_c_s) -> name        inout;
 
-  kini_s:  (initialiser  inout * visitor_c_s) -> initialiser inout; 
+  kini_s:  (initialiser  inout * visitor_c_s) -> initialiser inout;
 
   kcppdirective_s: (cpp_directive inout * visitor_c_s) -> cpp_directive inout;
   kdefineval_s: (define_val inout * visitor_c_s) -> define_val inout;
@@ -966,9 +966,9 @@ type visitor_c_s = {
 
   ktoplevel_s: (toplevel inout * visitor_c_s) -> toplevel inout;
   kinfo_s: (info inout * visitor_c_s) -> info inout;
- } 
+ }
 
-let default_visitor_c_s = 
+let default_visitor_c_s =
   { kexpr_s =      (fun (k,_) e  -> k e);
     kstatement_s = (fun (k,_) st -> k st);
     ktype_s      = (fun (k,_) t  -> k t);
@@ -983,57 +983,57 @@ let default_visitor_c_s =
     kstatementseq_s = (fun (k,_) x  -> k x);
     kstatementseq_list_s = (fun (k,_) x  -> k x);
     kcppdirective_s = (fun (k,_) x  -> k x);
-  } 
+  }
 
 let rec vk_expr_s = fun bigf expr ->
   let iif ii = vk_ii_s bigf ii in
   let rec exprf e = bigf.kexpr_s  (k, bigf) e
-  and k e = 
+  and k e =
     let ((unwrap_e, typ), ii) = e in
     (* !!! don't analyse optional type !!!
-     * old:  typ +> map_option (vk_type_s bigf) in 
+     * old:  typ +> map_option (vk_type_s bigf) in
      *)
-    let typ' = typ in 
-    let e' = 
+    let typ' = typ in
+    let e' =
       match unwrap_e with
       | Ident (name) -> Ident (vk_name_s bigf name)
       | Constant (c) -> Constant (c)
-      | FunCall  (e, es)         -> 
+      | FunCall  (e, es)         ->
           FunCall (exprf e,
-                  es +> List.map (fun (e,ii) -> 
+                  es +> List.map (fun (e,ii) ->
                     vk_argument_s bigf e, iif ii
                   ))
-            
+
       | CondExpr (e1, e2, e3)   -> CondExpr (exprf e1, Common2.fmap exprf e2, exprf e3)
       | Sequence (e1, e2)        -> Sequence (exprf e1, exprf e2)
       | Assignment (e1, op, e2)  -> Assignment (exprf e1, op, exprf e2)
-          
+
       | Postfix  (e, op) -> Postfix (exprf e, op)
       | Infix    (e, op) -> Infix   (exprf e, op)
       | Unary    (e, op) -> Unary   (exprf e, op)
       | Binary   (e1, op, e2) -> Binary (exprf e1, op, exprf e2)
-          
+
       | ArrayAccess    (e1, e2) -> ArrayAccess (exprf e1, exprf e2)
-      | RecordAccess   (e, name) -> 
-          RecordAccess     (exprf e, vk_name_s bigf name) 
-      | RecordPtAccess (e, name) -> 
-          RecordPtAccess   (exprf e, vk_name_s bigf name) 
+      | RecordAccess   (e, name) ->
+          RecordAccess     (exprf e, vk_name_s bigf name)
+      | RecordPtAccess (e, name) ->
+          RecordPtAccess   (exprf e, vk_name_s bigf name)
 
       | SizeOfExpr  (e) -> SizeOfExpr   (exprf e)
       | SizeOfType  (t) -> SizeOfType (vk_type_s bigf t)
       | Cast    (t, e) ->  Cast   (vk_type_s bigf t, exprf e)
 
-      | StatementExpr (statxs, is) -> 
+      | StatementExpr (statxs, is) ->
           StatementExpr (
             vk_statement_sequencable_list_s bigf statxs,
             iif is)
-      | Constructor (t, initxs) -> 
-          Constructor 
-            (vk_type_s bigf t, 
-            (initxs +> List.map (fun (ini, ii) -> 
-              vk_ini_s bigf ini, vk_ii_s bigf ii) 
+      | Constructor (t, initxs) ->
+          Constructor
+            (vk_type_s bigf t,
+            (initxs +> List.map (fun (ini, ii) ->
+              vk_ini_s bigf ini, vk_ii_s bigf ii)
             ))
-                      
+
       | ParenExpr (e) -> ParenExpr (exprf e)
 
     in
@@ -1041,9 +1041,9 @@ let rec vk_expr_s = fun bigf expr ->
   in exprf expr
 
 
-and vk_argument_s bigf argument = 
+and vk_argument_s bigf argument =
   let iif ii = vk_ii_s bigf ii in
-  let rec do_action = function 
+  let rec do_action = function
     | (ActMisc ii) -> ActMisc (iif ii)
   in
   (match argument with
@@ -1055,20 +1055,20 @@ and vk_argument_s bigf argument =
 (* ------------------------------------------------------------------------ *)
 
 
-and vk_name_s = fun bigf ident -> 
+and vk_name_s = fun bigf ident ->
   let iif ii = vk_ii_s bigf ii in
-  let rec namef x = bigf.kname_s (k,bigf) x 
-  and k id = 
+  let rec namef x = bigf.kname_s (k,bigf) x
+  and k id =
     (match id with
     | RegularName (s,ii) -> RegularName (s, iif ii)
-    | CppConcatenatedName xs -> 
-        CppConcatenatedName (xs +> List.map (fun ((x,ii1), ii2) -> 
+    | CppConcatenatedName xs ->
+        CppConcatenatedName (xs +> List.map (fun ((x,ii1), ii2) ->
           (x, iif ii1), iif ii2
         ))
     | CppVariadicName (s, ii) -> CppVariadicName (s, iif ii)
-    | CppIdentBuilder ((s,iis), xs) -> 
+    | CppIdentBuilder ((s,iis), xs) ->
         CppIdentBuilder ((s, iif iis),
-                        xs +> List.map (fun ((x,iix), iicomma) -> 
+                        xs +> List.map (fun ((x,iix), iicomma) ->
                           ((x, iif iix), iif iicomma)))
     )
   in
@@ -1078,54 +1078,54 @@ and vk_name_s = fun bigf ident ->
 
 
 
-and vk_statement_s = fun bigf st -> 
-  let rec statf st = bigf.kstatement_s (k, bigf) st 
-  and k st = 
+and vk_statement_s = fun bigf st ->
+  let rec statf st = bigf.kstatement_s (k, bigf) st
+  and k st =
     let (unwrap_st, ii) = st in
-    let st' = 
+    let st' =
       match unwrap_st with
-      | Labeled (Label (s, st)) -> 
+      | Labeled (Label (s, st)) ->
           Labeled (Label (s, statf st))
-      | Labeled (Case  (e, st)) -> 
+      | Labeled (Case  (e, st)) ->
           Labeled (Case  ((vk_expr_s bigf) e , statf st))
-      | Labeled (CaseRange  (e, e2, st)) -> 
-          Labeled (CaseRange  ((vk_expr_s bigf) e, 
-                              (vk_expr_s bigf) e2, 
+      | Labeled (CaseRange  (e, e2, st)) ->
+          Labeled (CaseRange  ((vk_expr_s bigf) e,
+                              (vk_expr_s bigf) e2,
                               statf st))
       | Labeled (Default st) -> Labeled (Default (statf st))
-      | Compound statxs -> 
+      | Compound statxs ->
           Compound (vk_statement_sequencable_list_s bigf statxs)
       | ExprStatement (None) ->  ExprStatement (None)
       | ExprStatement (Some e) -> ExprStatement (Some ((vk_expr_s bigf) e))
-      | Selection (If (e, st1, st2)) -> 
+      | Selection (If (e, st1, st2)) ->
           Selection  (If ((vk_expr_s bigf) e, statf st1, statf st2))
-      | Selection (Switch (e, st))   -> 
+      | Selection (Switch (e, st))   ->
           Selection  (Switch ((vk_expr_s bigf) e, statf st))
-      | Iteration (While (e, st))    -> 
+      | Iteration (While (e, st))    ->
           Iteration  (While ((vk_expr_s bigf) e, statf st))
-      | Iteration (DoWhile (st, e))  -> 
+      | Iteration (DoWhile (st, e))  ->
           Iteration  (DoWhile (statf st, (vk_expr_s bigf) e))
-      | Iteration (For ((e1opt,i1), (e2opt,i2), (e3opt,i3), st)) -> 
+      | Iteration (For ((e1opt,i1), (e2opt,i2), (e3opt,i3), st)) ->
           let e1opt' = statf (ExprStatement (e1opt),i1) in
           let e2opt' = statf (ExprStatement (e2opt),i2) in
           let e3opt' = statf (ExprStatement (e3opt),i3) in
           (match (e1opt', e2opt', e3opt') with
-          | ((ExprStatement x1,i1), (ExprStatement x2,i2), ((ExprStatement x3,i3))) -> 
+          | ((ExprStatement x1,i1), (ExprStatement x2,i2), ((ExprStatement x3,i3))) ->
               Iteration (For ((x1,i1), (x2,i2), (x3,i3), statf st))
           | x -> failwith "cant be here if iterator keep ExprStatement as is"
          )
 
-      | Iteration  (MacroIteration (s, es, st)) -> 
-          Iteration 
+      | Iteration  (MacroIteration (s, es, st)) ->
+          Iteration
             (MacroIteration
                 (s,
-                es +> List.map (fun (e, ii) -> 
+                es +> List.map (fun (e, ii) ->
                   vk_argument_s bigf e, vk_ii_s bigf ii
-                ), 
+                ),
                 statf st
                 ))
 
-            
+
       | Jump (Goto name) -> Jump (Goto (vk_name_s bigf name))
       | Jump (((Continue|Break|Return) as x)) -> Jump (x)
       | Jump (ReturnExpr e) -> Jump (ReturnExpr ((vk_expr_s bigf) e))
@@ -1140,92 +1140,92 @@ and vk_statement_s = fun bigf st ->
   in statf st
 
 
-and vk_statement_sequencable_s = fun bigf stseq -> 
+and vk_statement_sequencable_s = fun bigf stseq ->
   let f = bigf.kstatementseq_s in
-  let k stseq = 
+  let k stseq =
 
     match stseq with
-    | StmtElem st -> 
+    | StmtElem st ->
         StmtElem (vk_statement_s bigf st)
-    | CppDirectiveStmt directive -> 
+    | CppDirectiveStmt directive ->
         CppDirectiveStmt (vk_cpp_directive_s bigf directive)
-    | IfdefStmt ifdef -> 
+    | IfdefStmt ifdef ->
         IfdefStmt (vk_ifdef_directive_s bigf ifdef)
-    | IfdefStmt2 (ifdef, xxs) -> 
+    | IfdefStmt2 (ifdef, xxs) ->
         let ifdef' = List.map (vk_ifdef_directive_s bigf) ifdef in
-        let xxs' = xxs +> List.map (fun xs -> 
+        let xxs' = xxs +> List.map (fun xs ->
           xs +> vk_statement_sequencable_list_s bigf
         )
         in
         IfdefStmt2(ifdef', xxs')
   in f (k, bigf) stseq
 
-and vk_statement_sequencable_list_s = fun bigf statxs -> 
+and vk_statement_sequencable_list_s = fun bigf statxs ->
   let f = bigf.kstatementseq_list_s in
-  let k xs = 
+  let k xs =
     xs +> List.map (vk_statement_sequencable_s bigf)
   in
   f (k, bigf) statxs
-  
 
 
-and vk_asmbody_s = fun bigf (string_list, colon_list) -> 
+
+and vk_asmbody_s = fun bigf (string_list, colon_list) ->
   let  iif ii = vk_ii_s bigf ii in
 
   iif string_list,
-  colon_list +> List.map (fun (Colon xs, ii) -> 
-    Colon 
-      (xs +> List.map (fun (x, iicomma) -> 
+  colon_list +> List.map (fun (Colon xs, ii) ->
+    Colon
+      (xs +> List.map (fun (x, iicomma) ->
         (match x with
-        | ColonMisc, ii -> ColonMisc, iif ii 
+        | ColonMisc, ii -> ColonMisc, iif ii
         | ColonExpr e, ii -> ColonExpr (vk_expr_s bigf e), iif ii
         ), iif iicomma
-      )), 
-    iif ii 
+      )),
+    iif ii
   )
-    
-  
+
+
 
 
 (* todo? a visitor for qualifier *)
-and vk_type_s = fun bigf t -> 
+and vk_type_s = fun bigf t ->
   let rec typef t = bigf.ktype_s (k,bigf) t
   and iif ii = vk_ii_s bigf ii
-  and k t = 
+  and k t =
     let (q, t) = t in
     let (unwrap_q, iiq) = q in
     (* strip_info_visitor needs iiq to be processed before iit *)
     let iif_iiq = iif iiq in
     let q' = unwrap_q in
     let (unwrap_t, iit) = t in
-    let t' = 
+    let t' =
       match unwrap_t with
       | BaseType x -> BaseType x
       | Pointer t  -> Pointer (typef t)
-      | Array (eopt, t) -> Array (Common2.fmap (vk_expr_s bigf) eopt, typef t) 
-      | FunctionType (returnt, paramst) -> 
-          FunctionType 
-            (typef returnt, 
+      | Array (eopt, t) -> Array (Common2.fmap (vk_expr_s bigf) eopt, typef t)
+      | FunctionType (returnt, paramst) ->
+          FunctionType
+            (typef returnt,
             (match paramst with
-            | (ts, (b, iihas3dots)) -> 
-                (ts +> List.map (fun (param,iicomma) -> 
+            | (ts, (b, iihas3dots)) ->
+                (ts +> List.map (fun (param,iicomma) ->
                   (vk_param_s bigf param, iif iicomma)),
                 (b, iif iihas3dots))
             ))
 
-      | Enum  (sopt, enumt) -> 
+      | Enum  (sopt, enumt) ->
           Enum (sopt,
-               enumt +> List.map (fun ((name, eopt), iicomma) -> 
-                 
-                 ((vk_name_s bigf name, 
-                  eopt +> Common2.fmap (fun (info, e) -> 
+               enumt +> List.map (fun ((name, eopt), iicomma) ->
+
+                 ((vk_name_s bigf name,
+                  eopt +> Common2.fmap (fun (info, e) ->
                     vk_info_s bigf info,
                     vk_expr_s bigf e
-                 )), 
+                 )),
                  iif iicomma)
                )
                )
-      | StructUnion (sopt, su, fields) -> 
+      | StructUnion (sopt, su, fields) ->
           StructUnion (sopt, su, vk_struct_fields_s bigf fields)
 
 
@@ -1237,44 +1237,44 @@ and vk_type_s = fun bigf t ->
       | TypeOfExpr e -> TypeOfExpr (vk_expr_s bigf e)
       | TypeOfType t -> TypeOfType (typef t)
     in
-    (q', iif_iiq), 
+    (q', iif_iiq),
     (t', iif iit)
 
 
   in typef t
 
-and vk_attribute_s = fun bigf attr -> 
+and vk_attribute_s = fun bigf attr ->
   let iif ii = vk_ii_s bigf ii in
   match attr with
-  | Attribute s, ii -> 
+  | Attribute s, ii ->
       Attribute s, iif ii
 
 
 
-and vk_decl_s = fun bigf d -> 
-  let f = bigf.kdecl_s in 
+and vk_decl_s = fun bigf d ->
+  let f = bigf.kdecl_s in
   let iif ii = vk_ii_s bigf ii in
-  let rec k decl = 
+  let rec k decl =
     match decl with
-    | DeclList (xs, ii) -> 
+    | DeclList (xs, ii) ->
         DeclList (List.map aux xs,   iif ii)
-    | MacroDecl ((s, args),ii) -> 
-        MacroDecl 
-          ((s, 
+    | MacroDecl ((s, args),ii) ->
+        MacroDecl
+          ((s,
            args +> List.map (fun (e,ii) -> vk_argument_s bigf e, iif ii)
            ),
           iif ii)
 
 
-  and aux ({v_namei = var; 
-            v_type = t; 
-            v_storage = sto; 
-            v_local= local; 
-            v_attr = attrs}, iicomma) = 
-    {v_namei = 
-      (var +> Common2.map_option (fun (name, iniopt) -> 
-        vk_name_s bigf name, 
-        iniopt +> Common2.map_option (fun (info, init) -> 
+  and aux ({v_namei = var;
+            v_type = t;
+            v_storage = sto;
+            v_local= local;
+            v_attr = attrs}, iicomma) =
+    {v_namei =
+      (var +> Common2.map_option (fun (name, iniopt) ->
+        vk_name_s bigf name,
+        iniopt +> Common2.map_option (fun (info, init) ->
           vk_info_s bigf info,
           vk_ini_s bigf init
         )));
@@ -1285,25 +1285,25 @@ and vk_decl_s = fun bigf d ->
     },
     iif iicomma
 
-  in f (k, bigf) d 
+  in f (k, bigf) d
 
-and vk_ini_s = fun bigf ini -> 
+and vk_ini_s = fun bigf ini ->
   let rec inif ini = bigf.kini_s (k,bigf) ini
-  and k ini = 
+  and k ini =
     let (unwrap_ini, ii) = ini in
-    let ini' = 
+    let ini' =
       match unwrap_ini with
       | InitExpr e -> InitExpr (vk_expr_s bigf e)
-      | InitList initxs -> 
-          InitList (initxs +> List.map (fun (ini, ii) -> 
-            inif ini, vk_ii_s bigf ii) 
+      | InitList initxs ->
+          InitList (initxs +> List.map (fun (ini, ii) ->
+            inif ini, vk_ii_s bigf ii)
           )
 
 
-      | InitDesignators (xs, e) -> 
-          InitDesignators 
+      | InitDesignators (xs, e) ->
+          InitDesignators
             (xs +> List.map (vk_designator_s bigf),
-            inif e 
+            inif e
             )
 
     | InitFieldOld (s, e) -> InitFieldOld (s, inif e)
@@ -1314,66 +1314,66 @@ and vk_ini_s = fun bigf ini ->
   in inif ini
 
 
-and vk_designator_s = fun bigf design -> 
+and vk_designator_s = fun bigf design ->
   let iif ii = vk_ii_s bigf ii in
   let (designator, ii) = design in
   (match designator with
   | DesignatorField s -> DesignatorField s
   | DesignatorIndex e -> DesignatorIndex (vk_expr_s bigf e)
-  | DesignatorRange (e1, e2) -> 
+  | DesignatorRange (e1, e2) ->
       DesignatorRange (vk_expr_s bigf e1, vk_expr_s bigf e2)
   ), iif ii
 
 
 
 
-and vk_struct_fieldkinds_s = fun bigf onefield_multivars -> 
+and vk_struct_fieldkinds_s = fun bigf onefield_multivars ->
   let iif ii = vk_ii_s bigf ii in
-  
+
   onefield_multivars +> List.map (fun (field, iicomma) ->
     (match field with
-    | Simple (nameopt, t) -> 
-        Simple (Common2.map_option (vk_name_s bigf) nameopt, 
+    | Simple (nameopt, t) ->
+        Simple (Common2.map_option (vk_name_s bigf) nameopt,
                vk_type_s bigf t)
-    | BitField (nameopt, t, info, expr) -> 
-        BitField (Common2.map_option (vk_name_s bigf) nameopt, 
-                 vk_type_s bigf t, 
+    | BitField (nameopt, t, info, expr) ->
+        BitField (Common2.map_option (vk_name_s bigf) nameopt,
+                 vk_type_s bigf t,
                  vk_info_s bigf info,
                  vk_expr_s bigf expr)
     ), iif iicomma
   )
 
-and vk_struct_fields_s = fun bigf fields -> 
+and vk_struct_fields_s = fun bigf fields ->
 
   let iif ii = vk_ii_s bigf ii in
 
-  fields +> List.map (fun (field) -> 
+  fields +> List.map (fun (field) ->
     (match field with
-    | (DeclarationField (FieldDeclList (onefield_multivars, iiptvirg))) -> 
+    | (DeclarationField (FieldDeclList (onefield_multivars, iiptvirg))) ->
         DeclarationField
-          (FieldDeclList 
+          (FieldDeclList
               (vk_struct_fieldkinds_s bigf onefield_multivars, iif iiptvirg))
     | EmptyField info -> EmptyField (vk_info_s bigf info)
-    | MacroDeclField ((s, args),ii) -> 
+    | MacroDeclField ((s, args),ii) ->
         MacroDeclField
-          ((s, 
+          ((s,
            args +> List.map (fun (e,ii) -> vk_argument_s bigf e, iif ii)
            ),
           iif ii)
 
-    | CppDirectiveStruct directive -> 
+    | CppDirectiveStruct directive ->
         CppDirectiveStruct (vk_cpp_directive_s bigf directive)
-    | IfdefStruct ifdef -> 
+    | IfdefStruct ifdef ->
         IfdefStruct (vk_ifdef_directive_s bigf ifdef)
 
     )
   )
 
 
-and vk_def_s = fun bigf d -> 
+and vk_def_s = fun bigf d ->
   let f = bigf.kdef_s in
   let iif ii = vk_ii_s bigf ii in
-  let rec k d = 
+  let rec k d =
     match d with
     | {f_name = s;
        f_type = (returnt, (paramst, (b, iib)));
@@ -1381,40 +1381,40 @@ and vk_def_s = fun bigf d ->
        f_body = statxs;
        f_attr = attrs;
        f_old_c_style = oldstyle;
-      }, ii  
-        -> 
+      }, ii
+        ->
         {f_name = s;
-         f_type = 
-            (vk_type_s bigf returnt, 
+         f_type =
+            (vk_type_s bigf returnt,
             (paramst +> List.map (fun (param, iicomma) ->
               (vk_param_s bigf param, iif iicomma)
             ), (b, iif iib)));
          f_storage = sto;
-         f_body = 
+         f_body =
             vk_statement_sequencable_list_s bigf statxs;
-         f_attr = 
+         f_attr =
             attrs +> List.map (vk_attribute_s bigf);
-         f_old_c_style = 
-            oldstyle +> Common2.map_option (fun decls -> 
+         f_old_c_style =
+            oldstyle +> Common2.map_option (fun decls ->
               decls +> List.map (vk_decl_s bigf)
             );
         },
         iif ii
 
-  in f (k, bigf) d 
+  in f (k, bigf) d
 
-and vk_toplevel_s = fun bigf p -> 
+and vk_toplevel_s = fun bigf p ->
   let f = bigf.ktoplevel_s in
   let iif ii = vk_ii_s bigf ii in
-  let rec k p = 
+  let rec k p =
     match p with
     | Declaration decl -> Declaration (vk_decl_s bigf decl)
     | Definition def -> Definition (vk_def_s bigf def)
     | EmptyDef ii -> EmptyDef (iif ii)
-    | MacroTop (s, xs, ii) -> 
+    | MacroTop (s, xs, ii) ->
         MacroTop
-          (s, 
-          xs +> List.map (fun (elem, iicomma) -> 
+          (s,
+          xs +> List.map (fun (elem, iicomma) ->
             vk_argument_s bigf elem, iif iicomma
           ),
           iif ii
@@ -1426,63 +1426,63 @@ and vk_toplevel_s = fun bigf p ->
     | FinalDef info -> FinalDef (vk_info_s bigf info)
   in f (k, bigf) p
 
-and vk_program_s = fun bigf xs -> 
+and vk_program_s = fun bigf xs ->
   xs +> List.map (vk_toplevel_s bigf)
 
 
 and vk_cpp_directive_s = fun bigf top ->
   let iif ii = vk_ii_s bigf ii in
   let f = bigf.kcppdirective_s in
-  let rec k top = 
-  match top with 
+  let rec k top =
+  match top with
     (* go inside ? *)
     | Include {i_include = (s, ii);
                i_rel_pos = h_rel_pos;
                i_is_in_ifdef = b;
                i_content = copt;
-               } 
+               }
       -> Include {i_include = (s, iif ii);
                   i_rel_pos = h_rel_pos;
                   i_is_in_ifdef = b;
-                  i_content = copt +> Common2.map_option (fun (file, asts) -> 
+                  i_content = copt +> Common2.map_option (fun (file, asts) ->
                     file, vk_program_s bigf asts
                   );
       }
-    | Define ((s,ii), (defkind, defval)) -> 
-        Define ((s, iif ii), 
+    | Define ((s,ii), (defkind, defval)) ->
+        Define ((s, iif ii),
                (vk_define_kind_s bigf defkind, vk_define_val_s bigf defval))
     | Undef (s, ii) -> Undef (s, iif ii)
     | PragmaAndCo (ii) -> PragmaAndCo (iif ii)
 
   in f (k, bigf) top
 
-and vk_ifdef_directive_s = fun bigf ifdef -> 
+and vk_ifdef_directive_s = fun bigf ifdef ->
   let iif ii = vk_ii_s bigf ii in
   match ifdef with
   | IfdefDirective (ifkind, ii) -> IfdefDirective (ifkind, iif ii)
 
 
 
-and vk_define_kind_s  = fun bigf defkind -> 
+and vk_define_kind_s  = fun bigf defkind ->
   match defkind with
-  | DefineVar -> DefineVar 
-  | DefineFunc (params, ii) -> 
-      DefineFunc 
-        (params +> List.map (fun ((s,iis),iicomma) -> 
+  | DefineVar -> DefineVar
+  | DefineFunc (params, ii) ->
+      DefineFunc
+        (params +> List.map (fun ((s,iis),iicomma) ->
           ((s, vk_ii_s bigf iis), vk_ii_s bigf iicomma)
         ),
         vk_ii_s bigf ii
         )
 
 
-and vk_define_val_s = fun bigf x -> 
+and vk_define_val_s = fun bigf x ->
   let f = bigf.kdefineval_s in
   let iif ii = vk_ii_s bigf ii in
-  let rec k x = 
+  let rec k x =
     match x with
     | DefineExpr e  -> DefineExpr (vk_expr_s bigf e)
     | DefineStmt st -> DefineStmt (vk_statement_s bigf st)
-    | DefineDoWhileZero ((st,e),ii) -> 
+    | DefineDoWhileZero ((st,e),ii) ->
         let st' = vk_statement_s bigf st in
         let e' = vk_expr_s bigf e in
         DefineDoWhileZero ((st',e'), iif ii)
@@ -1492,77 +1492,77 @@ and vk_define_val_s = fun bigf x ->
     | DefineEmpty -> DefineEmpty
     | DefineInit ini -> DefineInit (vk_ini_s bigf ini)
 
-    | DefineTodo -> 
+    | DefineTodo ->
         pr2_once "DefineTodo";
         DefineTodo
   in
   f (k, bigf) x
-  
 
-and vk_info_s = fun bigf info -> 
+
+and vk_info_s = fun bigf info ->
   let rec infof ii = bigf.kinfo_s (k, bigf) ii
   and k i = i
   in
   infof info
 
-and vk_ii_s = fun bigf ii -> 
+and vk_ii_s = fun bigf ii ->
   List.map (vk_info_s bigf) ii
 
 (* ------------------------------------------------------------------------ *)
-and vk_node_s = fun bigf node -> 
+and vk_node_s = fun bigf node ->
   let iif ii = vk_ii_s bigf ii in
   let infof info = vk_info_s bigf info  in
 
   let rec nodef n = bigf.knode_s (k, bigf) n
-  and k node = 
+  and k node =
     F.rewrap node (
     match F.unwrap node with
-    | F.FunHeader (def) -> 
+    | F.FunHeader (def) ->
         assert (null (fst def).f_body);
         F.FunHeader (vk_def_s bigf def)
-          
+
     | F.Decl declb -> F.Decl (vk_decl_s bigf declb)
-    | F.ExprStatement (st, (eopt, ii)) ->  
+    | F.ExprStatement (st, (eopt, ii)) ->
         F.ExprStatement (st, (eopt +> Common2.map_option (vk_expr_s bigf), iif ii))
-          
-    | F.IfHeader (st, (e,ii))     -> 
+
+    | F.IfHeader (st, (e,ii))     ->
         F.IfHeader    (st, (vk_expr_s bigf e, iif ii))
-    | F.SwitchHeader (st, (e,ii)) -> 
+    | F.SwitchHeader (st, (e,ii)) ->
         F.SwitchHeader(st, (vk_expr_s bigf e, iif ii))
-    | F.WhileHeader (st, (e,ii))  -> 
+    | F.WhileHeader (st, (e,ii))  ->
         F.WhileHeader (st, (vk_expr_s bigf e, iif ii))
-    | F.DoWhileTail (e,ii)  -> 
+    | F.DoWhileTail (e,ii)  ->
         F.DoWhileTail (vk_expr_s bigf e, iif ii)
 
-    | F.ForHeader (st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) -> 
+    | F.ForHeader (st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) ->
         F.ForHeader (st,
                     (((e1opt +> Common2.map_option (vk_expr_s bigf), iif i1),
                      (e2opt +> Common2.map_option (vk_expr_s bigf), iif i2),
                      (e3opt +> Common2.map_option (vk_expr_s bigf), iif i3)),
                     iif ii))
 
-    | F.MacroIterHeader (st, ((s,es), ii)) -> 
+    | F.MacroIterHeader (st, ((s,es), ii)) ->
         F.MacroIterHeader
           (st,
           ((s, es +> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii)),
           iif ii))
 
-          
-    | F.ReturnExpr (st, (e,ii)) -> 
+
+    | F.ReturnExpr (st, (e,ii)) ->
         F.ReturnExpr (st, (vk_expr_s bigf e, iif ii))
-        
+
     | F.Case  (st, (e,ii)) -> F.Case (st, (vk_expr_s bigf e, iif ii))
-    | F.CaseRange (st, ((e1, e2),ii)) -> 
+    | F.CaseRange (st, ((e1, e2),ii)) ->
         F.CaseRange (st, ((vk_expr_s bigf e1, vk_expr_s bigf e2), iif ii))
 
     | F.CaseNode i -> F.CaseNode i
 
-    | F.DefineHeader((s,ii), (defkind)) -> 
+    | F.DefineHeader((s,ii), (defkind)) ->
         F.DefineHeader ((s, iif ii), (vk_define_kind_s bigf defkind))
 
     | F.DefineExpr e -> F.DefineExpr (vk_expr_s bigf e)
     | F.DefineType ft -> F.DefineType (vk_type_s bigf ft)
-    | F.DefineDoWhileZeroHeader ((),ii) -> 
+    | F.DefineDoWhileZeroHeader ((),ii) ->
         F.DefineDoWhileZeroHeader ((),iif ii)
     | F.DefineTodo -> F.DefineTodo
 
@@ -1570,8 +1570,8 @@ and vk_node_s = fun bigf node ->
                  i_rel_pos = h_rel_pos;
                  i_is_in_ifdef = b;
                  i_content = copt;
-                 }     
-      -> 
+                 }
+      ->
         assert (copt =*= None);
         F.Include {i_include = (s, iif ii);
                     i_rel_pos = h_rel_pos;
@@ -1579,8 +1579,8 @@ and vk_node_s = fun bigf node ->
                     i_content = copt;
                    }
 
-    | F.MacroTop (s, args, ii) -> 
-        F.MacroTop 
+    | F.MacroTop (s, args, ii) ->
+        F.MacroTop
           (s,
           args +> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii),
           iif ii)
@@ -1593,9 +1593,9 @@ and vk_node_s = fun bigf node ->
     | F.Continue (st,((),ii)) -> F.Continue (st,((),iif ii))
     | F.Default  (st,((),ii)) -> F.Default  (st,((),iif ii))
     | F.Return   (st,((),ii)) -> F.Return   (st,((),iif ii))
-    | F.Goto  (st, name, ((),ii)) -> 
+    | F.Goto  (st, name, ((),ii)) ->
         F.Goto  (st, vk_name_s bigf name, ((),iif ii))
-    | F.Label (st, name, ((),ii)) -> 
+    | F.Label (st, name, ((),ii)) ->
         F.Label (st, vk_name_s bigf name, ((),iif ii))
     | F.EndStatement iopt -> F.EndStatement (Common2.map_option infof iopt)
     | F.DoHeader (st, info) -> F.DoHeader (st, infof info)
@@ -1619,9 +1619,9 @@ and vk_node_s = fun bigf node ->
     )
   in
   nodef node
-  
+
 (* ------------------------------------------------------------------------ *)
-and vk_param_s = fun bigf param -> 
+and vk_param_s = fun bigf param ->
   let iif ii = vk_ii_s bigf ii in
   let {p_namei = swrapopt; p_register = (b, iib); p_type=ft} = param in
   { p_namei = swrapopt +> Common2.map_option (vk_name_s bigf);
@@ -1629,39 +1629,39 @@ and vk_param_s = fun bigf param ->
     p_type = vk_type_s bigf ft;
   }
 
-let vk_args_splitted_s = fun bigf args_splitted -> 
+let vk_args_splitted_s = fun bigf args_splitted ->
   let iif ii = vk_ii_s bigf ii in
-  args_splitted +> List.map (function  
+  args_splitted +> List.map (function
   | Left arg -> Left (vk_argument_s bigf arg)
   | Right ii -> Right (iif ii)
   )
 
-let vk_arguments_s = fun bigf args -> 
+let vk_arguments_s = fun bigf args ->
   let iif ii = vk_ii_s bigf ii in
   args +> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii)
 
 
-let vk_params_splitted_s = fun bigf args_splitted -> 
+let vk_params_splitted_s = fun bigf args_splitted ->
   let iif ii = vk_ii_s bigf ii in
-  args_splitted +> List.map (function  
+  args_splitted +> List.map (function
   | Left arg -> Left (vk_param_s bigf arg)
   | Right ii -> Right (iif ii)
   )
 
-let vk_params_s = fun bigf args -> 
+let vk_params_s = fun bigf args ->
   let iif ii = vk_ii_s bigf ii in
   args +> List.map (fun (p,ii) -> vk_param_s bigf p, iif ii)
 
-let vk_define_params_splitted_s = fun bigf args_splitted -> 
+let vk_define_params_splitted_s = fun bigf args_splitted ->
   let iif ii = vk_ii_s bigf ii in
-  args_splitted +> List.map (function  
+  args_splitted +> List.map (function
   | Left (s, iis) -> Left (s, vk_ii_s bigf iis)
   | Right ii -> Right (iif ii)
   )
 
-let vk_cst_s = fun bigf (cst, ii) -> 
+let vk_cst_s = fun bigf (cst, ii) ->
   let iif ii = vk_ii_s bigf ii in
   (match cst with
-  | Left cst -> Left cst 
+  | Left cst -> Left cst
   | Right s -> Right s
   ), iif ii

--- a/parsing_c/visitor_c.mli
+++ b/parsing_c/visitor_c.mli
@@ -17,7 +17,7 @@ type visitor_c = {
   kstatementseq: (statement_sequencable   -> unit) * visitor_c -> statement_sequencable   -> unit;
 
 
-  knode:      
+  knode:
     (Control_flow_c.node -> unit) * visitor_c -> Control_flow_c.node -> unit;
   ktoplevel: (toplevel -> unit) * visitor_c -> toplevel -> unit;
 
@@ -44,7 +44,7 @@ val vk_argument_list : visitor_c -> argument wrap2 list -> unit
 val vk_args_splitted : visitor_c -> (argument, il) Common.either list -> unit
 val vk_param : visitor_c -> parameterType -> unit
 val vk_param_list : visitor_c -> parameterType wrap2 list -> unit
-val vk_params_splitted : 
+val vk_params_splitted :
   visitor_c -> (parameterType, il) Common.either list -> unit
 
 val vk_struct_fields : visitor_c -> field list -> unit
@@ -52,7 +52,7 @@ val vk_struct_fieldkinds : visitor_c -> fieldkind wrap list -> unit
 
 val vk_cst : visitor_c -> ((constant, string) Common.either wrap) -> unit
 
-val vk_define_params_splitted : 
+val vk_define_params_splitted :
   visitor_c -> (string Ast_c.wrap, il) Common.either list -> unit
 
 
@@ -73,10 +73,10 @@ type visitor_c_s = {
   kcppdirective_s : (cpp_directive inout * visitor_c_s) -> cpp_directive inout;
   kdefineval_s : (define_val inout * visitor_c_s) -> define_val inout;
   kstatementseq_s: (statement_sequencable inout * visitor_c_s) -> statement_sequencable inout;
-  kstatementseq_list_s: 
+  kstatementseq_list_s:
     (statement_sequencable list inout * visitor_c_s) -> statement_sequencable list inout;
 
-  knode_s      : 
+  knode_s      :
     Control_flow_c.node inout * visitor_c_s -> Control_flow_c.node    inout;
   ktoplevel_s  : toplevel inout * visitor_c_s -> toplevel inout;
 
@@ -99,33 +99,33 @@ val vk_ii_s : visitor_c_s -> info list -> info list
 val vk_node_s : visitor_c_s -> Control_flow_c.node -> Control_flow_c.node
 val vk_program_s  : visitor_c_s -> program -> program
 
-val vk_arguments_s : 
-  visitor_c_s -> 
+val vk_arguments_s :
+  visitor_c_s ->
   argument wrap2 list -> argument wrap2 list
 
-val vk_args_splitted_s : 
-  visitor_c_s -> 
-  (argument, il) Common.either list -> 
+val vk_args_splitted_s :
+  visitor_c_s ->
+  (argument, il) Common.either list ->
   (argument, il) Common.either list
 
-val vk_params_s : 
-  visitor_c_s -> 
+val vk_params_s :
+  visitor_c_s ->
   parameterType wrap2 list -> parameterType wrap2 list
 
-val vk_params_splitted_s : 
-  visitor_c_s -> 
-  (parameterType, il) Common.either list -> 
+val vk_params_splitted_s :
+  visitor_c_s ->
+  (parameterType, il) Common.either list ->
   (parameterType, il) Common.either list
 
 
 
 val vk_param_s : visitor_c_s -> parameterType -> parameterType
 
-val vk_define_params_splitted_s : 
-  visitor_c_s -> 
-  (string Ast_c.wrap, il) Common.either list -> 
+val vk_define_params_splitted_s :
+  visitor_c_s ->
+  (string Ast_c.wrap, il) Common.either list ->
   (string Ast_c.wrap, il) Common.either list
 
 val vk_struct_fields_s : visitor_c_s -> field list -> field list
 
-val vk_cst_s : visitor_c_s -> ((constant, string) Common.either wrap) inout 
+val vk_cst_s : visitor_c_s -> ((constant, string) Common.either wrap) inout

--- a/pl_info/Makefile
+++ b/pl_info/Makefile
@@ -4,12 +4,12 @@
 TARGET=code_info
 
 # ast_cocci.ml and unparse_cocci2.ml should be deleted in the futur
-# to make parsing_c really independent of coccinelle. 
+# to make parsing_c really independent of coccinelle.
 # control_flow_c have also coccinelle dependencies.
 SRC= programming_language.ml ast_generic.ml place_code.ml parse_info.ml \
      statistics_code.ml statistics_parsing.ml
 
-SYSLIBS= str.cma unix.cma 
+SYSLIBS= str.cma unix.cma
 LIBS=../commons/commons.cma
 INCLUDES= -I ../commons
 
@@ -17,9 +17,9 @@ INCLUDES= -I ../commons
 # Generic variables
 ##############################################################################
 
-#for warning:  -w A 
+#for warning:  -w A
 #for profiling:  -p -inline 0   with OCAMLOPT
-OCAMLC=ocamlc$(OPTBIN) -g -dtypes   $(INCLUDES) 
+OCAMLC=ocamlc$(OPTBIN) -g -dtypes   $(INCLUDES)
 OCAMLOPT=ocamlopt$(OPTBIN)   $(INCLUDES) $(OPTFLAGS)
 OCAMLLEX=ocamllex$(OPTBIN) #-ml
 OCAMLYACC=ocamlyacc -v
@@ -63,7 +63,7 @@ clean::
 .ml.cmx:
 	$(OCAMLOPT) -c $<
 
-.ml.mldepend: 
+.ml.mldepend:
 	$(OCAMLC) -i $<
 
 clean::

--- a/pl_info/ast_generic.ml
+++ b/pl_info/ast_generic.ml
@@ -7,14 +7,14 @@ type assignOp = SimpleAssign | OpAssign of arithOp
 
 and binaryOp = Arith of arithOp | Logical of logicalOp
 
-       and arithOp   = 
+       and arithOp   =
          | Plus | Minus | Mul | Div | Mod
-         | DecLeft | DecRight 
+         | DecLeft | DecRight
          | And | Or | Xor
 
-       and logicalOp = 
-         | Inf | Sup | InfEq | SupEq 
-         | Eq | NotEq 
+       and logicalOp =
+         | Inf | Sup | InfEq | SupEq
+         | Eq | NotEq
          | AndLog | OrLog
 
 

--- a/pl_info/parse_info.ml
+++ b/pl_info/parse_info.ml
@@ -7,28 +7,28 @@ type t = {
     line: int;
     column: int;
     file: filename;
-  } 
+  }
   (* with sexp *)
 
-let fake_parse_info = { 
+let fake_parse_info = {
   charpos = -1; str = "";
   line = -1; column = -1; file = "";
 }
 
-let string_of_parse_info x = 
+let string_of_parse_info x =
   spf "%s at %s:%d:%d" x.str x.file x.line x.column
-let string_of_parse_info_bis x = 
+let string_of_parse_info_bis x =
   spf "%s:%d:%d" x.file x.line x.column
 
-let (info_from_charpos2: int -> filename -> (int * int * string)) = 
+let (info_from_charpos2: int -> filename -> (int * int * string)) =
  fun charpos filename ->
 
   (* Currently lexing.ml does not handle the line number position.
-   * Even if there is some fields in the lexing structure, they are not 
+   * Even if there is some fields in the lexing structure, they are not
    * maintained by the lexing engine :( So the following code does not work:
-   *   let pos = Lexing.lexeme_end_p lexbuf in 
-   *   sprintf "at file %s, line %d, char %d" pos.pos_fname pos.pos_lnum  
-   *      (pos.pos_cnum - pos.pos_bol) in 
+   *   let pos = Lexing.lexeme_end_p lexbuf in
+   *   sprintf "at file %s, line %d, char %d" pos.pos_fname pos.pos_lnum
+   *      (pos.pos_cnum - pos.pos_bol) in
    * Hence this function to overcome the previous limitation.
    *)
   let chan = open_in filename in
@@ -52,12 +52,12 @@ let (info_from_charpos2: int -> filename -> (int * int * string)) =
 	  charpos_to_pos_aux !posl;
 	end
     | None -> (!linen, charpos - !posl, "\n")
-  in 
+  in
   let res = charpos_to_pos_aux 0 in
   close_in chan;
   res
 
-let info_from_charpos a b = 
+let info_from_charpos a b =
   profile_code "Common.info_from_charpos" (fun () -> info_from_charpos2 a b)
 
 
@@ -79,33 +79,33 @@ let full_charpos_to_pos2 = fun filename ->
        incr line;
 
        (* '... +1 do'  cos input_line dont return the trailing \n *)
-       for i = 0 to (String.length s - 1) + 1 do 
+       for i = 0 to (String.length s - 1) + 1 do
          arr.(!charpos + i) <- (!line, i);
        done;
        charpos := !charpos + String.length s + 1;
        full_charpos_to_pos_aux();
-       
-     with End_of_file -> 
+
+     with End_of_file ->
        for i = !charpos to Array.length arr - 1 do
          arr.(i) <- (!line, 0);
        done;
        ();
-    in 
-    begin 
+    in
+    begin
       full_charpos_to_pos_aux ();
       close_in chan;
       arr
     end
 let full_charpos_to_pos a =
   profile_code "Common.full_charpos_to_pos" (fun () -> full_charpos_to_pos2 a)
-    
-let test_charpos file = 
+
+let test_charpos file =
   full_charpos_to_pos file +> dump +> pr2
 
 
 
-let complete_parse_info filename table x = 
-  { x with 
+let complete_parse_info filename table x =
+  { x with
     file = filename;
     line   = fst (table.(x.charpos));
     column = snd (table.(x.charpos));
@@ -118,9 +118,9 @@ let full_charpos_to_pos_large2 = fun filename ->
   let size = (Common2.filesize filename + 2) in
 
     (* old: let arr = Array.create size  (0,0) in *)
-    let arr1 = Bigarray.Array1.create 
+    let arr1 = Bigarray.Array1.create
       Bigarray.int Bigarray.c_layout size in
-    let arr2 = Bigarray.Array1.create 
+    let arr2 = Bigarray.Array1.create
       Bigarray.int Bigarray.c_layout size in
     Bigarray.Array1.fill arr1 0;
     Bigarray.Array1.fill arr2 0;
@@ -136,56 +136,56 @@ let full_charpos_to_pos_large2 = fun filename ->
        incr line;
 
        (* '... +1 do'  cos input_line dont return the trailing \n *)
-       for i = 0 to (String.length s - 1) + 1 do 
+       for i = 0 to (String.length s - 1) + 1 do
          (* old: arr.(!charpos + i) <- (!line, i); *)
          arr1.{!charpos + i} <- (!line);
          arr2.{!charpos + i} <- i;
        done;
        charpos := !charpos + String.length s + 1;
        full_charpos_to_pos_aux();
-       
-     with End_of_file -> 
-       for i = !charpos to (* old: Array.length arr *) 
+
+     with End_of_file ->
+       for i = !charpos to (* old: Array.length arr *)
          Bigarray.Array1.dim arr1 - 1 do
          (* old: arr.(i) <- (!line, 0); *)
          arr1.{i} <- !line;
          arr2.{i} <- 0;
        done;
        ();
-    in 
-    begin 
+    in
+    begin
       full_charpos_to_pos_aux ();
       close_in chan;
       (fun i -> arr1.{i}, arr2.{i})
     end
 let full_charpos_to_pos_large a =
-  profile_code "Common.full_charpos_to_pos_large" 
+  profile_code "Common.full_charpos_to_pos_large"
     (fun () -> full_charpos_to_pos_large2 a)
 
 
-let complete_parse_info_large filename table x = 
-  { x with 
+let complete_parse_info_large filename table x =
+  { x with
     file = filename;
     line   = fst (table (x.charpos));
     column = snd (table (x.charpos));
   }
 
 (*---------------------------------------------------------------------------*)
-(* Decalage is here to handle stuff such as cpp which include file and who 
+(* Decalage is here to handle stuff such as cpp which include file and who
  * can make shift.
  *)
 let (error_messagebis: filename -> (string * int) -> int -> string)=
  fun filename (lexeme, lexstart) decalage ->
 
   let charpos = lexstart      + decalage in
-  let tok = lexeme in 
+  let tok = lexeme in
   let (line, pos, linecontent) =  info_from_charpos charpos filename in
   spf "File \"%s\", line %d, column %d,  charpos = %d
     around = '%s', whole content = %s"
     filename line pos charpos tok (Common2.chop linecontent)
 
-let error_message = fun filename (lexeme, lexstart) -> 
-  try error_messagebis filename (lexeme, lexstart) 0    
+let error_message = fun filename (lexeme, lexstart) ->
+  try error_messagebis filename (lexeme, lexstart) 0
   with
     End_of_file ->
       ("PB in Common.error_message, position " ^ i_to_s lexstart ^
@@ -193,16 +193,16 @@ let error_message = fun filename (lexeme, lexstart) ->
 
 
 
-let error_message_short = fun filename (lexeme, lexstart) -> 
-  try 
+let error_message_short = fun filename (lexeme, lexstart) ->
+  try
   let charpos = lexstart in
   let (line, pos, linecontent) =  info_from_charpos charpos filename in
   spf "File \"%s\", line %d"  filename line
 
-  with End_of_file -> 
+  with End_of_file ->
     begin
       ("PB in Common.error_message, position " ^ i_to_s lexstart ^
           " given out of file:" ^ filename);
     end
-    
+
 

--- a/pl_info/place_code.ml
+++ b/pl_info/place_code.ml
@@ -8,13 +8,13 @@
  * times.
  *
  * todo? make difference between macroVar that expand to constant and
- * the one that expands to complex code ? 
- * 
+ * the one that expands to complex code ?
+ *
  * history: was in of ccomment/comments/comments_extraction.ml
  *
  * From ocamldoc manual, the ocaml entities:
  *  "In this chapter, we use the word element to refer to any of the
- *  following parts of an OCaml source file": 
+ *  following parts of an OCaml source file":
  *  - SEMI a module
  *  - DONE a class
  *  - DONE a type
@@ -25,11 +25,11 @@
  *  - a module type
  *  - a class type
  *  - DONE a class method
- *  - DONE a class value or 
+ *  - DONE a class value or
  *  - a class inheritance clause
  *)
 
-type place = 
+type place =
 
   | Header (* file/module/package comment *)
 
@@ -51,8 +51,8 @@ type place =
   | Constructor of string
   | Destructor of string
 
-  | ThrowErrorSpec 
-  | InheritanceSpec 
+  | ThrowErrorSpec
+  | InheritanceSpec
 
   (* ------------------- *)
   (* cppext: *)
@@ -62,7 +62,7 @@ type place =
   | MacroVariable of string
 
   (* #ifdef, make difference between the different kind ? cst, version, etc*)
-  | IfDef 
+  | IfDef
 
   (* #include, import *)
   | Include of string
@@ -78,7 +78,7 @@ type place =
   | Field of string
 
   (* add type ? maybe can detect that put lots of comments on int *)
-  | Struct of string 
+  | Struct of string
   | StructIdent (* as in struct /* xxx */ { }, often seen in sparse code *)
 
   | Enum of string
@@ -102,14 +102,14 @@ type place =
   (* end of stuff *)
 
   | EndCompound
-  | Else 
+  | Else
 
 
   | EndOfFile
 
   (* ------------------- *)
   (* fallthrough *)
-  | InInitializerUnknown 
+  | InInitializerUnknown
   | InStructUnknown
   | InEnumUnknown
   | InFuncUnknown
@@ -128,7 +128,7 @@ type place =
           * than comments in the LFS database
           *)
 
- and statement_place = 
+ and statement_place =
    | If
    | Loop (* for, while, iterator *)
 
@@ -158,14 +158,14 @@ type place =
 
    | StatementUnknown
 
- and expression_place = 
+ and expression_place =
    | Binary of Ast_generic.binaryOp
 
    | ExpressionUnknown
 
 
 (*****************************************************************************)
-let s_of_arithop op = 
+let s_of_arithop op =
   match op with
   | Ast_generic.Plus | Ast_generic.Minus -> "plusminus"
   | Ast_generic.Mul | Ast_generic.Div | Ast_generic.Mod -> "muldiv"
@@ -216,7 +216,7 @@ let (s_of_place : place -> string * string option) = function
   | EndOfFile -> "end_eof", None
   | Else -> "end_else", None
 
-  | Statement st -> 
+  | Statement st ->
       (match st with
       | If -> "if", None
       | Loop -> "loop", None
@@ -247,7 +247,7 @@ let (s_of_place : place -> string * string option) = function
       | StatementUnknown -> "statement_misc", None
       )
 
-  | Expression e -> 
+  | Expression e ->
       (match e with
       | Binary op -> "op", None
       | ExpressionUnknown -> "exp_misc", None
@@ -269,5 +269,5 @@ let (s_of_place : place -> string * string option) = function
 
 
 (* unify back some difference place like struct/class, function/method *)
-let simplify_and_group_place place = 
+let simplify_and_group_place place =
   raise Common.Todo

--- a/pl_info/programming_language.ml
+++ b/pl_info/programming_language.ml
@@ -1,13 +1,13 @@
-open Common 
+open Common
 
 
-type pl = 
+type pl =
   | C
   | Cplusplus
   | Java
 
 (* todo detect false C file, look for "Mode: Objective-C++" string in file ?*)
-let detect_pl_of_file file = 
+let detect_pl_of_file file =
   let (d,b,e) = Common2.dbe_of_filename file in
   match e with
   | "c" -> C

--- a/pl_info/statistics_code.ml
+++ b/pl_info/statistics_code.ml
@@ -4,21 +4,21 @@ open Common
 (*****************************************************************************)
 (* Entities stat *)
 (*****************************************************************************)
-(* 
- * This module can be used to store stat on code entities or commented 
- * code entities, be it C, C++, or Java entities. 
- * 
+(*
+ * This module can be used to store stat on code entities or commented
+ * code entities, be it C, C++, or Java entities.
+ *
  * The numbers can represent anything.
- * 
+ *
  * todo?: a little bit of overlap with Comments.place ? and quite tedious
  * all those fields to manipulate. OCaml not very good with fields to
- * factorize code. So change ? use a hash ? use Comments.place ? 
+ * factorize code. So change ? use a hash ? use Comments.place ?
  * But Comments.place type quite suited to the fact that all comments
  * does not have multiple place but are a choice.
- * 
- * note: no need for mutable nb_header: int; :) 
+ *
+ * note: no need for mutable nb_header: int; :)
  *)
-type entities_stat = { 
+type entities_stat = {
   mutable nb_define_var: int;
   mutable nb_define_func: int;
   mutable nb_include: int;
@@ -127,24 +127,24 @@ let op_entities_stat (+) st1 st2 = {
   nb_initializer = st1.nb_initializer + st2.nb_initializer;
 }
 
-let add_entities_stat st1 st2 = 
+let add_entities_stat st1 st2 =
   op_entities_stat (+) st1 st2
 
 
 
-let sum_entities_stat_list xs = 
+let sum_entities_stat_list xs =
   xs +> List.fold_left add_entities_stat (default_entities_stat())
 
-let div_pourcent_entities_stat st1 st2 = 
-  let (+++) n1 n2 = 
-    if n2 = 0 
-    then -1 
+let div_pourcent_entities_stat st1 st2 =
+  let (+++) n1 n2 =
+    if n2 = 0
+    then -1
     else (n1 * 100) / n2
   in
   op_entities_stat (+++) st1 st2
-      
 
-let print_entities_stat_list = fun xs -> 
+
+let print_entities_stat_list = fun xs ->
   let _files_total = (List.length xs) in
   let sum = sum_entities_stat_list xs in
   begin
@@ -183,8 +183,8 @@ let print_entities_stat_list = fun xs ->
     pr2 (spf "NB initializer = %d" sum.nb_initializer);
   end
 
-let hash_of_entities_stat sum = 
-  let h = Hashtbl.create 101 in 
+let hash_of_entities_stat sum =
+  let h = Hashtbl.create 101 in
   begin
     Hashtbl.add h "define_var" sum.nb_define_var;
     Hashtbl.add h "define_func" sum.nb_define_func;
@@ -223,7 +223,7 @@ let hash_of_entities_stat sum =
     h
   end
 
-let assoc_of_entities_stat x = 
+let assoc_of_entities_stat x =
   x +> hash_of_entities_stat +> Common.hash_to_list
 
 

--- a/pl_info/statistics_code.mli
+++ b/pl_info/statistics_code.mli
@@ -6,7 +6,7 @@
  * everything in the same visitor, so the entities_stat computation
  * are still actually in comments_extraction.ml.
  *)
-type entities_stat = { 
+type entities_stat = {
   mutable nb_define_var: int;
   mutable nb_define_func: int;
   mutable nb_include: int;
@@ -40,14 +40,14 @@ type entities_stat = {
   mutable nb_simple_assign: int;
   mutable nb_simple_field_assign: int;
   mutable nb_initializer: int;
-  
+
 }
 val default_entities_stat : unit -> entities_stat
 val print_entities_stat_list : entities_stat list -> unit
 
-val add_entities_stat : 
+val add_entities_stat :
   entities_stat -> entities_stat -> entities_stat
-val div_pourcent_entities_stat : 
+val div_pourcent_entities_stat :
   entities_stat -> entities_stat -> entities_stat
 
 val sum_entities_stat_list : entities_stat list -> entities_stat

--- a/pl_info/statistics_parsing.ml
+++ b/pl_info/statistics_parsing.ml
@@ -1,6 +1,6 @@
-open Common 
+open Common
 
-(* clone with parsing_c/parsing_stat.ml *) 
+(* clone with parsing_c/parsing_stat.ml *)
 
 (*****************************************************************************)
 (* Stat *)
@@ -9,69 +9,69 @@ type parsing_stat = {
     filename: filename;
     mutable have_timeout: bool;
 
-    mutable correct: int;  
+    mutable correct: int;
     mutable bad: int;
 
     mutable commentized: int; (* by our cpp commentizer *)
 
     (* if want to know exactly what was passed through, uncomment:
-     *  
+     *
      * mutable passing_through_lines: int;
-     * 
+     *
      * it differs from bad by starting from the error to
      * the synchro point instead of starting from start of
      * function to end of function.
      *)
 
-  } 
+  }
 
-let default_stat file =  { 
+let default_stat file =  {
     filename = file;
     have_timeout = false;
     correct = 0; bad = 0;
     commentized = 0;
   }
 
-(* todo: stat per dir ?  give in terms of func_or_decl numbers:   
- * nbfunc_or_decl pbs / nbfunc_or_decl total ?/ 
+(* todo: stat per dir ?  give in terms of func_or_decl numbers:
+ * nbfunc_or_decl pbs / nbfunc_or_decl total ?/
  *
- * note: cela dit si y'a des fichiers avec des #ifdef dont on connait pas les 
- * valeurs alors on parsera correctement tout le fichier et pourtant y'aura 
- * aucune def  et donc aucune couverture en fait.   
- * ==> TODO evaluer les parties non parsé ? 
+ * note: cela dit si y'a des fichiers avec des #ifdef dont on connait pas les
+ * valeurs alors on parsera correctement tout le fichier et pourtant y'aura
+ * aucune def  et donc aucune couverture en fait.
+ * ==> TODO evaluer les parties non parsé ?
  *)
 
-let print_parsing_stat_list ?(verbose=false) = fun statxs -> 
+let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   let total = (List.length statxs) in
-  let perfect = 
-    statxs 
-      +> List.filter (function 
+  let perfect =
+    statxs
+      +> List.filter (function
           {have_timeout = false; bad = 0} -> true | _ -> false)
-      +> List.length 
+      +> List.length
   in
 
-  if verbose then begin 
+  if verbose then begin
   pr "\n\n\n---------------------------------------------------------------";
   pr "pbs with files:";
-  statxs 
-    +> List.filter (function 
-      | {have_timeout = true} -> true 
-      | {bad = n} when n > 0 -> true 
+  statxs
+    +> List.filter (function
+      | {have_timeout = true} -> true
+      | {bad = n} when n > 0 -> true
       | _ -> false)
-    +> List.iter (function 
-        {filename = file; have_timeout = timeout; bad = n} -> 
+    +> List.iter (function
+        {filename = file; have_timeout = timeout; bad = n} ->
           pr (file ^ "  " ^ (if timeout then "TIMEOUT" else i_to_s n));
         );
 
   pr "\n\n\n";
   pr "files with lots of tokens passed/commentized:";
   let threshold_passed = 100 in
-  statxs 
-    +> List.filter (function 
+  statxs
+    +> List.filter (function
       | {commentized = n} when n > threshold_passed -> true
       | _ -> false)
-    +> List.iter (function 
-        {filename = file; commentized = n} -> 
+    +> List.iter (function
+        {filename = file; commentized = n} ->
           pr (file ^ "  " ^ (i_to_s n));
         );
 
@@ -89,14 +89,14 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   (spf "NB total files = %d; " total) ^
   (spf "NB total lines = %d; " total_lines) ^
   (spf "perfect = %d; " perfect) ^
-  (spf "pbs = %d; "     (statxs +> List.filter (function 
-      {have_timeout = b; bad = n} when n > 0 -> true | _ -> false) 
+  (spf "pbs = %d; "     (statxs +> List.filter (function
+      {have_timeout = b; bad = n} when n > 0 -> true | _ -> false)
                                +> List.length)) ^
-  (spf "timeout = %d; " (statxs +> List.filter (function 
-      {have_timeout = true; bad = n} -> true | _ -> false) 
+  (spf "timeout = %d; " (statxs +> List.filter (function
+      {have_timeout = true; bad = n} -> true | _ -> false)
                                +> List.length)) ^
   (spf "=========> %d" ((100 * perfect) / total)) ^ "%"
-                                                          
+
  );
   let gf, badf = float_of_int good, float_of_int bad in
   let passedf = float_of_int passed in

--- a/pl_info/statistics_parsing.mli
+++ b/pl_info/statistics_parsing.mli
@@ -4,6 +4,6 @@ type parsing_stat = {
     mutable correct: int;
     mutable bad: int;
     mutable commentized: int;
-  } 
+  }
 
 val print_parsing_stat_list: ?verbose:bool -> parsing_stat list -> unit

--- a/project.el
+++ b/project.el
@@ -1,11 +1,11 @@
 (defun pad-ocaml-project-Yacfe ()
   (interactive)
 
-  (setq 
+  (setq
    pad-ocaml-project-path "/home/pad/mobile/project-yacfe/code"
-   pad-ocaml-project-subdirs 
-   (split-string 
-    "commons globals extra 
+   pad-ocaml-project-subdirs
+   (split-string
+    "commons globals extra
      parsing_c parsing_cplusplus parsing_java
      analyze_c
      matcher_c
@@ -20,9 +20,9 @@
   ; --------------------------------------------------------------------------
   (setq
    pad-ocaml-project-prog     "yacfe"
-   pad-ocaml-project-args 
-   (join-string 
-    (list 
+   pad-ocaml-project-args
+   (join-string
+    (list
      "-debugger"
      (case 9
        (0 "")
@@ -62,14 +62,14 @@
        (96 "-parse_c++ /home/pad/c-yacfe/tests2/qualified_typedef.cpp")
        (97 "-parse_c++ /home/pad/c-yacfe/tests2/error_recov_test1.cpp")
        (98 "-parse_c++ /home/pad/c-yacfe/tests2/define_initializer_optvirg.cpp")
-       ;operator_eq.cpp 
-       ;constructor_multi.cpp 
+       ;operator_eq.cpp
+       ;constructor_multi.cpp
        ;constructed_template2.cpp
        ;false_positif_cast_is_constructor.cpp
        ;(100 "-parse_c++ /home/pad/c-yacfe/tests_c++/attribute_passing.cpp")
        (100 "-parse_c++ /home/pad/c-yacfe/tests_c++/ex_tara.cpp")
        ;constructed_bool1
-       
+
        (201 "-parse_java /home/pad/c-yacfe/tests-ex/java/objet-4eme-annee/tp7/Reference.java")
        (202 "-parse_java /home/pad/c-yacfe/tests_java/simple.java")
 
@@ -120,9 +120,9 @@
   ; --------------------------------------------------------------------------
   (setq
    pad-ocaml-project-prog     "yacfe_browser"
-   pad-ocaml-project-args 
-   (join-string 
-    (list 
+   pad-ocaml-project-args
+   (join-string
+    (list
      "-debugger"
      (case 1
        (0 "/home/pad/c-yacfe/tests-components/database/YACFEDB/")
@@ -137,7 +137,7 @@
 
 
   ; for the help system, for C-c C-h to find where to look for
-  (mapcar (lambda (p) 
+  (mapcar (lambda (p)
             (ocaml-add-path (concat pad-ocaml-project-path "/" p))
             (ocaml-add-path "/home/pad/packages/lib/ocaml/std-lib")
             (ocaml-add-path "/usr/lib/ocaml/3.09.2/lablgtk2")
@@ -149,7 +149,7 @@
           pad-ocaml-project-subdirs)
   )
 
-; specific emacs macros: 
+; specific emacs macros:
 (fset 'yacfe-goto-place
    [?\C-  ?\C-s ?: left ?\M-w ?\C-x ?\C-f ?/ S-insert return ?\C-\M-l right ?\C-  C-right ?\M-w ?\C-\M-l ?\M-g S-insert return])
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
                                     Yacfe
 
 -------------------
-Summary 
+Summary
 -------------------
 
 Yacfe (Yet Another C Front-End) is mainly an OCaml API to write
@@ -14,7 +14,7 @@ as much information as possible so that one can transform this AST and
 unparse it in a new file while preserving the coding style of the
 original file. Yacfe preserves the whitespaces, newlines, indentation,
 and comments from the original file, as well as the C preprocessor
-(cpp) macros and cpp directives. 
+(cpp) macros and cpp directives.
 
 Other source-to-source transformation tools such as CIL
 (http://manju.cs.berkeley.edu/cil/) do not preserve this coding style
@@ -50,7 +50,7 @@ Example
 You can then test Yacfe with:
 
    $ cd demos/
-   $ ocamlc -I ../commons/ -I ../parsing_c/ unix.cma str.cma bigarray.cma ../commons/commons.cma ../parsing_c/parsing_c.cma simple_zero_to_null.ml -o zero_to_null 
+   $ ocamlc -I ../commons/ -I ../parsing_c/ unix.cma str.cma bigarray.cma ../commons/commons.cma ../parsing_c/parsing_c.cma simple_zero_to_null.ml -o zero_to_null
    $ ./zero_to_null foo.c
    $ cat /tmp/modified.c
 
@@ -64,12 +64,12 @@ indentation, comments, cpp directives) has been maintained in
 
 The compilation process, in addition to building the parsing_c.cma library,
 also builds a binary program called 'yacfe' that can let you evaluate
-how good the Yacfe parser is. To test the parser for instance on the 
+how good the Yacfe parser is. To test the parser for instance on the
 source code of the git version control system, just do:
 
   $ cd /tmp
   $ wget http://kernel.org/pub/software/scm/git/git-1.6.2.4.tar.bz2
-  $ tar xvfj git-1.6.2.4.tar.bz2 
+  $ tar xvfj git-1.6.2.4.tar.bz2
   $ cd <yacfe_installation_dir>
   $ ./yacfe -parse /tmp/git-1.6.2.4/
 
@@ -103,9 +103,9 @@ where he can manually specify the class of specific but recurring
 macros that cause the above heuristics to originally fail. We have
 reused the syntax of cpp for the format of this file but Yacfe
 recognizes special keywords used in the body of macros as hints.
-Here is an excerpt of the configuration file for the Linux kernel: 
+Here is an excerpt of the configuration file for the Linux kernel:
 
-   #define change_hops YACFE__MACRO__ITERATOR 
+   #define change_hops YACFE__MACRO__ITERATOR
    #define DBG         YACFE__MACRO__STATEMENT
    #define KERN_EMERG  YACFE__MACRO__STRING
    #define DESC_ALIGN  YACFE__MACRO__DECL
@@ -113,11 +113,11 @@ Here is an excerpt of the configuration file for the Linux kernel:
 This file can also be used as a last resort as a way
 to partially call cpp for difficult macros, such as
 
-   __P(int, foo, (int x, int y)) 
+   __P(int, foo, (int x, int y))
    {
      printf("%d,%d", x y);
    }
-   
+
 by adding for instance this definition in the configuration file:
 
    #define __P(returnt, name, params) returnt name params
@@ -130,7 +130,7 @@ tool will be warned if it wants to transform those expansions.
 
 
 For more information on Yacfe see the files in the docs/ directory.
-The config/macros/ directory also contains examples of configuration files for 
+The config/macros/ directory also contains examples of configuration files for
 different popular open-source software.
 
 ----------------
@@ -139,7 +139,7 @@ Organization
 
 Here are roughly the services provided by Yacfe and their corresponding
 source files:
- - C parser which is also cpp-aware and program-transformation-friendly: 
+ - C parser which is also cpp-aware and program-transformation-friendly:
      - AST    (ast_c.ml)
      - lexer  (lexer_c.mll)
      - grammar (parser_c.mly)

--- a/test.ml
+++ b/test.ml
@@ -1,7 +1,7 @@
 open Common
 
 (* try put stuff in parsing_c/test_parsing_c.ml or analyze_c/test_analyze_c.ml
- * instead of in this file. 
+ * instead of in this file.
  *)
 
 open Ast_c
@@ -10,13 +10,13 @@ open Ast_c
 (* to be called by ocaml toplevel, to test. *)
 (*****************************************************************************)
 
-let cprogram_of_file file = 
+let cprogram_of_file file =
   (* useful only when called from toplevel *)
   Flag_parsing_c.std_h := "/home/pad/c-yacfe/config/macros/standard.h";
   Parse_c.init_defs !Flag_parsing_c.std_h;
 
   let (program2, _stat) = Parse_c.parse_c_and_cpp file in
-  program2 
+  program2
 
 
 (*****************************************************************************)

--- a/tests/hints_required.c
+++ b/tests/hints_required.c
@@ -1,6 +1,6 @@
-#include <stdio.h> 
+#include <stdio.h>
 
-#define XXX_ICH(i, a,b) for (i = a; i < b; i++) 
+#define XXX_ICH(i, a,b) for (i = a; i < b; i++)
 
 void main()
 {


### PR DESCRIPTION
This change removes trailing whitespace from the sources. There's a lot of it. This is cosmetic (and I have some more cosmetic changes), but is preparatory to some more substantive pulls I have queued up.

BTW, as I noted in a ticket earlier, I find these useful for noticing tabs and trailing whitespace that I've accidentally put in my code.

```elisp
;; This shows off any garbage trailing whitespace
(setq-default show-trailing-whitespace t)
;; This shows off any tabs chars by stretching the cursor
(setq x-stretch-cursor t)

(set-face-attribute 'trailing-whitespace nil :background "gray")
```

