### PR TITLE
simple_zero_to_null.ml: fix a warning about an ignored return value

### DIFF
--- a/demos/simple_zero_to_null.ml
+++ b/demos/simple_zero_to_null.ml
@@ -17,7 +17,7 @@ let null_transfo file =
   let (ast2, _stat) = Parse_c.parse_c_and_cpp file in
   let ast = Parse_c.program_of_program2 ast2 in
 
-  Type_annoter_c.annotate_program !Type_annoter_c.initial_env ast;
+  ignore (Type_annoter_c.annotate_program !Type_annoter_c.initial_env ast);
 
   let null_addon =
     Ast_cocci.ExpressionTag


### PR DESCRIPTION
This is a fairly trivial warning, but there's little reason to leave it in place since it's so easy to fix.