### PR TITLE
Replace "+>" with "|>", and remove redefinitions of "|>"

### DIFF
--- a/commons/common.ml
+++ b/commons/common.ml
@@ -29,7 +29,8 @@
  * reference.
  *)
 
-let (+>) o f = f o
+(* obsolete, replaced by "|>" in the standard library. *)
+(* let (+>) o f = f o *)
 
 let spf = Printf.sprintf
 
@@ -102,7 +103,7 @@ let (lines: string -> string list) = fun s ->
     | x::xs ->
         x::lines_aux xs
   in
-  Str.split_delim (Str.regexp "\n") s +> lines_aux
+  Str.split_delim (Str.regexp "\n") s |> lines_aux
 
 let save_excursion reference newv f =
   let old = !reference in
@@ -364,13 +365,13 @@ let profile_diagnostic () =
   if !profile = ProfNone then "" else
   let xs =
     Hashtbl.fold (fun k v acc -> (k,v)::acc) !_profile_table []
-      +> List.sort (fun (k1, (t1,n1)) (k2, (t2,n2)) -> compare t2 t1)
+      |> List.sort (fun (k1, (t1,n1)) (k2, (t2,n2)) -> compare t2 t1)
     in
     with_open_stringbuf (fun (pr,_) ->
       pr "---------------------";
       pr "profiling result";
       pr "---------------------";
-      xs +> List.iter (fun (k, (t,n)) ->
+      xs |> List.iter (fun (k, (t,n)) ->
         pr (Printf.sprintf "%-40s : %10.3f sec %10d count" k !t !n)
       )
     )
@@ -487,7 +488,7 @@ let usage usage_msg options  =
 
 (* If you don't want the -help and --help that are appended by Arg.align *)
 let arg_align2 xs =
-  Arg.align xs +> List.rev +> drop 2 +> List.rev
+  Arg.align xs |> List.rev |> drop 2 |> List.rev
 
 
 let short_usage usage_msg  ~short_opt =
@@ -498,13 +499,13 @@ let long_usage  usage_msg  ~short_opt ~long_opt  =
   pr "";
   let all_options_with_title =
     (("main options", "", short_opt)::long_opt) in
-  all_options_with_title +> List.iter
+  all_options_with_title |> List.iter
     (fun (title, explanations, xs) ->
       pr title;
       pr_xxxxxxxxxxxxxxxxx();
       if explanations <> ""
       then begin pr explanations; pr "" end;
-      arg_align2 xs +> List.iter (fun (key,action,s) ->
+      arg_align2 xs |> List.iter (fun (key,action,s) ->
         pr ("  " ^ key ^ s)
       );
       pr "";
@@ -544,7 +545,7 @@ type cmdline_actions = action_spec list
 exception WrongNumberOfArguments
 
 let options_of_actions action_ref actions =
-  actions +> List.map (fun (key, doc, _func) ->
+  actions |> List.map (fun (key, doc, _func) ->
     (key, (Arg.Unit (fun () -> action_ref := key)), doc)
   )
 
@@ -553,7 +554,7 @@ let (action_list: cmdline_actions -> Arg.key list) = fun xs ->
 
 let (do_action: Arg.key -> string list (* args *) -> cmdline_actions -> unit) =
   fun key args xs ->
-    let assoc = xs +> List.map (fun (a,b,c) -> (a,c)) in
+    let assoc = xs |> List.map (fun (a,b,c) -> (a,c)) in
     let action_func = List.assoc key assoc in
     action_func args
 
@@ -687,7 +688,7 @@ let rec filter_some = function
   | None :: l -> filter_some l
   | Some e :: l -> e :: filter_some l
 
-let map_filter f xs = xs +> List.map f +> filter_some
+let map_filter f xs = xs |> List.map f |> filter_some
 
 let rec find_some_opt p = function
   | [] -> None
@@ -832,7 +833,7 @@ let cat file =
     then cat_aux (l::acc) ()
     else acc
   in
-  cat_aux [] () +> List.rev +> (fun x -> close_in chan; x)
+  cat_aux [] () |> List.rev |> (fun x -> close_in chan; x)
 
 let read_file file =
   let ic = open_in file  in
@@ -1011,7 +1012,7 @@ let new_temp_file prefix suffix =
 let save_tmp_files = ref false
 let erase_temp_files () =
   if not !save_tmp_files then begin
-    !_temp_files_created +> List.iter (fun s ->
+    !_temp_files_created |> List.iter (fun s ->
       (* pr2 ("erasing: " ^ s); *)
       command2 ("rm -f " ^ s)
     );
@@ -1109,7 +1110,7 @@ let index_list xs =
 let index_list_0 xs = index_list xs
 
 let index_list_1 xs =
-  xs +> index_list +> List.map (fun (x,i) -> x, i+1)
+  xs |> index_list |> List.map (fun (x,i) -> x, i+1)
 
 let sort_prof a b =
   profile_code "Common.sort_by_xxx" (fun () -> List.sort a b)
@@ -1153,11 +1154,11 @@ type ('a, 'b) assoc = ('a * 'b) list
 
 let hash_to_list h =
   Hashtbl.fold (fun k v acc -> (k,v)::acc) h []
-  +> List.sort compare
+  |> List.sort compare
 
 let hash_of_list xs =
   let h = Hashtbl.create 101 in
-  xs +> List.iter (fun (k, v) -> Hashtbl.replace h k v);
+  xs |> List.iter (fun (k, v) -> Hashtbl.replace h k v);
   h
 
 
@@ -1169,21 +1170,21 @@ type 'a hashset = ('a, bool) Hashtbl.t
   (* with sexp *)
 
 let hashset_to_list h =
-  hash_to_list h +> List.map fst
+  hash_to_list h |> List.map fst
 
 let hashset_of_list xs =
-  xs +> List.map (fun x -> x, true) +> hash_of_list
+  xs |> List.map (fun x -> x, true) |> hash_of_list
 
 let hkeys h =
   let hkey = Hashtbl.create 101 in
-  h +> Hashtbl.iter (fun k v -> Hashtbl.replace hkey k true);
+  h |> Hashtbl.iter (fun k v -> Hashtbl.replace hkey k true);
   hashset_to_list hkey
 
 let group_assoc_bykey_eff2 xs =
   let h = Hashtbl.create 101 in
-  xs +> List.iter (fun (k, v) -> Hashtbl.add h k v);
+  xs |> List.iter (fun (k, v) -> Hashtbl.add h k v);
   let keys = hkeys h in
-  keys +> List.map (fun k -> k, Hashtbl.find_all h k)
+  keys |> List.map (fun k -> k, Hashtbl.find_all h k)
 
 let group_assoc_bykey_eff xs =
   profile_code "Common.group_assoc_bykey_eff" (fun () ->
@@ -1262,7 +1263,7 @@ let main_boilerplate f =
        * Common.debugger will be set in main(), so too late, so
        * have to be quicker
        *)
-      if Sys.argv +> Array.to_list +> List.exists (fun x -> x =$= "-debugger")
+      if Sys.argv |> Array.to_list |> List.exists (fun x -> x =$= "-debugger")
       then debugger := true;
 
       finalize          (fun ()->
@@ -1297,7 +1298,7 @@ let grep_dash_v_str =
  "| grep -v /.svn/ | grep -v .git_annot | grep -v .marshall"
 
 let files_of_dir_or_files_no_vcs_nofilter xs =
-  xs +> List.map (fun x ->
+  xs |> List.map (fun x ->
     if is_directory x
     then
       (* todo: should escape x *)
@@ -1312,7 +1313,7 @@ let files_of_dir_or_files_no_vcs_nofilter xs =
                              cmd (String.concat "\n" xs))))
       )
     else [x]
-  ) +> List.concat
+  ) |> List.concat
 
 
 (*****************************************************************************)

--- a/commons/common.mli
+++ b/commons/common.mli
@@ -1,5 +1,7 @@
 
-val (+>) : 'a -> ('a -> 'b) -> 'b
+
+(* obsolete, replaced by "|>" in the standard library. *)
+(* val (+>) : 'a -> ('a -> 'b) -> 'b *)
 
 val (=|=) : int    -> int    -> bool
 val (=<=) : char   -> char   -> bool

--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -31,8 +31,12 @@
  * reference.
  *)
 
-let (+>) o f = f o
-let (|>) o f = f o
+(* obsolete, replaced by "|>" in the standard library. *)
+(* let (+>) o f = f o *)
+
+(* "|>" is now in the standard library. *)
+(* let (|>) o f = f o *)
+
 (*let (++) = (@) *)
 
 exception Timeout
@@ -93,7 +97,7 @@ let rec list_last = function
 
 let (list_of_string: string -> char list) = function
     "" -> []
-  | s -> (enum 0 ((String.length s) - 1) +> List.map (String.get s))
+  | s -> (enum 0 ((String.length s) - 1) |> List.map (String.get s))
 
 let (lines: string -> string list) = fun s ->
   let rec lines_aux = function
@@ -102,7 +106,7 @@ let (lines: string -> string list) = fun s ->
     | x::xs ->
         x::lines_aux xs
   in
-  Str.split_delim (Str.regexp "\n") s +> lines_aux
+  Str.split_delim (Str.regexp "\n") s |> lines_aux
 
 
 let push v l =
@@ -513,9 +517,9 @@ let memory_stat () =
 let timenow () =
   "sys:" ^ (string_of_float (Sys.time ())) ^ " seconds" ^
   ":real:" ^
-    (let tm = Unix.time () +> Unix.gmtime in
-     tm.Unix.tm_min +> string_of_int ^ " min:" ^
-     tm.Unix.tm_sec +> string_of_int ^ ".00 seconds")
+    (let tm = Unix.time () |> Unix.gmtime in
+     (tm.Unix.tm_min |> string_of_int) ^ " min:" ^
+     (tm.Unix.tm_sec |> string_of_int) ^ ".00 seconds")
 
 let _count1 = ref 0
 let _count2 = ref 0
@@ -828,12 +832,12 @@ type timestamp = int
 let string_of_string s = "\"" ^ s "\""
 
 let string_of_list f xs =
-  "[" ^ (xs +> List.map f +> String.concat ";" ) ^ "]"
+  "[" ^ (xs |> List.map f |> String.concat ";" ) ^ "]"
 
 let string_of_unit () = "()"
 
 let string_of_array f xs =
-  "[|" ^ (xs +> Array.to_list +> List.map f +> String.concat ";") ^ "|]"
+  "[|" ^ (xs |> Array.to_list |> List.map f |> String.concat ";") ^ "|]"
 
 let string_of_option f = function
   | None   -> "None "
@@ -949,7 +953,7 @@ let macro_expand s =
 let t = macro_expand "{ x + y | (x,y) <- [(1,1);(2,2);(3,3)] and x>2 and y<3}"
 let x = { x + y | (x,y) <- [(1,1);(2,2);(3,3)] and x > 2 and y < 3}
 let t = macro_expand "{1 .. 10}"
-let x = {1 .. 10} +> List.map (fun i -> i)
+let x = {1 .. 10} |> List.map (fun i -> i)
 let t = macro_expand "[1;2] to append to [2;4]"
 let t = macro_expand "{x = 2; x = 3}"
 
@@ -1013,7 +1017,7 @@ class ['a] shared_variable_hook (x:'a) =
       begin
         data <- x;
         pr "refresh registered";
-        registered +> List.iter (fun f -> f ());
+        registered |> List.iter (fun f -> f ());
       end
     method get = data
     method modify f = self#set (f self#get)
@@ -1045,7 +1049,7 @@ let (add_hook_action: ('a -> unit) ->   ('a -> unit) list ref -> unit) =
 
 let (run_hooks_action: 'a -> ('a -> unit) list ref -> unit) =
  fun obj hooks ->
-  !hooks +> List.iter (fun f -> try f obj with _ -> ())
+  !hooks |> List.iter (fun f -> try f obj with _ -> ())
 
 
 type 'a mylazy = (unit -> 'a)
@@ -1197,7 +1201,7 @@ let myassert cond = if cond then () else failwith "assert error"
  *
  * The need for printf make me force to name stuff :(
  * How avoid ? use 'it' special keyword ?
- * In fact dont have to name it, use +> (fun v -> ...)  so when want
+ * In fact dont have to name it, use |> (fun v -> ...)  so when want
  * erase debug just have to erase one line.
  *)
 let warning s v = (pr2 ("Warning: " ^ s ^ "; value = " ^ (dump v)); v)
@@ -1330,7 +1334,7 @@ let is_lower = cbetween 'a' 'z'
 let is_alpha c = is_upper c || is_lower c
 let is_digit = cbetween '0' '9'
 
-let string_of_chars cs = cs +> List.map (String.make 1) +> String.concat ""
+let string_of_chars cs = cs |> List.map (String.make 1) |> String.concat ""
 
 
 
@@ -1630,7 +1634,7 @@ let rec filter_some = function
   | None :: l -> filter_some l
   | Some e :: l -> e :: filter_some l
 
-let map_filter f xs = xs +> List.map f +> filter_some
+let map_filter f xs = xs |> List.map f |> filter_some
 
 let rec find_some p = function
   | [] -> raise Not_found
@@ -1648,8 +1652,8 @@ let rec find_some_opt p = function
 
 (* same
 let map_find f xs =
-  xs +> List.map f +> List.find (function Some x -> true | None -> false)
-    +> (function Some x -> x | None -> raise Impossible)
+  xs |> List.map f |> List.find (function Some x -> true | None -> false)
+    |> (function Some x -> x | None -> raise Impossible)
 *)
 
 
@@ -1796,7 +1800,7 @@ let (split_list_regexp: string -> string list -> (string * string list) list) =
         else split_lr_aux (heading, x::accu) xs
   in
   split_lr_aux ("__noheading__", []) xs
-  +> (fun xs -> if (List.hd xs) =*= ("__noheading__",[]) then List.tl xs else xs)
+  |> (fun xs -> if (List.hd xs) =*= ("__noheading__",[]) then List.tl xs else xs)
 
 
 
@@ -1863,9 +1867,9 @@ let str_regexp_of_regexp x =
   Str.regexp (regexp_string_of_regexp x)
 
 let compile_regexp_union xs =
-  xs +> List.map (fun x ->
+  xs |> List.map (fun x ->
     regexp_string_of_regexp x
-  ) +> join "\\|" +> Str.regexp
+  ) |> join "\\|" |> Str.regexp
 
 
 (*****************************************************************************)
@@ -2102,8 +2106,8 @@ let dbe_of_filename file =
    *)
   ignore(Filename.chop_extension file);
   Filename.dirname file,
-  Filename.basename file +> fileprefix,
-  Filename.basename file +> filesuffix
+  Filename.basename file |> fileprefix,
+  Filename.basename file |> filesuffix
 
 let filename_of_dbe (dir, base, ext) =
   if ext =$= ""
@@ -2335,22 +2339,22 @@ let week_day_info = [
 ]
 
 let i_to_month_h =
-  month_info +> List.map (fun (i,month,monthstr,mlong,days) -> i, month)
+  month_info |> List.map (fun (i,month,monthstr,mlong,days) -> i, month)
 let s_to_month_h =
-  month_info +> List.map (fun (i,month,monthstr,mlong,days) -> monthstr, month)
+  month_info |> List.map (fun (i,month,monthstr,mlong,days) -> monthstr, month)
 let slong_to_month_h =
-  month_info +> List.map (fun (i,month,monthstr,mlong,days) -> mlong, month)
+  month_info |> List.map (fun (i,month,monthstr,mlong,days) -> mlong, month)
 let month_to_s_h =
-  month_info +> List.map (fun (i,month,monthstr,mlong,days) -> month, monthstr)
+  month_info |> List.map (fun (i,month,monthstr,mlong,days) -> month, monthstr)
 let month_to_i_h =
-  month_info +> List.map (fun (i,month,monthstr,mlong,days) -> month, i)
+  month_info |> List.map (fun (i,month,monthstr,mlong,days) -> month, i)
 
 let i_to_wday_h =
-  week_day_info +> List.map (fun (i,day,dayen,dayfr,daylong) -> i, day)
+  week_day_info |> List.map (fun (i,day,dayen,dayfr,daylong) -> i, day)
 let wday_to_en_h =
-  week_day_info +> List.map (fun (i,day,dayen,dayfr,daylong) -> day, dayen)
+  week_day_info |> List.map (fun (i,day,dayen,dayfr,daylong) -> day, dayen)
 let wday_to_fr_h =
-  week_day_info +> List.map (fun (i,day,dayen,dayfr,daylong) -> day, dayfr)
+  week_day_info |> List.map (fun (i,day,dayen,dayfr,daylong) -> day, dayfr)
 
 let month_of_string s =
   List.assoc s s_to_month_h
@@ -2422,7 +2426,7 @@ let unix_time_of_string s =
 
     let y = s_to_i syear - 1900 in
     let mon =
-      smonth +> month_of_string +> int_of_month +> (fun i -> i -1)
+      smonth |> month_of_string |> int_of_month |> (fun i -> i -1)
     in
 
     let tm = Unix.localtime (Unix.time ()) in
@@ -2485,8 +2489,8 @@ let days_in_week_of_day day =
   let start_d = mday - wday in
   let end_d = mday + (6 - wday) in
 
-  enum start_d end_d +> List.map (fun mday ->
-    Unix.mktime {tm with Unix.tm_mday = mday} +> fst
+  enum start_d end_d |> List.map (fun mday ->
+    Unix.mktime {tm with Unix.tm_mday = mday} |> fst
   )
 
 let first_day_in_week_of_day day =
@@ -2618,13 +2622,13 @@ let unixtime_to_dmy tm =
 
 
 let unixtime_to_floattime tm =
-  Unix.mktime tm +> fst
+  Unix.mktime tm |> fst
 
 let floattime_to_unixtime sec =
   Unix.localtime sec
 
 let floattime_to_dmy sec =
-  sec +> floattime_to_unixtime +> unixtime_to_dmy
+  sec |> floattime_to_unixtime |> unixtime_to_dmy
 
 
 let sec_to_days sec =
@@ -2701,7 +2705,7 @@ let timestamp () =
 
 (* now in prelude:
  * let (list_of_string: string -> char list) = fun s ->
- * (enum 0 ((String.length s) - 1) +> List.map (String.get s))
+ * (enum 0 ((String.length s) - 1) |> List.map (String.get s))
  *)
 
 let _ = assert (list_of_string "abcd" =*= ['a';'b';'c';'d'])
@@ -2728,20 +2732,20 @@ let (lines_with_nl: string -> string list) = fun s ->
         let e = x ^ "\n" in
         e::lines_aux xs
   in
-  (time_func (fun () -> Str.split_delim (Str.regexp "\n") s)) +> lines_aux
+  (time_func (fun () -> Str.split_delim (Str.regexp "\n") s)) |> lines_aux
 
 (* in fact better make it return always complete lines, simplify *)
 (*  Str.split, but lines "\n1\n2\n" dont return the \n and forget the first \n => split_delim better than split *)
-(* +> List.map (fun s -> s ^ "\n") but add an \n even at the end => lines_aux *)
+(* |> List.map (fun s -> s ^ "\n") but add an \n even at the end => lines_aux *)
 (* old: slow
   let chars = list_of_string s in
-  chars +> List.fold_left (fun (acc, lines) char ->
+  chars |> List.fold_left (fun (acc, lines) char ->
     let newacc = acc ^ (String.make 1 char) in
     if char = '\n'
     then ("", newacc::lines)
     else (newacc, lines)
     ) ("", [])
-       +> (fun (s, lines) -> List.rev (s::lines))
+       |> (fun (s, lines) -> List.rev (s::lines))
 *)
 
 (*  CHECK: unlines (lines x) = x *)
@@ -2755,18 +2759,18 @@ let (unwords: string list -> string) = fun s ->
 let (split_space: string -> string list)   = fun s ->
   Str.split (Str.regexp "[ \t\n]+") s
 
-let n_space n = repeat " " n +> join ""
+let n_space n = repeat " " n |> join ""
 
 let indent_string n s =
   let xs = lines s in
   xs
-  +> List.map (fun s -> n_space n ^ s)
-  +> unlines
+  |> List.map (fun s -> n_space n ^ s)
+  |> unlines
 
 
 (* todo opti ? *)
 let nblines s =
-  lines s +> List.length
+  lines s |> List.length
 (*
 let _ = example (nblines "" =|= 0)
 let _ = example (nblines "toto" =|= 1)
@@ -2800,11 +2804,11 @@ let nblines_eff a =
 
 (* could be in h_files-format *)
 let words_of_string_with_newlines s =
-  lines s +> List.map words +> List.flatten +> exclude null_string
+  lines s |> List.map words |> List.flatten |> exclude null_string
 
 let lines_with_nl_either s =
   let xs = Str.full_split (Str.regexp "\n") s in
-  xs +> List.map (function
+  xs |> List.map (function
   | Str.Delim s -> Right ()
   | Str.Text s -> Left s
   )
@@ -2837,10 +2841,10 @@ let cat file =
     then cat_aux (l::acc) ()
     else acc
   in
-  cat_aux [] () +> List.rev +> (fun x -> close_in chan; x)
+  cat_aux [] () |> List.rev |> (fun x -> close_in chan; x)
 
 let cat_array file =
-  (""::cat file) +> Array.of_list
+  (""::cat file) |> Array.of_list
 
 (* Spec for cat_excerpts:
 let cat_excerpts file lines =
@@ -2858,7 +2862,7 @@ let cat_excerpts file lines = Common.with_open_infile file (fun chan ->
     | c::cdr when (c==count) -> aux (l::acc) cdr (count+1)
     | _ -> aux acc lines (count+1)
   in
-  aux [] lines 1 +> List.rev)
+  aux [] lines 1 |> List.rev)
 
 let interpolate str =
   begin
@@ -2936,7 +2940,7 @@ let unix_diff file1 file2 =
 
 let get_mem() =
   cmd_to_list("grep VmData /proc/" ^ string_of_int (Unix.getpid()) ^ "/status")
-  +> join ""
+  |> join ""
 
 (* now in prelude:
  * let command2 s = ignore(Sys.command s)
@@ -2978,7 +2982,7 @@ let command2_y_or_no_exit_if_no cmd =
 
 let command_safe ?(verbose=false) program args =
   let pid = Unix.fork () in
-  let cmd_str = (program::args) +> join " " in
+  let cmd_str = (program::args) |> join " " in
   if pid =|= 0 then begin
     pr2 ("running: " ^ cmd_str);
     Unix.execv program (Array.of_list (program::args))
@@ -3022,7 +3026,7 @@ let filemtime file =
 
 (* opti? use wc -l ? *)
 let nblines_file file =
-  cat file +> List.length
+  cat file |> List.length
 
 let lfile_exists filename =
   try
@@ -3114,8 +3118,8 @@ let capsule_unix f args =
 let (readdir_to_kind_list: string -> Unix.file_kind -> string list) =
  fun path kind ->
   Sys.readdir path
-  +> Array.to_list
-  +> List.filter (fun s ->
+  |> Array.to_list
+  |> List.filter (fun s ->
     try
       let stat = Unix.lstat (path ^ "/" ^  s) in
       stat.Unix.st_kind =*= kind
@@ -3136,8 +3140,8 @@ let (readdir_to_link_list: string -> string list) = fun path ->
 
 let (readdir_to_dir_size_list: string -> (string * int) list) = fun path ->
   Sys.readdir path
-  +> Array.to_list
-  +> map_filter (fun s ->
+  |> Array.to_list
+  |> map_filter (fun s ->
     let stat = Unix.lstat (path ^ "/" ^  s) in
     if stat.Unix.st_kind =*= Unix.S_DIR
     then Some (s, stat.Unix.st_size)
@@ -3197,7 +3201,7 @@ let cache_computation_robust2
 
   let dependencies =
     (* could do md5sum too *)
-    ((file::need_no_changed_files) +> List.map (fun f -> f, filemtime f),
+    ((file::need_no_changed_files) |> List.map (fun f -> f, filemtime f),
     need_no_changed_variables)
   in
 
@@ -3239,11 +3243,11 @@ let dirs_of_dir dir =
 (* update: have added the -type f, so normally need less the sanity_check_xxx
  * function below *)
 let files_of_dir_or_files ext xs =
-  xs +> List.map (fun x ->
+  xs |> List.map (fun x ->
     if is_directory x
     then cmd_to_list ("find " ^ x  ^" -noleaf -type f -name \"*." ^ext^"\"")
     else [x]
-  ) +> List.concat
+  ) |> List.concat
 
 
 let grep_dash_v_str =
@@ -3257,7 +3261,7 @@ let arg_symlink () =
 
 
 let files_of_dir_or_files_no_vcs ext xs =
-  xs +> List.map (fun x ->
+  xs |> List.map (fun x ->
     if is_directory x
     then
       cmd_to_list
@@ -3265,36 +3269,36 @@ let files_of_dir_or_files_no_vcs ext xs =
          grep_dash_v_str
         )
     else [x]
-  ) +> List.concat
+  ) |> List.concat
 
 
 let files_of_dir_or_files_no_vcs_nofilter xs =
-  xs +> List.map (fun x ->
+  xs |> List.map (fun x ->
     if is_directory x
     then
       cmd_to_list_and_status
         ("find "^arg_symlink()^x^" -noleaf -type f " ^
             grep_dash_v_str
-        ) +> fst
+        ) |> fst
     else [x]
-  ) +> List.concat
+  ) |> List.concat
 
 
 let files_of_dir_or_files_no_vcs_post_filter regex xs =
-  xs +> List.map (fun x ->
+  xs |> List.map (fun x ->
     if is_directory x
     then
       cmd_to_list
         ("find "^arg_symlink()^x^
          " -noleaf -type f " ^ grep_dash_v_str
         )
-        +> List.filter (fun s -> s =~ regex)
+        |> List.filter (fun s -> s =~ regex)
     else [x]
-  ) +> List.concat
+  ) |> List.concat
 
 
 let sanity_check_files_and_adjust ext files =
-  let files = files +> List.filter (fun file ->
+  let files = files |> List.filter (fun file ->
     if not (file =~ (".*\\."^ext))
     then begin
       pr2 ("warning: seems not a ."^ext^" file");
@@ -3430,7 +3434,7 @@ let exn_to_real_unixexit f =
 
 let uncat xs file =
   Common.with_open_outfile file (fun (pr,_chan) ->
-    xs +> List.iter (fun s -> pr s; pr "\n");
+    xs |> List.iter (fun s -> pr s; pr "\n");
 
   )
 
@@ -3473,7 +3477,7 @@ let rec unzip zs =
 
 
 let map_withkeep f xs =
-  xs +> List.map (fun x -> f x, x)
+  xs |> List.map (fun x -> f x, x)
 
 (* now in prelude
  * let rec take n xs =
@@ -3558,8 +3562,8 @@ let rec group_by_mapped_key fkey l =
 
 let group_and_count xs =
   xs
-  +> groupBy (=*=)
-  +> List.map (fun xs ->
+  |> groupBy (=*=)
+  |> List.map (fun xs ->
     match xs with
     | x::rest -> x, List.length xs
     | [] -> raise Common.Impossible
@@ -3603,7 +3607,7 @@ let (group_by_pre: ('a -> bool) -> 'a list -> 'a list * ('a * 'a list) list)=
     let xs' = List.rev xs in
     let (ys, unclassified) = group_by_post f xs' in
     List.rev unclassified,
-    ys +> List.rev +> List.map (fun (xs, x) -> x, List.rev xs )
+    ys |> List.rev |> List.map (fun (xs, x) -> x, List.rev xs )
 
 let _ = assert
   (group_by_pre (fun x -> x =|= 3) [1;1;3;2;3;4;5;3;6;6;6] =*=
@@ -3677,12 +3681,12 @@ let index_list_and_total xs =
   let total = List.length xs in
   if null xs then [] (* enum 0 (-1) generate an exception *)
   else zip xs (enum 0 ((List.length xs) -1))
-    +> List.map (fun (a,b) -> (a,b,total))
+    |> List.map (fun (a,b) -> (a,b,total))
 
 let index_list_0 xs = index_list xs
 
 let index_list_1 xs =
-  xs +> index_list +> List.map (fun (x,i) -> x, i+1)
+  xs |> index_list |> List.map (fun (x,i) -> x, i+1)
 
 let avg_list xs =
   let sum = sum_int xs in
@@ -4074,7 +4078,7 @@ let rec insert_elem_pos (e, pos) xs =
 
 let rec uncons_permut xs =
   let indexed = index_list xs in
-  indexed +> List.map (fun (x, pos) -> (x, pos),  remove_elem_pos pos xs)
+  indexed |> List.map (fun (x, pos) -> (x, pos),  remove_elem_pos pos xs)
 let _ =
   assert
     (uncons_permut ['a';'b';'c'] =*=
@@ -4085,7 +4089,7 @@ let _ =
 
 let rec uncons_permut_lazy xs =
   let indexed = index_list xs in
-  indexed +> List.map (fun (x, pos) ->
+  indexed |> List.map (fun (x, pos) ->
     (x, pos),
     lazy (remove_elem_pos pos xs)
   )
@@ -4126,7 +4130,7 @@ let pack_sorted same xs =
     |	((cur,rest), y::ys) ->
           if same (List.hd cur) y then pack_s_aux (y::cur, rest) ys
           else pack_s_aux ([y], cur::rest) ys
-  in pack_s_aux ([List.hd xs],[]) (List.tl xs) +> List.rev
+  in pack_s_aux ([List.hd xs],[]) (List.tl xs) |> List.rev
 let test_pack = pack_sorted (=*=) [1;1;1;2;2;3;4]
 
 
@@ -4154,8 +4158,8 @@ let rec sorted_keep_best f = function
 
 
 let (cartesian_product: 'a list -> 'b list -> ('a * 'b) list) = fun xs ys ->
-  xs +> List.map (fun x ->  ys +> List.map (fun y -> (x,y)))
-     +> List.flatten
+  xs |> List.map (fun x ->  ys |> List.map (fun y -> (x,y)))
+     |> List.flatten
 
 let _ = assert_equal
     (cartesian_product [1;2] ["3";"4";"5"])
@@ -4294,7 +4298,7 @@ let array_find_index_typed f a =
 type 'a matrix = 'a array array
 
 let map_matrix f mat =
-  mat +> Array.map (fun arr -> arr +> Array.map f)
+  mat |> Array.map (fun arr -> arr |> Array.map f)
 
 let (make_matrix_init:
         nrow:int -> ncolumn:int -> (int -> int -> 'a) -> 'a matrix) =
@@ -4324,19 +4328,19 @@ let invariant_matrix m =
   raise Common.Todo
 
 let (rows_of_matrix: 'a matrix -> 'a list list) = fun m ->
-  Array.to_list m +> List.map Array.to_list
+  Array.to_list m |> List.map Array.to_list
 
 let (columns_of_matrix: 'a matrix -> 'a list list) = fun m ->
   let nbcols = nb_columns_matrix m in
   let nbrows = nb_rows_matrix m in
-  (enum 0 (nbcols -1)) +> List.map (fun j ->
-    (enum 0 (nbrows -1)) +> List.map (fun i ->
+  (enum 0 (nbcols -1)) |> List.map (fun j ->
+    (enum 0 (nbrows -1)) |> List.map (fun i ->
       m.(i).(j)
     ))
 
 
 let all_elems_matrix_by_row m =
-  rows_of_matrix m +> List.flatten
+  rows_of_matrix m |> List.flatten
 
 
 let ex_matrix1 =
@@ -4403,7 +4407,7 @@ let is_set xs =
 
 let (single_set: 'a -> 'a set) = fun x -> insert_set x empty_set
 let (set: 'a list -> 'a set) = fun xs ->
-  xs +> List.fold_left (flip insert_set) empty_set +> List.sort compare
+  xs |> List.fold_left (flip insert_set) empty_set |> List.sort compare
 
 let (exists_set: ('a -> bool) -> 'a set -> bool) = List.exists
 let (forall_set: ('a -> bool) -> 'a set -> bool) = List.for_all
@@ -4419,21 +4423,21 @@ let iter_set = List.iter
 let (top_set: 'a set -> 'a) = List.hd
 
 let (inter_set: 'a set -> 'a set -> 'a set) = fun s1 s2 ->
-  s1 +> fold_set (fun acc x -> if member_set x s2 then insert_set x acc else acc) empty_set
+  s1 |> fold_set (fun acc x -> if member_set x s2 then insert_set x acc else acc) empty_set
 let (union_set: 'a set -> 'a set -> 'a set) = fun s1 s2 ->
-  s2 +> fold_set (fun acc x -> if member_set x s1 then acc else insert_set x acc) s1
+  s2 |> fold_set (fun acc x -> if member_set x s1 then acc else insert_set x acc) s1
 let (minus_set: 'a set -> 'a set -> 'a set) = fun s1 s2 ->
-  s1 +> filter_set  (fun x -> not (member_set x s2))
+  s1 |> filter_set  (fun x -> not (member_set x s2))
 
 
 let union_all l = List.fold_left union_set [] l
 
-let big_union_set f xs = xs +> map_set f +> fold_set union_set empty_set
+let big_union_set f xs = xs |> map_set f |> fold_set union_set empty_set
 
 let (card_set: 'a set -> int) = List.length
 
 let (include_set: 'a set -> 'a set -> bool) = fun s1 s2 ->
-  (s1 +> forall_set (fun p -> member_set p s2))
+  (s1 |> forall_set (fun p -> member_set p s2))
 
 let equal_set s1 s2 = include_set s1 s2 && include_set s2 s1
 
@@ -4527,7 +4531,7 @@ module StringSetOrig = Set.Make(struct type t = string let compare = compare end
 module StringSet = struct
   include StringSetOrig
   let of_list xs =
-    xs +> List.fold_left (fun acc e ->
+    xs |> List.fold_left (fun acc e ->
       StringSetOrig.add e acc
     ) StringSetOrig.empty
   let to_list t =
@@ -4543,7 +4547,7 @@ type ('a,'b) assoc  = ('a * 'b) list
 
 
 let (assoc_to_function: ('a, 'b) assoc -> ('a -> 'b)) = fun xs ->
-  xs +> List.fold_left (fun acc (k, v) ->
+  xs |> List.fold_left (fun acc (k, v) ->
     (fun k' ->
       if k =*= k' then v else acc k'
     )) (fun k -> failwith "no key in this assoc")
@@ -4564,14 +4568,14 @@ let keys xs = List.map fst xs
 let lookup = assoc
 
 (* assert unique key ?*)
-let del_assoc key xs = xs +> List.filter (fun (k,v) -> k <> key)
+let del_assoc key xs = xs |> List.filter (fun (k,v) -> k <> key)
 let replace_assoc (key, v) xs = insert_assoc (key, v) (del_assoc key xs)
 
 let apply_assoc key f xs =
   let old = assoc key xs in
   replace_assoc (key, f old) xs
 
-let big_union_assoc f xs = xs +> map_assoc f +> fold_assoc union_set empty_set
+let big_union_assoc f xs = xs |> map_assoc f |> fold_assoc union_set empty_set
 
 (* todo: pb normally can suppr fun l -> .... l but if do that, then strange type _a
  => assoc_map is strange too => equal dont work
@@ -4649,7 +4653,7 @@ let hremove k h = Hashtbl.remove h k
 
 let hash_to_list h =
   Hashtbl.fold (fun k v acc -> (k,v)::acc) h []
-  +> List.sort compare
+  |> List.sort compare
 
 let hash_to_list_unsorted h =
   Hashtbl.fold (fun k v acc -> (k,v)::acc) h []
@@ -4658,7 +4662,7 @@ let hash_of_list xs =
   let h = Hashtbl.create 101 in
   begin
     (* replace or add? depends the semantic of hashtbl you want *)
-    xs +> List.iter (fun (k, v) -> Hashtbl.replace h k v);
+    xs |> List.iter (fun (k, v) -> Hashtbl.replace h k v);
     h
   end
 
@@ -4692,7 +4696,7 @@ let hfind_option key h =
 
 let count_elements_sorted_highfirst xs =
   let h = Hashtbl.create 101 in
-  xs +> List.iter (fun e ->
+  xs |> List.iter (fun e ->
     hupdate_default e (fun old -> old + 1) (fun () -> 0) h
   );
   let xs = hash_to_list h in
@@ -4726,20 +4730,20 @@ let hash_hashset_add k e h =
       end
 
 let hashset_to_set baseset h =
- h +> hash_to_list +> List.map fst +> (fun xs -> baseset#fromlist xs)
+ h |> hash_to_list |> List.map fst |> (fun xs -> baseset#fromlist xs)
 
-let hashset_to_list h = hash_to_list h +> List.map fst
+let hashset_to_list h = hash_to_list h |> List.map fst
 
 let hashset_of_list xs =
-  xs +> List.map (fun x -> x, true) +> hash_of_list
+  xs |> List.map (fun x -> x, true) |> hash_of_list
 
 let hashset_union h1 h2 =
-  h2 +> Hashtbl.iter (fun k _bool ->
+  h2 |> Hashtbl.iter (fun k _bool ->
     Hashtbl.replace h1 k true
   )
 
 let hashset_inter h1 h2 =
-  h1 +> Hashtbl.iter (fun k _bool ->
+  h1 |> Hashtbl.iter (fun k _bool ->
     if not (Hashtbl.mem h2 k)
     then Hashtbl.remove h1 k
   )
@@ -4747,20 +4751,20 @@ let hashset_inter h1 h2 =
 
 let hkeys h =
   let hkey = Hashtbl.create 101 in
-  h +> Hashtbl.iter (fun k v -> Hashtbl.replace hkey k true);
+  h |> Hashtbl.iter (fun k v -> Hashtbl.replace hkey k true);
   hashset_to_list hkey
 
 let hunion h1 h2 =
-  h2 +> Hashtbl.iter (fun k v ->
+  h2 |> Hashtbl.iter (fun k v ->
     Hashtbl.add h1 k v
   )
 
 
 let group_assoc_bykey_eff2 xs =
   let h = Hashtbl.create 101 in
-  xs +> List.iter (fun (k, v) -> Hashtbl.add h k v);
+  xs |> List.iter (fun (k, v) -> Hashtbl.add h k v);
   let keys = hkeys h in
-  keys +> List.map (fun k -> k, Hashtbl.find_all h k)
+  keys |> List.map (fun k -> k, Hashtbl.find_all h k)
 
 let group_assoc_bykey_eff xs =
   Common.profile_code "Common.group_assoc_bykey_eff" (fun () ->
@@ -4768,17 +4772,17 @@ let group_assoc_bykey_eff xs =
 
 
 let test_group_assoc () =
-  let xs = enum 0 10000 +> List.map (fun i -> i_to_s i, i) in
+  let xs = enum 0 10000 |> List.map (fun i -> i_to_s i, i) in
   let xs = ("0", 2)::xs in
-(*    let _ys = xs +> Common.groupBy (fun (a,resa) (b,resb) -> a =$= b)  *)
-  let ys = xs +> group_assoc_bykey_eff
+(*    let _ys = xs |> Common.groupBy (fun (a,resa) (b,resb) -> a =$= b)  *)
+  let ys = xs |> group_assoc_bykey_eff
   in
   pr2_gen ys
 
 
 let uniq_eff xs =
   let h = Hashtbl.create 101 in
-  xs +> List.iter (fun k ->
+  xs |> List.iter (fun k ->
     Hashtbl.replace h k true
   );
   hkeys h
@@ -4786,8 +4790,8 @@ let uniq_eff xs =
 let big_union_eff xxs =
   let h = Hashtbl.create 101 in
 
-  xxs +> List.iter (fun xs ->
-    xs +> List.iter (fun k ->
+  xxs |> List.iter (fun xs ->
+    xs |> List.iter (fun k ->
     Hashtbl.replace h k true
   );
   );
@@ -4813,12 +4817,12 @@ let diff_set_eff xs1 xs2 =
   let honly_in_h1 = Hashtbl.create 101 in
   let honly_in_h2 = Hashtbl.create 101 in
 
-  h1 +> Hashtbl.iter (fun k _ ->
+  h1 |> Hashtbl.iter (fun k _ ->
     if Hashtbl.mem h2 k
     then Hashtbl.replace hcommon k true
     else Hashtbl.add honly_in_h1 k true
   );
-  h2 +> Hashtbl.iter (fun k _ ->
+  h2 |> Hashtbl.iter (fun k _ ->
     if Hashtbl.mem h1 k
     then Hashtbl.replace hcommon k true
     else Hashtbl.add honly_in_h2 k true
@@ -4949,7 +4953,7 @@ let rec (tree2_iter: ('a -> unit) -> 'a tree2 -> unit) = fun f tree ->
   match tree with
   | Tree (node, xs) ->
       f node;
-      xs +> List.iter (tree2_iter f)
+      xs |> List.iter (tree2_iter f)
 
 
 type ('a, 'b) tree =
@@ -4961,7 +4965,7 @@ let rec map_tree ~fnode ~fleaf tree  =
   match tree with
   | Leaf x -> Leaf (fleaf x)
   | Node (x, xs) ->
-      Node (fnode x, xs +> List.map (map_tree ~fnode ~fleaf))
+      Node (fnode x, xs |> List.map (map_tree ~fnode ~fleaf))
 
 
 (*****************************************************************************)
@@ -4989,13 +4993,13 @@ let rec (treeref_node_iter:
 (*  | LeafRef _ -> ()*)
   | NodeRef (n, xs) ->
       f (n, xs);
-      !xs +> List.iter (treeref_node_iter f)
+      !xs |> List.iter (treeref_node_iter f)
 
 
 let find_treeref f tree =
   let res = ref [] in
 
-  tree +> treeref_node_iter (fun (n, xs) ->
+  tree |> treeref_node_iter (fun (n, xs) ->
     if f (n,xs)
     then push (n, xs) res;
   );
@@ -5015,7 +5019,7 @@ let rec (treeref_node_iter_with_parents:
 (*    | LeafRef _ -> ()*)
     | NodeRef (n, xs) ->
         f (n, xs) acc ;
-        !xs +> List.iter (aux (n::acc))
+        !xs |> List.iter (aux (n::acc))
   in
   aux [] tree
 
@@ -5044,13 +5048,13 @@ let rec (treeref_node_iter2:
   | LeafRef2 _ -> ()
   | NodeRef2 (n, xs) ->
       f (n, xs);
-      !xs +> List.iter (treeref_node_iter2 f)
+      !xs |> List.iter (treeref_node_iter2 f)
 
 
 let find_treeref2 f tree =
   let res = ref [] in
 
-  tree +> treeref_node_iter2 (fun (n, xs) ->
+  tree |> treeref_node_iter2 (fun (n, xs) ->
     if f (n,xs)
     then push (n, xs) res;
   );
@@ -5071,7 +5075,7 @@ let rec (treeref_node_iter_with_parents2:
     | LeafRef2 _ -> ()
     | NodeRef2 (n, xs) ->
         f (n, xs) acc ;
-        !xs +> List.iter (aux (n::acc))
+        !xs |> List.iter (aux (n::acc))
   in
   aux [] tree
 
@@ -5090,7 +5094,7 @@ let rec (treeref_node_iter_with_parents2:
 let find_treeref_with_parents_some f tree =
   let res = ref [] in
 
-  tree +> treeref_node_iter_with_parents (fun (n, xs) parents ->
+  tree |> treeref_node_iter_with_parents (fun (n, xs) parents ->
     match f (n,xs) parents with
     | Some v -> push v res;
     | None -> ()
@@ -5103,7 +5107,7 @@ let find_treeref_with_parents_some f tree =
 let find_multi_treeref_with_parents_some f tree =
   let res = ref [] in
 
-  tree +> treeref_node_iter_with_parents (fun (n, xs) parents ->
+  tree |> treeref_node_iter_with_parents (fun (n, xs) parents ->
     match f (n,xs) parents with
     | Some v -> push v res;
     | None -> ()
@@ -5134,19 +5138,19 @@ let (del_node: 'a -> 'a graph -> 'a graph) = fun node (nodes, arcs) ->
   (nodes $-$ set [node], arcs)
 (* could do more job:
   let _ = assert (successors node (nodes, arcs) = empty) in
-   +> List.filter (fun (src, dst) -> dst != node))
+   |> List.filter (fun (src, dst) -> dst != node))
 *)
 let (add_arc: ('a * 'a) -> 'a graph -> 'a graph) = fun arc (nodes, arcs) ->
   (nodes, set [arc] $+$ arcs)
 
 let (del_arc: ('a * 'a) -> 'a graph -> 'a graph) = fun arc (nodes, arcs) ->
-  (nodes, arcs +> List.filter (fun a -> not (arc =*= a)))
+  (nodes, arcs |> List.filter (fun a -> not (arc =*= a)))
 
 let (successors: 'a -> 'a graph -> 'a set) = fun x (nodes, arcs) ->
-  arcs +> List.filter (fun (src, dst) -> src =*= x) +> List.map snd
+  arcs |> List.filter (fun (src, dst) -> src =*= x) |> List.map snd
 
 let (predecessors: 'a -> 'a graph -> 'a set) = fun x (nodes, arcs) ->
-  arcs +> List.filter (fun (src, dst) -> dst =*= x) +> List.map fst
+  arcs |> List.filter (fun (src, dst) -> dst =*= x) |> List.map fst
 
 let (nodes: 'a graph -> 'a set) = fun (nodes, arcs) -> nodes
 
@@ -5156,8 +5160,8 @@ let rec (fold_upward: ('b -> 'a -> 'b) -> 'a set -> 'b -> 'a graph  -> 'b) =
   match xs with
   | [] -> acc
   | x::xs -> (f acc x)
-        +> (fun newacc -> fold_upward f (graph +> predecessors x) newacc graph)
-        +> (fun newacc -> fold_upward f xs newacc graph)
+        |> (fun newacc -> fold_upward f (graph |> predecessors x) newacc graph)
+        |> (fun newacc -> fold_upward f xs newacc graph)
    (* TODO avoid already visited *)
 
 let empty_graph = ([], [])
@@ -5279,7 +5283,7 @@ let iter = List.iter
 let find = List.find
 let exists = List.exists
 let forall = List.for_all
-let big_union f xs = xs +> map f +> fold union_set empty_set
+let big_union f xs = xs |> map f |> fold union_set empty_set
 (* let empty = [] *)
 let empty_list = []
 let sort xs = List.sort Pervasives.compare xs
@@ -5366,7 +5370,7 @@ let (diff: (int -> int -> diff -> unit)-> (string list * string list) -> unit)=
     let res = cat fileresult in
     let a = ref 0 in
     let b = ref 0 in
-    res +> List.iter (fun s ->
+    res |> List.iter (fun s ->
       match s with
       | ("" | " ") -> f !a !b Match; incr a; incr b;
       | ">" -> f !a !b BnotinA; incr b;
@@ -5395,7 +5399,7 @@ let (diff2: (int -> int -> diff -> unit) -> (string * string) -> unit) =
     let res = cat "/tmp/diffresult" in
     let a = ref 0 in
     let b = ref 0 in
-    res +> List.iter (fun s ->
+    res |> List.iter (fun s ->
       match s with
       | "(" -> f !a !b Match; incr a; incr b;
       | ">" -> f !a !b BnotinA; incr b;
@@ -5411,7 +5415,7 @@ let (diff2: (int -> int -> diff -> unit) -> (string * string) -> unit) =
 
 (* src: coccinelle *)
 let contain_any_token_with_egrep tokens file =
-  let tokens = tokens +> List.map (fun s ->
+  let tokens = tokens |> List.map (fun s ->
     match () with
     | _ when s =~ "^[A-Za-z_][A-Za-z_0-9]*$" ->
         "\\b" ^ s ^ "\\b"
@@ -5519,12 +5523,12 @@ let regression_testing_vs newscore bestscore =
   let newbestscore = empty_score () in
 
   let allres =
-    (hash_to_list newscore +> List.map fst)
+    (hash_to_list newscore |> List.map fst)
       $+$
-    (hash_to_list bestscore +> List.map fst)
+    (hash_to_list bestscore |> List.map fst)
   in
   begin
-    allres +> List.iter (fun res ->
+    allres |> List.iter (fun res ->
       match
         optionise (fun () -> Hashtbl.find newscore res),
         optionise (fun () -> Hashtbl.find bestscore res)
@@ -5584,9 +5588,9 @@ let string_of_score_result v =
   | Pb s -> "Pb: " ^ s
 
 let total_scores score =
-  let total = hash_to_list score +> List.length in
-  let good  = hash_to_list score +> List.filter
-    (fun (s, v) -> v =*= Ok) +> List.length in
+  let total = hash_to_list score |> List.length in
+  let good  = hash_to_list score |> List.filter
+    (fun (s, v) -> v =*= Ok) |> List.length in
   good, total
 
 
@@ -5598,7 +5602,7 @@ let print_total_score score =
   pr2 (Printf.sprintf "good = %d/%d" good total)
 
 let print_score score =
-  score +> hash_to_list +> List.iter (fun (k, v) ->
+  score |> hash_to_list |> List.iter (fun (k, v) ->
     pr2 (Printf.sprintf "%s --> %s" k (string_of_score_result v))
   );
   print_total_score score;
@@ -5697,7 +5701,7 @@ let new_scope_h scoped_env =
   scoped_env := {!scoped_env with scoped_list = []::!scoped_env.scoped_list}
 let del_scope_h scoped_env =
   begin
-    List.hd !scoped_env.scoped_list +> List.iter (fun (k, v) ->
+    List.hd !scoped_env.scoped_list |> List.iter (fun (k, v) ->
       Hashtbl.remove !scoped_env.scoped_h k
     );
     scoped_env := {!scoped_env with scoped_list =
@@ -5813,7 +5817,7 @@ let random_subset_of_list num xs =
       decr cnt;
     end
   done;
-  let objs = hash_to_list h +> List.map fst in
+  let objs = hash_to_list h |> List.map fst in
   objs
 (*x: common.ml *)
 (*###########################################################################*)
@@ -5911,8 +5915,8 @@ let cmdline_actions () =
 
 (* Infix trick, seen in jane street lib and harrop's code, and maybe in GMP *)
 module Infix = struct
-  let (+>) = (+>)
-  let (|>) = (|>)
+  (* let (+>) = (+>) *)
+  (* let (|>) = (|>) *)
   let (==~) = (==~)
   let (=~) = (=~)
 end
@@ -5975,13 +5979,13 @@ let format_to_string f =
 
 (* todo? vs common_prefix_of_files_or_dirs? *)
 let find_common_root files =
-  let dirs_part = files +> List.map fst in
+  let dirs_part = files |> List.map fst in
 
   let rec aux current_candidate xs =
     try
-      let topsubdirs = xs +> List.map List.hd +> uniq_eff in
+      let topsubdirs = xs |> List.map List.hd |> uniq_eff in
       (match topsubdirs with
-      | [x] -> aux (x::current_candidate)        (xs +> List.map List.tl)
+      | [x] -> aux (x::current_candidate)        (xs |> List.map List.tl)
       | _ -> List.rev current_candidate
       )
     with  _ -> List.rev current_candidate
@@ -6025,7 +6029,7 @@ let inits_of_absolute_dir dir =
     | ["."] -> []
     | _ -> dirs
   in
-  inits dirs +> List.map (fun xs ->
+  inits dirs |> List.map (fun xs ->
     "/" ^ join "/" xs
   )
 
@@ -6039,7 +6043,7 @@ let inits_of_relative_dir dir =
     | ["."] -> []
     | _ -> dirs
   in
-  inits dirs +> List.tl +> List.map (fun xs ->
+  inits dirs |> List.tl |> List.map (fun xs ->
    join "/" xs
   )
 
@@ -6059,7 +6063,7 @@ let (tree_of_files: filename list -> (string, (string * filename)) tree) =
   let files_fullpath = files in
 
   (* extract dirs and file from file, e.g. ["home";"pad"], "__flib.php", path *)
-  let files = files +> List.map dirs_and_base_of_file in
+  let files = files |> List.map dirs_and_base_of_file in
 
 
   (* find root, eg ["home";"pad"] *)
@@ -6068,7 +6072,7 @@ let (tree_of_files: filename list -> (string, (string * filename)) tree) =
   let files = zip files files_fullpath in
 
   (* remove the root part *)
-  let files = files +> List.map (fun ((dirs, base), path) ->
+  let files = files |> List.map (fun ((dirs, base), path) ->
     let n = List.length root in
     let (root', rest) =
       take n dirs,
@@ -6082,10 +6086,10 @@ let (tree_of_files: filename list -> (string, (string * filename)) tree) =
   (* now ready to build the tree recursively *)
   let rec aux (xs: ((string list * string) * filename) list) =
     let files_here, rest =
-      xs +> List.partition (fun ((dirs, base), _) -> null dirs)
+      xs |> List.partition (fun ((dirs, base), _) -> null dirs)
     in
     let groups =
-      rest +> group_by_mapped_key (fun ((dirs, base),_) ->
+      rest |> group_by_mapped_key (fun ((dirs, base),_) ->
         (* would be a file if null dirs *)
         assert(not (null dirs));
         List.hd dirs
@@ -6093,15 +6097,15 @@ let (tree_of_files: filename list -> (string, (string * filename)) tree) =
 
 
     let nodes =
-      groups +> List.map (fun (k, xs) ->
-        let xs' = xs +> List.map (fun ((dirs, base), path) ->
+      groups |> List.map (fun (k, xs) ->
+        let xs' = xs |> List.map (fun ((dirs, base), path) ->
           (List.tl dirs, base), path
         )
         in
         Node (k, aux xs')
       )
     in
-    let leaves = files_here +> List.map (fun ((_dir, base), path) ->
+    let leaves = files_here |> List.map (fun ((_dir, base), path) ->
       Leaf (base, path)
     ) in
     nodes @ leaves
@@ -6112,13 +6116,13 @@ let (tree_of_files: filename list -> (string, (string * filename)) tree) =
 
 (* finding the common root *)
 let common_prefix_of_files_or_dirs2 xs =
-  let xs = xs +> List.map relative_to_absolute in
+  let xs = xs |> List.map relative_to_absolute in
   match xs with
   | [] -> failwith "common_prefix_of_files_or_dirs: empty list"
   | [x] -> x
   | y::ys ->
       (* todo: work when dirs ?*)
-      let xs = xs +> List.map dirs_and_base_of_file in
+      let xs = xs |> List.map dirs_and_base_of_file in
       let dirs = find_common_root xs in
       "/" ^ join "/" dirs
 
@@ -6153,9 +6157,9 @@ let (generic_print: 'a -> string -> string) = fun v typ ->
      " in v;;' " ^
      " | calc.top > /tmp/result_generic_print");
    cat "/tmp/result_generic_print"
-   +> drop_while (fun e -> not (e =~ "^#.*")) +> tail
-   +> unlines
-   +> (fun s ->
+   |> drop_while (fun e -> not (e =~ "^#.*")) |> tail
+   |> unlines
+   |> (fun s ->
        if (s =~ ".*= \\(.+\\)")
        then matched1 s
        else "error in generic_print, not good format:" ^ s)

--- a/commons/common2.mli
+++ b/commons/common2.mli
@@ -78,8 +78,8 @@ end
 (* Same spirit. Trick found in Jane Street core lib, but originated somewhere
  * else I think: the ability to open nested modules. *)
 module Infix : sig
-  val ( +> ) : 'a -> ('a -> 'b) -> 'b
-  val ( |> ) : 'a -> ('a -> 'b) -> 'b
+  (* val ( +> ) : 'a -> ('a -> 'b) -> 'b *)
+  (* val ( |> ) : 'a -> ('a -> 'b) -> 'b *)
   val ( =~ ) : string -> string -> bool
   val ( ==~ ) : string -> Str.regexp -> bool
 end
@@ -353,8 +353,12 @@ val macro_expand : string -> unit
 (* Composition/Control *)
 (*****************************************************************************)
 
-val ( +> ) : 'a -> ('a -> 'b) -> 'b
-val ( |> ) : 'a -> ('a -> 'b) -> 'b
+(* obsolete, replaced by "|>" in the standard library. *)
+(* val ( +> ) : 'a -> ('a -> 'b) -> 'b *)
+
+(* obsolete, "|>" is in the standard library. *)
+(* val ( |> ) : 'a -> ('a -> 'b) -> 'b *)
+
 val ( +!> ) : 'a ref -> ('a -> 'a) -> unit
 val ( $ ) : ('a -> 'b) -> ('b -> 'c) -> 'a -> 'c
 

--- a/commons/ocaml.ml
+++ b/commons/ocaml.ml
@@ -312,7 +312,7 @@ let option_ofv a__of_sexp sexp = match sexp with
 (* Format pretty printers *)
 (*****************************************************************************)
 let add_sep xs =
-  xs +> List.map (fun x -> Right x) +> Common2.join_gen (Left ())
+  xs |> List.map (fun x -> Right x) |> Common2.join_gen (Left ())
 
 (*
  * OCaml value pretty printer. A similar functionnality is provided by
@@ -351,14 +351,14 @@ let string_of_v v =
       | VInt i -> ppf "%d" i
       | VTuple xs ->
           ppf "(@[";
-              xs +> add_sep +> List.iter (function
+              xs |> add_sep |> List.iter (function
               | Left _ -> ppf ",@ ";
               | Right v -> aux v
               );
           ppf "@])";
       | VDict xs ->
           ppf "{@[";
-          xs +> List.iter (fun (s, v) ->
+          xs |> List.iter (fun (s, v) ->
             (* less: could open a box there too? *)
             ppf "@,%s=" s;
             aux v;
@@ -371,7 +371,7 @@ let string_of_v v =
           | [] -> ppf "%s" s
           | y::ys ->
               ppf "@[<hov 2>%s(@," s;
-              xs +> add_sep +> List.iter (function
+              xs |> add_sep |> List.iter (function
               | Left _ -> ppf ",@ ";
               | Right v -> aux v
               );
@@ -385,7 +385,7 @@ let string_of_v v =
       | VRef v -> ppf "Ref(@["; aux v; ppf "@])";
       | VList xs ->
           ppf "[@[<hov>";
-          xs +> add_sep +> List.iter (function
+          xs |> add_sep |> List.iter (function
           | Left _ -> ppf ";@ ";
           | Right v -> aux v
           );

--- a/commons_ocollection/oassoc.ml
+++ b/commons_ocollection/oassoc.ml
@@ -50,7 +50,7 @@ object(o: 'o)
       o#replkey (k, f old)
 
   method apply_with_default2 = fun k f default ->
-    o#apply_with_default k f default +> ignore
+    o#apply_with_default k f default |> ignore
 
 
 end

--- a/commons_ocollection/ocollection.ml
+++ b/commons_ocollection/ocollection.ml
@@ -24,10 +24,10 @@ object(o: 'o)
 
 
   method add2: 'a -> unit = fun a ->
-    o#add a +> ignore;
+    o#add a |> ignore;
     ()
   method del2: 'a -> unit = fun a ->
-    o#del a +> ignore;
+    o#del a |> ignore;
     ()
   method clear: unit =
     o#iter (fun e -> o#del2 e);
@@ -43,21 +43,21 @@ object(o: 'o)
   method tolist: 'a list =
     List.rev (o#fold (fun acc e -> e::acc) [])
   method fromlist: 'a list -> 'o =
-    fun xs -> xs +> List.fold_left (fun o e -> o#add e) o#empty
+    fun xs -> xs |> List.fold_left (fun o e -> o#add e) o#empty
 
   method length: int =
-    (* oldsimple: o#tolist +> List.length *)
+    (* oldsimple: o#tolist |> List.length *)
     (* opti: *)
     let count = ref 0 in
     o#iter (fun e -> incr count);
     !count
 
   method exists: ('a -> bool) -> bool = fun f ->
-    o#tolist +> List.exists f
+    o#tolist |> List.exists f
 
   method filter: ('a -> bool) -> 'o = fun f ->
     (* iter and call add from empty, or del *)
-    o#tolist +> List.filter f +> o#fromlist
+    o#tolist |> List.filter f |> o#fromlist
 
   (* forall, fold, map *)
 

--- a/commons_ocollection/ograph.ml
+++ b/commons_ocollection/ograph.ml
@@ -24,5 +24,5 @@ object(o: 'o)
   method virtual brothers: 'a -> 'a Oset.oset
 
   method mydebug: ('a * 'a list) list =
-    (o#nodes)#tolist +> List.map (fun a -> (a, (o#successors a)#tolist))
+    (o#nodes)#tolist |> List.map (fun a -> (a, (o#successors a)#tolist))
 end

--- a/commons_ocollection/ograph2way.ml
+++ b/commons_ocollection/ograph2way.ml
@@ -65,8 +65,8 @@ object(o)
       match xs#view with (* could be done with an iter *)
       | Empty -> acc
       | Cons(x, xs) -> (acc#add x)
-          +> (fun newacc -> aux (o#predecessors x) newacc)
-          +> (fun newacc -> aux xs newacc)
+          |> (fun newacc -> aux (o#predecessors x) newacc)
+          |> (fun newacc -> aux xs newacc)
     in aux xs (f2()) (* (new osetb []) *)
 
   method children  xs =
@@ -74,8 +74,8 @@ object(o)
       match xs#view with (* could be done with an iter *)
       | Empty -> acc
       | Cons(x, xs) -> (acc#add x)
-          +> (fun newacc -> aux (o#successors x) newacc)
-          +> (fun newacc -> aux xs newacc)
+          |> (fun newacc -> aux (o#successors x) newacc)
+          |> (fun newacc -> aux xs newacc)
     in aux xs (f2()) (* (new osetb []) *)
 
 

--- a/commons_ocollection/ograph_extended.ml
+++ b/commons_ocollection/ograph_extended.ml
@@ -107,8 +107,8 @@ class ['a,'b] ograph_extended =
         match xs#view with (* could be done with an iter *)
         | Empty -> acc
         | Cons(x, xs) -> (acc#add x)
-              +> (fun newacc -> aux (o#predecessors x) newacc)
-              +> (fun newacc -> aux xs newacc)
+              |> (fun newacc -> aux (o#predecessors x) newacc)
+              |> (fun newacc -> aux xs newacc)
       in aux xs (f2()) (* (new osetb []) *)
 
     method children  xs =
@@ -116,8 +116,8 @@ class ['a,'b] ograph_extended =
         match xs#view with (* could be done with an iter *)
         | Empty -> acc
         | Cons(x, xs) -> (acc#add x)
-              +> (fun newacc -> aux (o#successors x) newacc)
-              +> (fun newacc -> aux xs newacc)
+              |> (fun newacc -> aux (o#successors x) newacc)
+              |> (fun newacc -> aux xs newacc)
       in aux xs (f2()) (* (new osetb []) *)
 
     method brothers  x =
@@ -206,13 +206,13 @@ class ['a,'b] ograph_mutable =
 let dfs_iter xi f g =
   let already = Hashtbl.create 101 in
   let rec aux_dfs xs =
-    xs +> List.iter (fun xi ->
+    xs |> List.iter (fun xi ->
       if Hashtbl.mem already xi then ()
       else begin
         Hashtbl.add already xi true;
         f xi;
         let succ = g#successors xi in
-        aux_dfs (succ#tolist +> List.map fst);
+        aux_dfs (succ#tolist |> List.map fst);
       end
     ) in
   aux_dfs [xi]
@@ -226,8 +226,8 @@ let dfs_iter_with_path xi f g =
       Hashtbl.add already xi true;
       f xi path;
       let succ = g#successors xi in
-      let succ' = succ#tolist +> List.map fst in
-      succ' +> List.iter (fun yi ->
+      let succ' = succ#tolist |> List.map fst in
+      succ' |> List.iter (fun yi ->
           aux_dfs (xi::path) yi
       );
       end

--- a/commons_ocollection/ograph_simple.ml
+++ b/commons_ocollection/ograph_simple.ml
@@ -57,7 +57,7 @@ object(o)
     then failwith "del_leaf_node_and_its_edges: have some successors"
     else begin
       let pred = o#predecessors i in
-      pred#tolist +> List.iter (fun (k, edge) ->
+      pred#tolist |> List.iter (fun (k, edge) ->
         o#del_arc (k,i) edge;
       );
       o#del_node i
@@ -65,7 +65,7 @@ object(o)
 
   method leaf_nodes () =
     let (set : 'key Oset.oset)  = build_set () in
-    o#nodes#tolist +> List.fold_left (fun acc (k,v) ->
+    o#nodes#tolist |> List.fold_left (fun acc (k,v) ->
       if (o#successors k)#null
       then acc#add k
       else acc
@@ -110,8 +110,8 @@ object(o)
       else
         let acc = acc#add x in
         let prefs = o#predecessors x in
-        let prefs = prefs#tolist +> List.map fst in
-        prefs +> List.fold_left (fun acc x -> aux acc x) acc
+        let prefs = prefs#tolist |> List.map fst in
+        prefs |> List.fold_left (fun acc x -> aux acc x) acc
     in
     let set = aux empty_set k in
     let set = set#del k in

--- a/commons_ocollection/seti.ml
+++ b/commons_ocollection/seti.ml
@@ -19,7 +19,7 @@ type seti = elt list (* last elements is in first pos, ordered reverse *)
  * merged (intervalle are separated) *)
 let invariant xs =
   let rec aux min xs =
-    xs +> List.fold_left (fun min e ->
+    xs |> List.fold_left (fun min e ->
       match e with
       | Exact i ->
           if i <= min then pr2 (spf "i = %d, min = %d" i min);
@@ -37,7 +37,7 @@ let invariant xs =
 
 let string_of_seti xs =
   "[" ^
-    join "," (xs +> List.rev +> List.map (function
+    join "," (xs |> List.rev |> List.map (function
     | (Exact i) -> string_of_int i
     | (Interv (i,j)) -> Printf.sprintf "%d - %d" i j)) ^
     "]"
@@ -142,7 +142,7 @@ let rec mem e = function
         if e >= i && e <= j then true
       else mem e xs
 
-let iter f xs = xs +> List.iter
+let iter f xs = xs |> List.iter
   (function
   | Exact i -> f i
   | Interv (i, j) -> for k = i to j do f k done
@@ -249,7 +249,7 @@ let union xs ys =
         | _ -> raise Impossible (* intervise *)
         )
   in
-(*     union_set (tolist xs) (tolist ys) +> fromlist *)
+(*     union_set (tolist xs) (tolist ys) |> fromlist *)
   List.rev_map exactize (aux (List.rev_map intervise xs) (List.rev_map intervise ys))
 
 (* bug/feature:   discovered by vlad rusu, my invariant for intervalle is
@@ -313,7 +313,7 @@ let diff xs ys =
         | _ -> raise Impossible (* intervise *)
         )
   in
-(*       minus_set (tolist xs) (tolist ys) +> fromlist *)
+(*       minus_set (tolist xs) (tolist ys) |> fromlist *)
   List.rev_map exactize (aux (List.rev_map intervise xs) (List.rev_map intervise ys))
 
 
@@ -328,7 +328,7 @@ let rec debug = function
 (*****************************************************************************)
 (* if operation return wrong result, then may later have to patch them *)
 let patch1 xs = List.map exactize xs
-let patch2 xs = xs +> List.map (fun e ->
+let patch2 xs = xs |> List.map (fun e ->
   match e with
   | Interv (i,j) when i > j && i =|= j+1 ->
       let _ = pr2 (spf "i = %d, j = %d" i j) in
@@ -337,7 +337,7 @@ let patch2 xs = xs +> List.map (fun e ->
 )
 let patch3 xs =
   let rec aux min xs =
-    xs +> List.fold_left (fun (min,acc) e ->
+    xs |> List.fold_left (fun (min,acc) e ->
       match e with
       | Exact i ->
           if i =|= min
@@ -347,6 +347,6 @@ let patch3 xs =
           (j, (Interv (i,j)::acc))
     ) (min, [])
   in
-  aux min_int (List.rev xs) +> snd
+  aux min_int (List.rev xs) |> snd
 
 

--- a/demos/c_transducer.ml
+++ b/demos/c_transducer.ml
@@ -53,10 +53,10 @@ let visit asts2 =
           ()
     );
   } in
-  asts +> List.iter (Visitor_c.vk_toplevel bigf);
+  asts |> List.iter (Visitor_c.vk_toplevel bigf);
 
   let stats = Statistics_c.statistics_of_program asts in
-  stats +> Statistics_code.assoc_of_entities_stat +> List.iter (fun (s,v) ->
+  stats |> Statistics_code.assoc_of_entities_stat |> List.iter (fun (s,v) ->
     Common.push2 (spf "nb_%s:%d" s v) props
   );
 

--- a/demos/simple_zero_to_null.ml
+++ b/demos/simple_zero_to_null.ml
@@ -48,7 +48,7 @@ let null_transfo file =
   } ast;
   let tmpfile = "/tmp/modified.c" in
   Unparse_c.pp_program_default ast2 tmpfile;
-  Common.cat tmpfile +> List.iter pr2;
+  Common.cat tmpfile |> List.iter pr2;
   ()
 
 let main =

--- a/main.ml
+++ b/main.ml
@@ -41,7 +41,7 @@ let parse_and_comments_of_file file =
 
       (* let _estat = Statistics_c.statistics_of_program program in *)
 
-  program2 +> List.iter (fun (ast, (s, toks)) ->
+  program2 |> List.iter (fun (ast, (s, toks)) ->
     Parse_c.print_commentized toks
   )
 
@@ -66,7 +66,7 @@ let main_action xs =
 
         Common2.check_stack_nbfiles nbfiles;
 
-        files +> Common.index_list +> List.iter (fun (file, i) ->
+        files |> Common.index_list |> List.iter (fun (file, i) ->
 
           pr2 (spf "PARSING: %s (%d/%d)" file i nbfiles);
 
@@ -85,7 +85,7 @@ let main_action xs =
           in
 
           (*
-          let _info_comments = comments +> List.map fst in
+          let _info_comments = comments |> List.map fst in
           Parse_c_comments_only.check_extraction file info_comments;
           *)
 
@@ -132,7 +132,7 @@ let parse_all xs =
     match xs with
     | [x] when Common2.is_directory x -> Some x
     | xs ->
-        Some (xs +> Common.join "" +> Common2.md5sum_of_string)
+        Some (xs |> Common.join "" |> Common2.md5sum_of_string)
   in
 *)
 
@@ -157,7 +157,7 @@ let parse_all xs =
   let biglist = (fun () ->
 
     let files =
-      if (xs +> List.for_all Common2.is_directory)
+      if (xs |> List.for_all Common2.is_directory)
       then
         let ext = "[ch]" in
         let ext2 = "java" in
@@ -173,7 +173,7 @@ let parse_all xs =
     let nbfiles = List.length files in
     Common2.check_stack_nbfiles nbfiles;
 
-    files +> Common.index_list +> List.map (fun (i,j) -> (i,j,nbfiles))
+    files |> Common.index_list |> List.map (fun (i,j) -> (i,j,nbfiles))
   )
   in
   let map_ex = parse_one_file in
@@ -181,7 +181,7 @@ let parse_all xs =
   let reduce_ex = (fun xxs ->
     let stats_parse = xxs in
 
-    stats_parse +> List.iter (fun (file, stat) ->
+    stats_parse |> List.iter (fun (file, stat) ->
       let s =
         spf "bad = %d, timeout = %B"
           stat.Statistics_parsing.bad stat.Statistics_parsing.have_timeout
@@ -196,7 +196,7 @@ let parse_all xs =
     );
 
 
-    dirname_opt +> Common.do_option (fun dirname ->
+    dirname_opt |> Common.do_option (fun dirname ->
       pr2 "--------------------------------";
       pr2 "regression testing  information";
       pr2 "--------------------------------";

--- a/parsing_c/ast_c.ml
+++ b/parsing_c/ast_c.ml
@@ -1063,7 +1063,7 @@ let rec (unsplit_comma: ('a, il) either list -> 'a wrap2 list) =
 (*****************************************************************************)
 
 let rec stmt_elems_of_sequencable xs =
-  xs +> List.map (fun x ->
+  xs |> List.map (fun x ->
     match x with
     | StmtElem e -> [e]
     | CppDirectiveStmt _
@@ -1073,11 +1073,11 @@ let rec stmt_elems_of_sequencable xs =
         []
     | IfdefStmt2 (_ifdef, xxs) ->
         pr2 ("stmt_elems_of_sequencable: IfdefStm2 TODO?");
-        xxs +> List.map (fun xs ->
+        xxs |> List.map (fun xs ->
           let xs' = stmt_elems_of_sequencable xs in
           xs'
-        ) +> List.flatten
-  ) +> List.flatten
+        ) |> List.flatten
+  ) |> List.flatten
 
 
 
@@ -1086,14 +1086,14 @@ let rec stmt_elems_of_sequencable xs =
 
 let s_of_inc_file inc_file =
   match inc_file with
-  | Local xs -> xs +> Common.join "/"
-  | NonLocal xs -> xs +> Common.join "/"
+  | Local xs -> xs |> Common.join "/"
+  | NonLocal xs -> xs |> Common.join "/"
   | Weird s -> s
 
 let s_of_inc_file_bis inc_file =
   match inc_file with
-  | Local xs -> "\"" ^ xs +> Common.join "/" ^ "\""
-  | NonLocal xs -> "<" ^ xs +> Common.join "/" ^ ">"
+  | Local xs -> "\"" ^ (xs |> Common.join "/") ^ "\""
+  | NonLocal xs -> "<" ^ (xs |> Common.join "/") ^ ">"
   | Weird s -> s
 
 let fieldname_of_fieldkind fieldkind =
@@ -1104,18 +1104,18 @@ let fieldname_of_fieldkind fieldkind =
 
 let s_of_attr attr =
   attr
-  +> List.map (fun (Attribute s, ii) -> s)
-  +> Common.join ","
+  |> List.map (fun (Attribute s, ii) -> s)
+  |> Common.join ","
 
 let str_of_name ident =
   match ident with
   | RegularName (s,ii) -> s
   | CppConcatenatedName xs ->
-      xs +> List.map (fun (x,iiop) -> unwrap x) +> Common.join "##"
+      xs |> List.map (fun (x,iiop) -> unwrap x) |> Common.join "##"
   | CppVariadicName (s, ii) -> "##" ^ s
   | CppIdentBuilder ((s,iis), xs) ->
       s ^ "(" ^
-        (xs +> List.map (fun ((x,iix), iicomma) -> x) +> Common.join ",") ^
+        (xs |> List.map (fun ((x,iix), iicomma) -> x) |> Common.join ",") ^
         ")"
 
 let info_of_name ident =
@@ -1149,5 +1149,5 @@ let get_s_and_ii_of_name name =
 
 
 let name_of_parameter param =
-  param.p_namei +> Common2.map_option (str_of_name)
+  param.p_namei |> Common2.map_option (str_of_name)
 

--- a/parsing_c/comment_annotater_c.ml
+++ b/parsing_c/comment_annotater_c.ml
@@ -116,12 +116,12 @@ let annotate_program toks asts =
    assert(List.length toks_with_after =|= List.length toks_with_before);
 
    Common2.zip toks_with_before toks_with_after
-   +> List.iter (fun ((t1, before), (t2, after)) ->
+   |> List.iter (fun ((t1, before), (t2, after)) ->
 
      assert(t1 =*= t2);
 
-     let before' = before +> List.map convert_relevant_tokens in
-     let after' = after  +> List.map convert_relevant_tokens in
+     let before' = before |> List.map convert_relevant_tokens in
+     let after' = after  |> List.map convert_relevant_tokens in
 
      let info = Token_helpers.info_of_tok t1 in
      info.Ast_c.comments_tag :=

--- a/parsing_c/compare_c.ml
+++ b/parsing_c/compare_c.ml
@@ -107,7 +107,7 @@ let normal_form_program xs =
 
   }
   in
-  xs +> List.map (fun p -> Visitor_c.vk_toplevel_s  bigf p)
+  xs |> List.map (fun p -> Visitor_c.vk_toplevel_s  bigf p)
 
 
 
@@ -120,7 +120,7 @@ let normal_form_token x =
     | Parser_c.TString ((s, kind),i1) -> Parser_c.TString (("",kind), i1)
     | x -> x
   in
-  x' +> Token_helpers.visitor_info_of_tok (fun info ->
+  x' |> Token_helpers.visitor_info_of_tok (fun info ->
     let info = Ast_c.al_info 0 info in
     let str = Ast_c.str_of_info info in
     if Common2.string_match_substring cvs_keyword_regexp str
@@ -169,7 +169,7 @@ let compare_ast filename1 filename2  =
   let process_filename filename =
     let (c, _stat) = Parse_c.parse_print_error_heuristic filename in
     let c = List.map fst c in
-    c +> Lib_parsing_c.al_program +> normal_form_program
+    c |> Lib_parsing_c.al_program |> normal_form_program
   in
 
   let c1 = process_filename filename1 in
@@ -183,7 +183,7 @@ let compare_ast filename1 filename2  =
     then Pb "not same number of entities (func, decl, ...)"
     else
       begin
-        zip c1 c2 +> List.iter (function
+        zip c1 c2 |> List.iter (function
         | Declaration a, Declaration b -> if not (a =*= b) then incr error
         | Definition a, Definition b ->   if not (a =*= b) then incr error
         | EmptyDef a, EmptyDef b ->       if not (a =*= b) then incr error
@@ -297,8 +297,8 @@ let compare_token filename1 filename2 =
   in
   let final_loop xs ys =
     loop
-      (xs +> List.filter (fun x -> not (is_normal_space_or_comment x)))
-      (ys +> List.filter (fun x -> not (is_normal_space_or_comment x)))
+      (xs |> List.filter (fun x -> not (is_normal_space_or_comment x)))
+      (ys |> List.filter (fun x -> not (is_normal_space_or_comment x)))
   in
 
   (*
@@ -314,7 +314,7 @@ let compare_token filename1 filename2 =
     if List.length c1 <> List.length c2
     then Pb "not same number of entities (func, decl, ...)"
     else
-        zip c1 c2 +> Common2.fold_k (fun acc ((a,infoa),(b,infob)) k ->
+        zip c1 c2 |> Common2.fold_k (fun acc ((a,infoa),(b,infob)) k ->
           match a, b with
           | NotParsedCorrectly a, NotParsedCorrectly b ->
               (match final_loop (snd infoa) (snd infob) with
@@ -370,12 +370,12 @@ let compare_result_to_string (correct, diffxs) =
   | Pb s ->
       ("seems incorrect: " ^ s) ^ "\n" ^
         "diff (result(-) vs expected_result(+)) = " ^ "\n" ^
-        (diffxs +> Common.join "\n") ^ "\n"
+        (diffxs |> Common.join "\n") ^ "\n"
   | PbOnlyInNotParsedCorrectly s ->
       "seems incorrect, but only because of code that was not parsable" ^ "\n"^
         ("explanation:" ^ s) ^ "\n" ^
         "diff (result(-) vs expected_result(+)) = " ^ "\n" ^
-        (diffxs +> Common.join "\n") ^ "\n"
+        (diffxs |> Common.join "\n") ^ "\n"
 
 
 let compare_result_to_bool correct =

--- a/parsing_c/control_flow_c.ml
+++ b/parsing_c/control_flow_c.ml
@@ -282,7 +282,7 @@ let extract_is_fake ((node, info), nodestr) = info.is_fake
 let mk_any_node is_fake node labels bclabels nodestr =
   let nodestr =
     if !Flag_parsing_c.show_flow_labels
-    then nodestr ^ ("[" ^ (labels +> List.map i_to_s +> join ",") ^ "]")
+    then nodestr ^ ("[" ^ (labels |> List.map i_to_s |> join ",") ^ "]")
     else nodestr
   in
   ((node, {labels = labels;is_loop=false;bclabels=bclabels;is_fake=is_fake}),
@@ -293,14 +293,14 @@ let mk_fake_node = mk_any_node true (* for duplicated braces *)
 
 (* ------------------------------------------------------------------------ *)
 let first_node g =
-  g#nodes#tolist +> List.find (fun (i, node) ->
+  g#nodes#tolist |> List.find (fun (i, node) ->
     match unwrap node with TopNode -> true | _ -> false
-    ) +> fst
+    ) |> fst
 
 let find_node f g =
-  g#nodes#tolist +> List.find (fun (nodei, node) ->
+  g#nodes#tolist |> List.find (fun (nodei, node) ->
     f (unwrap node))
-     +> fst
+     |> fst
 
 
 (* remove an intermediate node and redirect the connexion  *)
@@ -309,18 +309,18 @@ let remove_one_node nodei g =
   let succs = (g#successors nodei)#tolist in
   assert (not (null preds));
 
-  preds +> List.iter (fun (predi, Direct) ->
+  preds |> List.iter (fun (predi, Direct) ->
     g#del_arc ((predi, nodei), Direct);
   );
-  succs +> List.iter (fun (succi, Direct) ->
+  succs |> List.iter (fun (succi, Direct) ->
     g#del_arc ((nodei, succi), Direct);
   );
 
   g#del_node nodei;
 
   (* connect in-nodes to out-nodes *)
-  preds +> List.iter (fun (pred, Direct) ->
-    succs +> List.iter (fun (succ, Direct) ->
+  preds |> List.iter (fun (pred, Direct) ->
+    succs |> List.iter (fun (succ, Direct) ->
       g#add_arc ((pred, succ), Direct);
     );
   )

--- a/parsing_c/cpp_ast_c.ml
+++ b/parsing_c/cpp_ast_c.ml
@@ -75,14 +75,14 @@ type cpp_option =
 
 
 let i_of_cpp_options xs =
-  xs +> Common.map_filter (function
+  xs |> Common.map_filter (function
   | I f -> Some f
   | D _ -> None
   )
 
 let cpp_option_of_cmdline (xs, ys) =
-  (xs +> List.map (fun s -> I s)) @
-  (ys +> List.map (fun s ->
+  (xs |> List.map (fun s -> I s)) @
+  (ys |> List.map (fun s ->
     if s =~ "\\([A-Z][A-Z0-9_]*\\)=\\(.*\\)"
     then
       let (def, value) = matched2 s in
@@ -101,7 +101,7 @@ let init_adjust_candidate_header_files dir =
   let ext = "[h]" in
   let files = Common2.files_of_dir_or_files ext [dir] in
 
-  files +> List.iter (fun file ->
+  files |> List.iter (fun file ->
     let base = Filename.basename file in
     pr2 file;
     Hashtbl.add _hcandidates base file;
@@ -120,7 +120,7 @@ let find_header_file1 cppopts dirname inc_file =
       then [finalfile]
       else []
   | NonLocal f ->
-      i_of_cpp_options cppopts +> Common.map_filter (fun dirname ->
+      i_of_cpp_options cppopts |> Common.map_filter (fun dirname ->
         let finalfile =
           Filename.concat dirname (Ast_c.s_of_inc_file inc_file) in
         if Sys.file_exists finalfile
@@ -167,7 +167,7 @@ let find_header_file cppopts dirname inc_file =
 (* ---------------------------------------------------------------------- *)
 let trace_cpp_process depth mark inc_file =
   pr2 (spf "%s>%s %s"
-          (Common2.repeat "-" depth +> Common.join "")
+          (Common2.repeat "-" depth |> Common.join "")
           mark
           (s_of_inc_file_bis inc_file));
   ()
@@ -201,14 +201,14 @@ let parse_c_and_cpp_cache file =
 let (show_cpp_i_opts: string list -> unit) = fun xs ->
   if not (null xs) then begin
     pr2 "-I";
-    xs +> List.iter pr2
+    xs |> List.iter pr2
   end
 
 
 let (show_cpp_d_opts: string list -> unit) = fun xs ->
   if not (null xs) then begin
     pr2 "-D";
-    xs +> List.iter pr2
+    xs |> List.iter pr2
   end
 
 (*****************************************************************************)
@@ -227,7 +227,7 @@ let (cpp_expand_include2:
   let rec aux stack dirname ast =
     let depth = List.length stack in
 
-    ast +> Visitor_c.vk_program_s { Visitor_c.default_visitor_c_s with
+    ast |> Visitor_c.vk_program_s { Visitor_c.default_visitor_c_s with
       Visitor_c.kcppdirective_s = (fun (k, bigf) cpp ->
         match cpp with
         | Include {i_include = (inc_file, ii);
@@ -338,12 +338,12 @@ let should_ifdefize tag ifdefs_directives xxs =
 let group_ifdef tag xs =
   let (xxs, xs) = Common2.group_by_post (is_ifdef_and_same_tag tag) xs in
 
-  xxs +> List.map snd +> List.map (fun x ->
+  xxs |> List.map snd |> List.map (fun x ->
     match x with
     | IfdefStmt y -> y
     | StmtElem _ | CppDirectiveStmt _ | IfdefStmt2 _ -> raise Impossible
   ),
-  xxs +> List.map fst,
+  xxs |> List.map fst,
   xs
 
 

--- a/parsing_c/cpp_token_c.ml
+++ b/parsing_c/cpp_token_c.ml
@@ -201,7 +201,7 @@ let rec remap_keyword_tokens xs =
 let rec (cpp_engine: (string , Parser_c.token list) assoc ->
           Parser_c.token list -> Parser_c.token list) =
  fun env xs ->
-  xs +> List.map (fun tok ->
+  xs |> List.map (fun tok ->
     (* expand only TIdent ? no cos the parameter of the macro
      * can actually be some 'register' so may have to look for
      * any tokens candidates for the expansion.
@@ -213,8 +213,8 @@ let rec (cpp_engine: (string , Parser_c.token list) assoc ->
     | TIdent (s,i1) when List.mem_assoc s env -> Common2.assoc s env
     | x -> [x]
   )
-  +> List.flatten
-  +> remap_keyword_tokens
+  |> List.flatten
+  |> remap_keyword_tokens
 
 
 
@@ -290,7 +290,7 @@ let rec apply_macro_defs
                 (* old: id.new_tokens_before <- bodymacro; *)
 
                 (* update: if wrong number, then I just pass this macro *)
-                [Parenthised (xxs, info_parens)] +>
+                [Parenthised (xxs, info_parens)] |>
                   iter_token_paren (set_as_comment Token_c.CppMacro);
                 set_as_comment Token_c.CppMacro id;
 
@@ -298,8 +298,8 @@ let rec apply_macro_defs
               end
               else
 
-                let xxs' = xxs +> List.map (fun x ->
-                  (tokens_of_paren_ordered x) +> List.map (fun x ->
+                let xxs' = xxs |> List.map (fun x ->
+                  (tokens_of_paren_ordered x) |> List.map (fun x ->
                     TH.visitor_info_of_tok Ast_c.make_expanded x.tok
                   )
                 ) in
@@ -311,7 +311,7 @@ let rec apply_macro_defs
                  * will pass as argument to the macro some tokens that
                  * are all TCommentCpp
                  *)
-                [Parenthised (xxs, info_parens)] +>
+                [Parenthised (xxs, info_parens)] |>
                   iter_token_paren (set_as_comment Token_c.CppMacro);
                 set_as_comment Token_c.CppMacro id;
 
@@ -336,14 +336,14 @@ let rec apply_macro_defs
 
                     msg_apply_known_macro_hint s;
                     id.tok <- token_from_parsinghack_hint (s,i1) hint;
-                    [Parenthised (xxs, info_parens)] +>
+                    [Parenthised (xxs, info_parens)] |>
                       iter_token_paren (set_as_comment Token_c.CppMacro);
                     set_as_comment Token_c.CppMacro id2;
 
                 | _ ->
                     msg_apply_known_macro_hint s;
                     id.tok <- token_from_parsinghack_hint (s,i1) hint;
-                    [Parenthised (xxs, info_parens)] +>
+                    [Parenthised (xxs, info_parens)] |>
                       iter_token_paren (set_as_comment Token_c.CppMacro);
                 )
 
@@ -370,7 +370,7 @@ let rec apply_macro_defs
           (match body with
           | DefineBody [newtok] ->
              (* special case when 1-1 substitution, we reuse the token *)
-              id.tok <- (newtok +> TH.visitor_info_of_tok (fun _ ->
+              id.tok <- (newtok |> TH.visitor_info_of_tok (fun _ ->
                 TH.info_of_tok id.tok))
           | DefineBody bodymacro ->
               set_as_comment Token_c.CppMacro id;
@@ -388,7 +388,7 @@ let rec apply_macro_defs
   (* recurse *)
   | (PToken x)::xs -> apply_macro_defs xs
   | (Parenthised (xxs, info_parens))::xs ->
-      xxs +> List.iter apply_macro_defs;
+      xxs |> List.iter apply_macro_defs;
       apply_macro_defs xs
  in
  apply_macro_defs xs
@@ -564,11 +564,11 @@ let rec define_parse xs =
   | [] -> []
   | TDefine i1::TIdentDefine (s,i2)::TOParDefine i3::xs ->
       let (tokparams, _, xs) =
-        xs +> Common2.split_when (function TCPar _ -> true | _ -> false) in
+        xs |> Common2.split_when (function TCPar _ -> true | _ -> false) in
       let (body, _, xs) =
-        xs +> Common2.split_when (function TDefEOL _ -> true | _ -> false) in
+        xs |> Common2.split_when (function TDefEOL _ -> true | _ -> false) in
       let params =
-        tokparams +> Common.map_filter (function
+        tokparams |> Common.map_filter (function
         | TComma _ -> None
         | TIdent (s, _) -> Some s
 
@@ -591,7 +591,7 @@ let rec define_parse xs =
       (* bugfix: also substitute to ident in body so cpp_engine will
        * have an easy job.
        *)
-      let body = body +> List.map (fun tok ->
+      let body = body |> List.map (fun tok ->
         match tok with
         | TIdent _ -> tok
         | _ ->
@@ -603,14 +603,14 @@ let rec define_parse xs =
               TIdent (s, ii)
             end
             else tok
-      ) +> List.map (TH.visitor_info_of_tok Ast_c.make_expanded) in
+      ) |> List.map (TH.visitor_info_of_tok Ast_c.make_expanded) in
       let def = (s, (s, Params params, macro_body_to_maybe_hint body)) in
       def::define_parse xs
 
   | TDefine i1::TIdentDefine (s,i2)::xs ->
       let (body, _, xs) =
-        xs +> Common2.split_when (function TDefEOL _ -> true | _ -> false) in
-      let body = body +> List.map
+        xs |> Common2.split_when (function TDefEOL _ -> true | _ -> false) in
+      let body = body |> List.map
         (TH.visitor_info_of_tok Ast_c.make_expanded) in
       let def = (s, (s, NoParam, macro_body_to_maybe_hint body)) in
       def::define_parse xs
@@ -623,7 +623,7 @@ let rec define_parse xs =
 
 
 let extract_cpp_define xs =
-  let cleaner = xs +> List.filter (fun x ->
+  let cleaner = xs |> List.filter (fun x ->
     not (TH.is_comment x)
   ) in
   define_parse cleaner

--- a/parsing_c/lib_parsing_c.ml
+++ b/parsing_c/lib_parsing_c.ml
@@ -41,7 +41,7 @@ let strip_info_visitor _ =
       let ft' = k ft in
       match Ast_c.unwrap_typeC ft' with
       | Ast_c.TypeName (s,_typ) ->
-          Ast_c.TypeName (s, Ast_c.noTypedefDef()) +> Ast_c.rewrap_typeC ft'
+          Ast_c.TypeName (s, Ast_c.noTypedefDef()) |> Ast_c.rewrap_typeC ft'
       | _ -> ft'
 
     );
@@ -111,7 +111,7 @@ let real_strip_info_visitor _ =
       let ft' = k ft in
       match Ast_c.unwrap_typeC ft' with
       | Ast_c.TypeName (s,_typ) ->
-          Ast_c.TypeName (s, Ast_c.noTypedefDef()) +> Ast_c.rewrap_typeC ft'
+          Ast_c.TypeName (s, Ast_c.noTypedefDef()) |> Ast_c.rewrap_typeC ft'
       | _ -> ft'
 
     );
@@ -166,7 +166,7 @@ let max_min_ii_by_pos xs =
   | [x] -> (x, x)
   | x::xs ->
       let pos_leq p1 p2 = (Ast_c.compare_pos p1 p2) =|= (-1) in
-      xs +> List.fold_left (fun (maxii,minii) e ->
+      xs |> List.fold_left (fun (maxii,minii) e ->
         let maxii' = if pos_leq maxii e then e else maxii in
         let minii' = if pos_leq e minii then e else minii in
         maxii', minii'
@@ -232,12 +232,12 @@ let names_of_parameters_in_def def =
   | None ->
       let ftyp = def.Ast_c.f_type in
       let (ret, (params, bwrap)) = ftyp in
-      params +> Common.map_filter (fun (param,ii) ->
+      params |> Common.map_filter (fun (param,ii) ->
         Ast_c.name_of_parameter param
       )
 
 let names_of_parameters_in_macro xs =
-  xs +> List.map (fun (xx, ii) ->
+  xs |> List.map (fun (xx, ii) ->
     let (s, ii2) = xx in
     s
   )

--- a/parsing_c/parser_c.mly
+++ b/parsing_c/parser_c.mly
@@ -150,9 +150,9 @@ let (fixDeclSpecForDecl: decl -> (fullType * (storage wrap)))  = function
  | (Some sign,   None, (None| Some (BaseType (IntType (Si (_,CInt))))))  ->
      BaseType(IntType (Si (sign, CInt))), iit
  | ((None|Some Signed),Some x,(None|Some(BaseType(IntType (Si (_,CInt)))))) ->
-     BaseType(IntType (Si (Signed, [Short,CShort; Long, CLong; LongLong, CLongLong] +> List.assoc x))), iit
+     BaseType(IntType (Si (Signed, [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x))), iit
  | (Some UnSigned, Some x, (None| Some (BaseType (IntType (Si (_,CInt))))))->
-     BaseType(IntType (Si (UnSigned, [Short,CShort; Long, CLong; LongLong, CLongLong] +> List.assoc x))), iit
+     BaseType(IntType (Si (UnSigned, [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x))), iit
  | (Some sign,   None, (Some (BaseType (IntType CChar))))   -> BaseType(IntType (Si (sign, CChar2))), iit
  | (None, Some Long,(Some(BaseType(FloatType CDouble))))    -> BaseType (FloatType (CLongDouble)), iit
 
@@ -230,7 +230,7 @@ let (fixOldCDecl: fullType -> fullType) = fun ty ->
       | [{p_namei = None; p_type = ((_qua, (BaseType Void,_)))},_] ->
           ty
       | params ->
-          (params +> List.iter (fun (param,_) ->
+          (params |> List.iter (fun (param,_) ->
             match param with
             | {p_namei = None} ->
               (* if majuscule, then certainly macro-parameter *)
@@ -260,7 +260,7 @@ let fixFunc (typ, compound, old_style_opt) =
       (match params with
       | [{p_namei= None; p_type =((_qua, (BaseType Void,_)))}, _] ->  ()
       | params ->
-          params +> List.iter (function
+          params |> List.iter (function
           | ({p_namei = Some s}, _) -> ()
 	  | _ -> ()
                 (* failwith "internal errror: fixOldCDecl not good" *)
@@ -326,7 +326,7 @@ let fix_add_params_ident = function
       (match params with
       | [{p_namei=None; p_type=((_qua, (BaseType Void,_)))}, _] ->  ()
       | params ->
-          params +> List.iter (function
+          params |> List.iter (function
           | ({p_namei= Some name}, _) ->
               LP.add_ident (Ast_c.str_of_name s)
 	  | _ ->
@@ -1056,7 +1056,7 @@ type_qualif_attr:
  *)*/
 
 declarator:
- | pointer direct_d { (fst $2, fun x -> x +> $1 +> (snd $2)  ) }
+ | pointer direct_d { (fst $2, fun x -> x |> $1 |> (snd $2)  ) }
  | direct_d         { $1  }
 
 /*(* so must do  int * const p; if the pointer is constant, not the pointee *)*/
@@ -1096,7 +1096,7 @@ tccro: TCCro { dt "tccro" ();$1 }
 abstract_declarator:
  | pointer                            { $1 }
  |         direct_abstract_declarator { $1 }
- | pointer direct_abstract_declarator { fun x -> x +> $2 +> $1 }
+ | pointer direct_abstract_declarator { fun x -> x |> $2 |> $1 }
 
 direct_abstract_declarator:
  | TOPar abstract_declarator TCPar /*(* forunparser: old: $2 *)*/
@@ -1242,7 +1242,7 @@ decl2:
        let (returnType,storage) = fixDeclSpecForDecl $1 in
        let iistart = Ast_c.fakeInfo () in
        DeclList (
-         ($2 +> List.map (fun ((((name,f),attrs), ini), iivirg) ->
+         ($2 |> List.map (fun ((((name,f),attrs), ini), iivirg) ->
            let s = str_of_name name in
            let iniopt =
              match ini with
@@ -1408,7 +1408,7 @@ designator:
 
 gcc_comma_opt_struct:
  | TComma {  [$1] }
- | /*(* empty *)*/  {  [Ast_c.fakeInfo() +> Ast_c.rewrap_str ","]  }
+ | /*(* empty *)*/  {  [Ast_c.fakeInfo() |> Ast_c.rewrap_str ","]  }
 
 
 
@@ -1462,7 +1462,7 @@ field_declaration:
        if fst (unwrap storage) <> NoSto
        then Common2.internal_error "parsing dont allow this";
 
-       FieldDeclList ($2 +> (List.map (fun (f, iivirg) ->
+       FieldDeclList ($2 |> (List.map (fun (f, iivirg) ->
          f returnType, iivirg))
                          ,[$3])
          (* dont need to check if typedef or func initialised cos

--- a/parsing_c/parsing_stat.ml
+++ b/parsing_c/parsing_stat.ml
@@ -65,20 +65,20 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   let total = List.length statxs in
   let perfect =
     statxs
-      +> List.filter (function
+      |> List.filter (function
           {have_timeout = false; bad = 0} -> true | _ -> false)
-      +> List.length
+      |> List.length
   in
 
   if verbose then begin
   pr "\n\n\n---------------------------------------------------------------";
   pr "pbs with files:";
   statxs
-    +> List.filter (function
+    |> List.filter (function
       | {have_timeout = true} -> true
       | {bad = n} when n > 0 -> true
       | _ -> false)
-    +> List.iter (function
+    |> List.iter (function
         {filename = file; have_timeout = timeout; bad = n} ->
           pr (file ^ "  " ^ (if timeout then "TIMEOUT" else i_to_s n));
         );
@@ -87,10 +87,10 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   pr "files with lots of tokens passed/commentized:";
   let threshold_passed = 100 in
   statxs
-    +> List.filter (function
+    |> List.filter (function
       | {commentized = n} when n > threshold_passed -> true
       | _ -> false)
-    +> List.iter (function
+    |> List.iter (function
         {filename = file; commentized = n} ->
           pr (file ^ "  " ^ (i_to_s n));
         );
@@ -101,18 +101,18 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   pr (
   (spf "NB total files = %d; " total) ^
   (spf "perfect = %d; " perfect) ^
-  (spf "pbs = %d; "     (statxs +> List.filter (function
+  (spf "pbs = %d; "     (statxs |> List.filter (function
       {have_timeout = b; bad = n} when n > 0 -> true | _ -> false)
-                               +> List.length)) ^
-  (spf "timeout = %d; " (statxs +> List.filter (function
+                               |> List.length)) ^
+  (spf "timeout = %d; " (statxs |> List.filter (function
       {have_timeout = true; bad = n} -> true | _ -> false)
-                               +> List.length)) ^
+                               |> List.length)) ^
   (spf "=========> %d" ((100 * perfect) / total)) ^ "%"
 
   );
-  let good = statxs +> List.fold_left (fun acc {correct = x} -> acc+x) 0 in
-  let bad  = statxs +> List.fold_left (fun acc {bad = x} -> acc+x) 0  in
-  let passed = statxs +> List.fold_left (fun acc {commentized = x} -> acc+x) 0
+  let good = statxs |> List.fold_left (fun acc {correct = x} -> acc+x) 0 in
+  let bad  = statxs |> List.fold_left (fun acc {bad = x} -> acc+x) 0  in
+  let passed = statxs |> List.fold_left (fun acc {commentized = x} -> acc+x) 0
   in
   let gf, badf = float_of_int good, float_of_int bad in
   let passedf = float_of_int passed in
@@ -147,10 +147,10 @@ let lines_around_error_line ~context (file, line) =
 
 let print_recurring_problematic_tokens xs =
   let h = Hashtbl.create 101 in
-  xs +> List.iter (fun x ->
+  xs |> List.iter (fun x ->
     let file = x.filename in
-    x.problematic_lines +> List.iter (fun (xs, line_error) ->
-      xs +> List.iter (fun s ->
+    x.problematic_lines |> List.iter (fun (xs, line_error) ->
+      xs |> List.iter (fun s ->
         Common2.hupdate_default s
           (fun (old, example)  -> old + 1, example)
           (fun() -> 0, (file, line_error)) h;
@@ -159,13 +159,13 @@ let print_recurring_problematic_tokens xs =
   pr2 ("maybe 10 most problematic tokens");
   Common2.pr2_xxxxxxxxxxxxxxxxx();
   Common.hash_to_list h
-  +> List.sort (fun (k1,(v1,_)) (k2,(v2,_)) -> compare v2 v1)
-  +> Common.take_safe 10
-  +> List.iter (fun (k,(i, (file_ex, line_ex))) ->
+  |> List.sort (fun (k1,(v1,_)) (k2,(v2,_)) -> compare v2 v1)
+  |> Common.take_safe 10
+  |> List.iter (fun (k,(i, (file_ex, line_ex))) ->
     pr2 (spf "%s: present in %d parsing errors" k i);
     pr2 ("example: ");
     let lines = lines_around_error_line ~context:2 (file_ex, line_ex) in
-    lines +> List.iter (fun s -> pr2 ("       " ^ s));
+    lines |> List.iter (fun s -> pr2 ("       " ^ s));
 
   );
   Common2.pr2_xxxxxxxxxxxxxxxxx();
@@ -339,6 +339,6 @@ let assoc_stat_number =
   ]
 
 let print_stat_numbers () =
-  assoc_stat_number +> List.iter (fun (k, vref) ->
+  assoc_stat_number |> List.iter (fun (k, vref) ->
     pr2 (spf "%-30s -> %d" k !vref);
   )

--- a/parsing_c/pretty_print_c.ml
+++ b/parsing_c/pretty_print_c.ml
@@ -80,7 +80,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
     (match exp, ii with
     | Ident (ident),         []     -> pp_name ident
     (* only a MultiString can have multiple ii *)
-    | Constant (MultiString _), is     -> is +> List.iter pr_elem
+    | Constant (MultiString _), is     -> is |> List.iter pr_elem
     | Constant (c),         [i]     -> pr_elem i
     | FunCall  (e, es),     [i1;i2] ->
         pp_expression e; pr_elem i1;
@@ -118,7 +118,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
     | StatementExpr (statxs, [ii1;ii2]),  [i1;i2] ->
         pr_elem i1;
         pr_elem ii1;
-        statxs +> List.iter pp_statement_seq;
+        statxs |> List.iter pp_statement_seq;
         pr_elem ii2;
         pr_elem i2;
     | Constructor (t, xs), lp::rp::i1::i2::iicommaopt ->
@@ -126,12 +126,12 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
         pp_type t;
         pr_elem rp;
         pr_elem i1;
-        xs +> List.iter (fun (x, ii) ->
+        xs |> List.iter (fun (x, ii) ->
           assert (List.length ii <= 1);
-          ii +> List.iter (function x -> pr_elem x; pr_space());
+          ii |> List.iter (function x -> pr_elem x; pr_space());
           pp_init x
         );
-        iicommaopt +> List.iter pr_elem;
+        iicommaopt |> List.iter pr_elem;
         pr_elem i2;
 
     | ParenExpr (e), [i1;i2] -> pr_elem i1; pp_expression e; pr_elem i2;
@@ -148,26 +148,26 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
     if !Flag_parsing_c.pretty_print_type_info
     then begin
-      pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "/*");
-      !typ +>
-      (fun (ty,_test) -> ty +>
+      pr_elem (Ast_c.fakeInfo() |> Ast_c.rewrap_str "/*");
+      !typ |>
+      (fun (ty,_test) -> ty |>
 	Common.do_option
 	  (fun (x,l) -> pp_type x;
 	    let s = match l with
 	      Ast_c.LocalVar _ -> ", local"
 	    | _ -> "" in
-	    pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str s)));
-      pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "*/");
+	    pr_elem (Ast_c.fakeInfo() |> Ast_c.rewrap_str s)));
+      pr_elem (Ast_c.fakeInfo() |> Ast_c.rewrap_str "*/");
     end
 
   and pp_arg_list es =
-    es +> List.iter (fun (e, opt) ->
+    es |> List.iter (fun (e, opt) ->
       assert (List.length opt <= 1); (* opt must be a comma? *)
-      opt +> List.iter (function x -> pr_elem x; pr_space());
+      opt |> List.iter (function x -> pr_elem x; pr_space());
       pp_argument e)
 
   and pp_argument argument =
-    let rec pp_action (ActMisc ii) = ii +> List.iter pr_elem in
+    let rec pp_action (ActMisc ii) = ii |> List.iter pr_elem in
     match argument with
     | Left e -> pp_expression e
     | Right weird ->
@@ -181,19 +181,19 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
         let (i1) = Common2.tuple_of_list1 ii in
         pr_elem i1
     | CppConcatenatedName xs ->
-        xs +> List.iter (fun ((x,ii1), ii2) ->
-          ii2 +> List.iter pr_elem;
-          ii1 +> List.iter pr_elem;
+        xs |> List.iter (fun ((x,ii1), ii2) ->
+          ii2 |> List.iter pr_elem;
+          ii1 |> List.iter pr_elem;
         )
     | CppVariadicName (s, ii) ->
-        ii +> List.iter pr_elem
+        ii |> List.iter pr_elem
     | CppIdentBuilder ((s,iis), xs) ->
         let (iis, iop, icp) = Common2.tuple_of_list3 iis in
         pr_elem iis;
         pr_elem iop;
-        xs +> List.iter (fun ((x,iix), iicomma) ->
-          iicomma +> List.iter pr_elem;
-          iix +> List.iter pr_elem;
+        xs |> List.iter (fun ((x,iix), iicomma) ->
+          iicomma |> List.iter pr_elem;
+          iix |> List.iter pr_elem;
         );
         pr_elem icp
 
@@ -216,7 +216,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 	pp_statement st
     | Compound statxs, [i1;i2] ->
         pr_elem i1; start_block();
-        statxs +> Common2.print_between pr_nl pp_statement_seq;
+        statxs |> Common2.print_between pr_nl pp_statement_seq;
         end_block(); pr_elem i2;
 
     | ExprStatement (None), [i] -> pr_elem i;
@@ -267,9 +267,9 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
         pr_elem i1; pr_space();
         pr_elem i2;
 
-        es +> List.iter (fun (e, opt) ->
+        es |> List.iter (fun (e, opt) ->
           assert (List.length opt <= 1);
-          opt +> List.iter pr_elem;
+          opt |> List.iter pr_elem;
           pp_argument e;
         );
 
@@ -304,7 +304,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
         assert (null ii);
         pp_def def
     | MacroStmt, ii ->
-        ii +> List.iter pr_elem ;
+        ii |> List.iter pr_elem ;
 
     | (Labeled (Case  (_,_))
     | Labeled (CaseRange  (_,_,_)) | Labeled (Default _)
@@ -334,8 +334,8 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
 (* XXX elsif YYY elsif ZZZ endif *)
   and pp_ifdef_tree_sequence_aux ifdefs xxs =
-    Common2.zip ifdefs xxs +> List.iter (fun (ifdef, xs) ->
-      xs +> List.iter pp_statement_seq;
+    Common2.zip ifdefs xxs |> List.iter (fun (ifdef, xs) ->
+      xs |> List.iter pp_statement_seq;
       pp_ifdef ifdef
     )
 
@@ -345,14 +345,14 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
 (* ---------------------- *)
   and pp_asmbody (string_list, colon_list) =
-    string_list +> List.iter pr_elem ;
-    colon_list +> List.iter (fun (Colon xs, ii) ->
-      ii +> List.iter pr_elem;
-      xs +> List.iter (fun (x,iicomma) ->
+    string_list |> List.iter pr_elem ;
+    colon_list |> List.iter (fun (Colon xs, ii) ->
+      ii |> List.iter pr_elem;
+      xs |> List.iter (fun (x,iicomma) ->
 	assert ((List.length iicomma) <= 1);
-	iicomma +> List.iter (function x -> pr_elem x; pr_space());
+	iicomma |> List.iter (function x -> pr_elem x; pr_space());
 	(match x with
-	| ColonMisc, ii -> ii +> List.iter pr_elem;
+	| ColonMisc, ii -> ii |> List.iter pr_elem;
 	| ColonExpr e, [istring;iopar;icpar] ->
             pr_elem istring;
             pr_elem iopar;
@@ -395,13 +395,13 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
       let print_sto_qu (sto, (qu, iiqu)) =
         let all_ii = get_sto sto @ iiqu in
         all_ii
-          +> List.sort Ast_c.compare_pos
-          +> Common2.print_between pr_space pr_elem
+          |> List.sort Ast_c.compare_pos
+          |> Common2.print_between pr_space pr_elem
 
       in
       let print_sto_qu_ty (sto, (qu, iiqu), iity) =
         let all_ii = get_sto sto @ iiqu @ iity in
-        let all_ii2 = all_ii +> List.sort Ast_c.compare_pos in
+        let all_ii2 = all_ii |> List.sort Ast_c.compare_pos in
 
         if all_ii <> all_ii2
         then begin
@@ -409,9 +409,9 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
              * cf -test strangeorder
              *)
           pr2 "STRANGEORDER";
-          all_ii2 +> Common2.print_between pr_space pr_elem
+          all_ii2 |> Common2.print_between pr_space pr_elem
         end
-        else all_ii2 +> Common2.print_between pr_space pr_elem
+        else all_ii2 |> Common2.print_between pr_space pr_elem
       in
 
       match ty, iity with
@@ -433,7 +433,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
           | x -> raise Impossible
 	  );
 
-          fields +> List.iter
+          fields |> List.iter
             (fun (field) ->
 
               match field with
@@ -471,9 +471,9 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
                       ); (* match x, first onefield_multivars *)
 
                       (* for other vars *)
-		      xs +> List.iter (function
+		      xs |> List.iter (function
 			| (Simple (nameopt, typ)), iivirg ->
-			    iivirg +> List.iter pr_elem;
+			    iivirg |> List.iter pr_elem;
 			    let identinfo =
 			      match nameopt with
 			      | None -> None
@@ -482,7 +482,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 			    pp_type_with_ident_rest identinfo typ Ast_c.noattr
 
 			| (BitField (nameopt, typ, iidot, expr)), iivirg ->
-			    iivirg +> List.iter pr_elem;
+			    iivirg |> List.iter pr_elem;
 			    (match nameopt with
 			    | Some name ->
                                 let (s,is) = get_s_and_ii_of_name name in
@@ -496,21 +496,21 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 		  | [] -> raise Impossible
 		  ); (* onefield_multivars *)
 		  assert (List.length iiptvirg =|= 1);
-		  iiptvirg +> List.iter pr_elem;
+		  iiptvirg |> List.iter pr_elem;
 
 
 	      | MacroDeclField ((s, es), ii)  ->
                  let (iis, lp, rp, iiend, ifakestart) =
                    Common2.tuple_of_list5 ii in
                  (* iis::lp::rp::iiend::ifakestart::iisto
-	         iisto +> List.iter pr_elem; (* static and const *)
+	         iisto |> List.iter pr_elem; (* static and const *)
                  *)
 	         pr_elem ifakestart;
 	         pr_elem iis;
 	         pr_elem lp;
-	         es +> List.iter (fun (e, opt) ->
+	         es |> List.iter (fun (e, opt) ->
                    assert (List.length opt <= 1);
-                   opt +> List.iter pr_elem;
+                   opt |> List.iter pr_elem;
                    pp_argument e;
 	         );
 
@@ -545,11 +545,11 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
           | x -> raise Impossible
 	  );
 
-          enumt +> List.iter (fun ((name, eopt), iicomma) ->
+          enumt |> List.iter (fun ((name, eopt), iicomma) ->
             assert (List.length iicomma <= 1);
-            iicomma +> List.iter (function x -> pr_elem x; pr_space());
+            iicomma |> List.iter (function x -> pr_elem x; pr_space());
             pp_name name;
-            eopt +> Common.do_option (fun (ieq, e) ->
+            eopt |> Common.do_option (fun (ieq, e) ->
               pr_elem ieq;
               pp_expression e;
 	  ));
@@ -585,11 +585,11 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
           if !Flag_parsing_c.pretty_print_typedef_value
           then begin
-            pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "{*");
-            typ +> Common.do_option (fun typ ->
+            pr_elem (Ast_c.fakeInfo() |> Ast_c.rewrap_str "{*");
+            typ |> Common.do_option (fun typ ->
                 pp_type typ;
             );
-            pr_elem (Ast_c.fakeInfo() +> Ast_c.rewrap_str "*}");
+            pr_elem (Ast_c.fakeInfo() |> Ast_c.rewrap_str "*}");
           end;
 
       | (TypeOfExpr (e), iis) ->
@@ -627,7 +627,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
     fun ident (((qu, iiqu), (ty, iity)) as fullt) attrs ->
       let print_ident ident = Common.do_option (fun (s, iis) ->
-        (* XXX attrs +> pp_attributes pr_elem pr_space; *)
+        (* XXX attrs |> pp_attributes pr_elem pr_space; *)
         pr_elem iis
 	) ident
       in
@@ -651,7 +651,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
           (*WRONG I THINK, use left & right function *)
           (* bug: pp_type_with_ident_rest None t;      print_ident ident *)
           pr_elem i;
-          iiqu +> List.iter pr_elem; (* le const est forcement apres le '*' *)
+          iiqu |> List.iter pr_elem; (* le const est forcement apres le '*' *)
           pp_type_with_ident_rest ident t attrs;
 
       (* ugly special case ... todo? maybe sufficient in practice *)
@@ -691,7 +691,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
       | (Array (eopt, t), [i1;i2]) ->
           pp_type_left fullt;
 
-          iiqu +> List.iter pr_elem;
+          iiqu |> List.iter pr_elem;
           print_ident ident;
 
           pp_type_right fullt;
@@ -700,7 +700,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
       | (FunctionType (returnt, paramst), [i1;i2]) ->
           pp_type_left fullt;
 
-          iiqu +> List.iter pr_elem;
+          iiqu |> List.iter pr_elem;
           print_ident ident;
 
           pp_type_right fullt;
@@ -715,7 +715,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
       match ty, iity with
       | (Pointer t, [i]) ->
           pr_elem i;
-          iiqu +> List.iter pr_elem; (* le const est forcement apres le '*' *)
+          iiqu |> List.iter pr_elem; (* le const est forcement apres le '*' *)
           pp_type_left t
 
       | (Array (eopt, t), [i1;i2]) -> pp_type_left t
@@ -742,7 +742,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
          p_register = (b,iib);
          p_type=t;} = param in
 
-    iib +> List.iter pr_elem;
+    iib |> List.iter pr_elem;
 
     match nameopt with
     | None ->
@@ -761,7 +761,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
     | (Array (eopt, t), [i1;i2]) ->
         pr_elem i1;
-        eopt +> do_option pp_expression;
+        eopt |> do_option pp_expression;
         pr_elem i2;
         pp_type_right t
 
@@ -770,13 +770,13 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
         pr_elem i1;
         (match paramst with
         | (ts, (b, iib)) ->
-            ts +> List.iter (fun (param,iicomma) ->
+            ts |> List.iter (fun (param,iicomma) ->
               assert ((List.length iicomma) <= 1);
-              iicomma +> List.iter (function x -> pr_elem x; pr_space());
+              iicomma |> List.iter (function x -> pr_elem x; pr_space());
 
               pp_param param;
 	    );
-            iib +> List.iter pr_elem;
+            iib |> List.iter pr_elem;
         );
         pr_elem i2
 
@@ -806,7 +806,7 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
 	pr_elem ifakestart;
 
-        (* old: iisto +> List.iter pr_elem; *)
+        (* old: iisto |> List.iter pr_elem; *)
 
 
         (* handling the first var. Special case, we print the whole type *)
@@ -816,14 +816,14 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 	    pp_type_with_ident
 	      (Some (s, iis)) (Some (storage, iisto))
 	      returnType attrs;
-	    iniopt +> do_option (fun (iini, init) ->
+	    iniopt |> do_option (fun (iini, init) ->
 	      pr_elem iini;
               pp_init init);
 	| None -> pp_type returnType
 	);
 
       (* for other vars, we just call pp_type_with_ident_rest. *)
-	xs +> List.iter (function
+	xs |> List.iter (function
 	| ({v_namei = Some (name, iniopt);
 	    v_type = returnType;
 	    v_storage = storage2;
@@ -832,10 +832,10 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
             let (s,iis) = get_s_and_ii_of_name name in
 	    assert (storage2 =*= storage);
-	    iivirg +> List.iter pr_elem;
+	    iivirg |> List.iter pr_elem;
 	    pp_type_with_ident_rest
 	      (Some (s, iis)) returnType attrs;
-	    iniopt +> do_option (fun (iini, init) ->
+	    iniopt |> do_option (fun (iini, init) ->
 	      pr_elem iini; pp_init init
             );
 
@@ -847,12 +847,12 @@ let pretty_print_c pr_elem pr_space pr_nl pr_indent pr_outdent pr_unindent =
 
     | MacroDecl ((s, es), iis::lp::rp::iiend::ifakestart::iisto) ->
 	pr_elem ifakestart;
-	iisto +> List.iter pr_elem; (* static and const *)
+	iisto |> List.iter pr_elem; (* static and const *)
 	pr_elem iis;
 	pr_elem lp;
-	es +> List.iter (fun (e, opt) ->
+	es |> List.iter (fun (e, opt) ->
           assert (List.length opt <= 1);
-          opt +> List.iter pr_elem;
+          opt |> List.iter pr_elem;
           pp_argument e;
 	);
 
@@ -868,17 +868,17 @@ and pp_init (init, iinit) =
       | InitExpr e, [] -> pp_expression e;
       | InitList xs, i1::i2::iicommaopt ->
           pr_elem i1; start_block();
-          xs +> List.iter (fun (x, ii) ->
+          xs |> List.iter (fun (x, ii) ->
             assert (List.length ii <= 1);
-            ii +> List.iter (function e -> pr_elem e; pr_nl());
+            ii |> List.iter (function e -> pr_elem e; pr_nl());
             pp_init x
           );
-          iicommaopt +> List.iter pr_elem;
+          iicommaopt |> List.iter pr_elem;
 	  end_block();
           pr_elem i2;
 
       | InitDesignators (xs, initialiser), [i1] -> (* : *)
-          xs +> List.iter pp_designator;
+          xs |> List.iter pp_designator;
           pr_elem i1;
           pp_init initialiser
 
@@ -911,8 +911,8 @@ and pp_init (init, iinit) =
 
 (* ---------------------- *)
   and pp_attributes pr_elem pr_space attrs =
-    attrs +> List.iter (fun (attr, ii) ->
-      ii +> List.iter pr_elem;
+    attrs |> List.iter (fun (attr, ii) ->
+      ii |> List.iter pr_elem;
     );
 
 (* ---------------------- *)
@@ -951,8 +951,8 @@ and pp_init (init, iinit) =
                pp_type_with_ident None None t
 
            | paramst ->
-               paramst +> List.iter (fun (((bool, s, t), ii_b_s), iicomma) ->
-	       iicomma +> List.iter pr_elem;
+               paramst |> List.iter (fun (((bool, s, t), ii_b_s), iicomma) ->
+	       iicomma |> List.iter pr_elem;
 
 	       (match b, s, ii_b_s with
                | false, Some s, [i1] ->
@@ -971,21 +971,21 @@ and pp_init (init, iinit) =
          (* normally ii represent the ",..." but it is also abused
             with the f(void) case *)
          (* assert (List.length iib <= 2);*)
-           iib +> List.iter pr_elem;
+           iib |> List.iter pr_elem;
 
         *)
-        paramst +> List.iter (fun (param,iicomma) ->
+        paramst |> List.iter (fun (param,iicomma) ->
           assert ((List.length iicomma) <= 1);
-          iicomma +> List.iter (function x -> pr_elem x; pr_space());
+          iicomma |> List.iter (function x -> pr_elem x; pr_space());
 
           pp_param param;
         );
-        iib +> List.iter pr_elem;
+        iib |> List.iter pr_elem;
 
 
         pr_elem iifunc2;
         pr_elem i1;
-        statxs +> List.iter pp_statement_seq;
+        statxs |> List.iter pp_statement_seq;
         pr_elem i2;
     | _ -> raise Impossible
 
@@ -1035,10 +1035,10 @@ and pp_init (init, iinit) =
 	| DefineFunc (params, ii) ->
             let (i1,i2) = Common2.tuple_of_list2 ii in
             pr_elem i1;
-            params +> List.iter (fun ((s,iis), iicomma) ->
+            params |> List.iter (fun ((s,iis), iicomma) ->
               assert (List.length iicomma <= 1);
-              iicomma +> List.iter pr_elem;
-              iis +> List.iter pr_elem;
+              iicomma |> List.iter pr_elem;
+              iis |> List.iter pr_elem;
             );
             pr_elem i2;
 	);
@@ -1063,19 +1063,19 @@ and pp_init (init, iinit) =
     | MacroTop (s, es,   [i1;i2;i3;i4]) ->
 	pr_elem i1;
 	pr_elem i2;
-	es +> List.iter (fun (e, opt) ->
+	es |> List.iter (fun (e, opt) ->
           assert (List.length opt <= 1);
-          opt +> List.iter pr_elem;
+          opt |> List.iter pr_elem;
           pp_argument e;
 	);
 	pr_elem i3;
 	pr_elem i4;
 
 
-    | EmptyDef ii -> ii +> List.iter pr_elem
+    | EmptyDef ii -> ii |> List.iter pr_elem
     | NotParsedCorrectly ii ->
 	assert (List.length ii >= 1);
-	ii +> List.iter pr_elem
+	ii |> List.iter pr_elem
     | FinalDef info -> pr_elem (Ast_c.rewrap_str "" info)
 
     | IfdefTop ifdefdir -> pp_ifdef ifdefdir
@@ -1097,9 +1097,9 @@ and pp_init (init, iinit) =
       (*
 	 iif ii;
 	 iif iidotsb;
-	 attrs +> List.iter (vk_attribute bigf);
+	 attrs |> List.iter (vk_attribute bigf);
 	 vk_type bigf rett;
-	 paramst +> List.iter (fun (param, iicomma) ->
+	 paramst |> List.iter (fun (param, iicomma) ->
          vk_param bigf param;
          iif iicomma;
 	 );
@@ -1129,9 +1129,9 @@ and pp_init (init, iinit) =
         (*
            iif i1; iif i2; iif i3;
            iif ii;
-           e1opt +> do_option (vk_expr bigf);
-           e2opt +> do_option (vk_expr bigf);
-           e3opt +> do_option (vk_expr bigf);
+           e1opt |> do_option (vk_expr bigf);
+           e2opt |> do_option (vk_expr bigf);
+           e3opt |> do_option (vk_expr bigf);
         *)
 	pr2 "XXX"
 
@@ -1275,7 +1275,7 @@ let pr_elem info =
     let before = !(info.comments_tag).mbefore in
     if not (null before) then begin
       pp "-->";
-      before +> List.iter (fun (comment_like, pinfo) ->
+      before |> List.iter (fun (comment_like, pinfo) ->
         let s = pinfo.Parse_info.str in
         pp s
       );

--- a/parsing_c/test_parsing_c.ml
+++ b/parsing_c/test_parsing_c.ml
@@ -20,7 +20,7 @@ let test_tokens_c file =
   Flag_parsing_c.verbose_lexing := true;
   Flag_parsing_c.verbose_parsing := true;
 
-  Parse_c.tokens file +> List.iter (fun x -> pr2_gen x);
+  Parse_c.tokens file |> List.iter (fun x -> pr2_gen x);
   ()
 
 
@@ -50,7 +50,7 @@ let test_parse_gen xs ext =
 
   Common2.check_stack_nbfiles (List.length fullxs);
 
-  fullxs +> List.iter (fun file ->
+  fullxs |> List.iter (fun file ->
     if not (file =~ (".*\\."^ext))
     then pr2 ("warning: seems not a ."^ext^" file");
 
@@ -59,7 +59,7 @@ let test_parse_gen xs ext =
     pr2 ("PARSING: " ^ file);
 
     let (xs, stat) = Parse_c.parse_print_error_heuristic file in
-    xs +> List.iter (fun (ast, (s, toks)) ->
+    xs |> List.iter (fun (ast, (s, toks)) ->
       Parse_c.print_commentized toks
     );
 
@@ -73,7 +73,7 @@ let test_parse_gen xs ext =
     else Hashtbl.add newscore file (Common2.Pb s)
   );
 
-  dirname_opt +> Common.do_option (fun dirname ->
+  dirname_opt |> Common.do_option (fun dirname ->
     Common2.pr2_xxxxxxxxxxxxxxxxx();
     pr2 "regression testing  information";
     Common2.pr2_xxxxxxxxxxxxxxxxx();
@@ -115,13 +115,13 @@ let test_parse xs =
     | [x] when Common2.is_directory x -> Some x
     | _ -> None
   in
-  dirname_opt +> Common.do_option (fun dir ->
+  dirname_opt |> Common.do_option (fun dir ->
 
     let ext = "h" in
     let fullxs = Common2.files_of_dir_or_files_no_vcs ext [dir] in
-    fullxs +> List.iter (fun file ->
+    fullxs |> List.iter (fun file ->
       let xs = Parse_c.parse_cpp_define_file file in
-      xs +> List.iter (fun (x, def) ->
+      xs |> List.iter (fun (x, def) ->
         let (s, params, body) = def in
         Hashtbl.replace !Parse_c._defs s (s, params, body);
       );
@@ -135,7 +135,7 @@ let test_parse xs =
   let stat_list = ref [] in
   Common2.check_stack_nbfiles (List.length fullxs);
 
-  fullxs +> List.iter (fun file ->
+  fullxs |> List.iter (fun file ->
     if not (file =~ (".*\\."^ext))
     then pr2 ("warning: seems not a ."^ext^" file");
 
@@ -143,7 +143,7 @@ let test_parse xs =
     pr2 ("PARSING: " ^ file);
 
     let (xs, stat) = Parse_c.parse_print_error_heuristic file in
-    xs +> List.iter (fun (ast, (s, toks)) ->
+    xs |> List.iter (fun (ast, (s, toks)) ->
       Parse_c.print_commentized toks
     );
 
@@ -188,7 +188,7 @@ let test_cfg file =
 
   let (program, _stat) = Parse_c.parse_print_error_heuristic file in
 
-  program +> List.iter (fun (e,_) ->
+  program |> List.iter (fun (e,_) ->
     let toprocess =
       match specific_func, e with
       | None, _ -> true
@@ -202,7 +202,7 @@ let test_cfg file =
       (* old: Flow_to_ast.test !Flag.show_flow def *)
       (try
           let flow = Ast_to_flow.ast_to_control_flow e in
-          flow +> do_option (fun flow ->
+          flow |> do_option (fun flow ->
             Ast_to_flow.deadcode_detection flow;
             let flow = Ast_to_flow.annotate_loop_nodes flow in
 
@@ -229,10 +229,10 @@ let test_cfg_ifdef file =
 
   let ast = Cpp_ast_c.cpp_ifdef_statementize ast in
 
-  ast +> List.iter (fun e ->
+  ast |> List.iter (fun e ->
     (try
         let flow = Ast_to_flow.ast_to_control_flow e in
-        flow +> do_option (fun flow ->
+        flow |> do_option (fun flow ->
           Ast_to_flow.deadcode_detection flow;
           let flow = Ast_to_flow.annotate_loop_nodes flow in
           Ograph_extended.print_ograph_mutable flow ("/tmp/output.dot") true
@@ -248,13 +248,13 @@ let test_parse_unparse infile =
 
   let (program2, _stat) = Parse_c.parse_print_error_heuristic infile in
   let program2_with_ppmethod =
-    program2 +> List.map (fun x -> x, Unparse_c.PPnormal)
+    program2 |> List.map (fun x -> x, Unparse_c.PPnormal)
   in
   Unparse_c.pp_program program2_with_ppmethod tmpfile;
   Common.command2 ("cat " ^ tmpfile);
   (* if want see diff of space => no -b -B *)
   Common.command2 (spf "diff -u -p  %s %s" infile tmpfile);
-  (* +> Transformation.test_simple_trans1;*)
+  (* |> Transformation.test_simple_trans1;*)
   ()
 
 
@@ -269,16 +269,16 @@ let test_type_c infile =
   let (program2, _stat) =  Parse_c.parse_print_error_heuristic infile in
   let _program2 =
     program2
-    +> Common2.unzip
-    +> (fun (program, infos) ->
+    |> Common2.unzip
+    |> (fun (program, infos) ->
       Type_annoter_c.annotate_program !Type_annoter_c.initial_env
-        program +> List.map fst,
+        program |> List.map fst,
       infos
     )
-    +> Common2.uncurry Common2.zip
+    |> Common2.uncurry Common2.zip
   in
   let program2_with_ppmethod =
-    program2 +> List.map (fun x -> x, Unparse_c.PPnormal)
+    program2 |> List.map (fun x -> x, Unparse_c.PPnormal)
   in
   Unparse_c.pp_program program2_with_ppmethod tmpfile;
   Common.command2 ("cat " ^ tmpfile);
@@ -289,15 +289,15 @@ let test_type_c infile =
 (* ex: demos/platform_ifdef.c *)
 let test_comment_annotater infile =
   let (program2, _stat) =  Parse_c.parse_print_error_heuristic infile in
-  let asts = program2 +> List.map (fun (ast,_) -> ast) in
-  let toks = program2 +> List.map (fun (ast, (s, toks)) -> toks) +>
+  let asts = program2 |> List.map (fun (ast,_) -> ast) in
+  let toks = program2 |> List.map (fun (ast, (s, toks)) -> toks) |>
     List.flatten in
 
   Flag_parsing_c.pretty_print_comment_info := true;
 
   pr2 "pretty print, before comment annotation: --->";
   Common2.adjust_pp_with_indent (fun () ->
-  asts +> List.iter (fun ast ->
+  asts |> List.iter (fun ast ->
     Pretty_print_c.pp_toplevel_simple ast;
   );
   );
@@ -306,7 +306,7 @@ let test_comment_annotater infile =
 
   Common2.adjust_pp_with_indent (fun () ->
   pr2 "pretty print, after comment annotation: --->";
-  asts +> List.iter (fun ast ->
+  asts |> List.iter (fun ast ->
     Pretty_print_c.pp_toplevel_simple ast;
   );
   );
@@ -333,8 +333,8 @@ let test_compare_c_hardcoded () =
       "tests/equal_modulo1.c"
       "tests/equal_modulo2.c"
     *)
-  +> Compare_c.compare_result_to_string
-  +> pr2
+  |> Compare_c.compare_result_to_string
+  |> pr2
 
 
 
@@ -351,7 +351,7 @@ let test_attributes file =
     Visitor_c.kdecl = (fun (k, bigf) decl ->
       match decl with
       | DeclList (xs, ii) ->
-          xs +> List.iter (fun (onedecl, iicomma) ->
+          xs |> List.iter (fun (onedecl, iicomma) ->
 
             let sattr  = Ast_c.s_of_attr onedecl.v_attr in
             let idname =
@@ -391,11 +391,11 @@ let extract_macros ~selection x =
 
   let ext = "h" in
   let fullxs = Common2.files_of_dir_or_files_no_vcs ext [x] in
-  fullxs +> List.iter (fun file ->
+  fullxs |> List.iter (fun file ->
 
     pr ("/* PARSING: " ^ file ^ " */");
     let xs = Parse_c.parse_cpp_define_file file in
-    xs +> List.iter (fun (x, def) ->
+    xs |> List.iter (fun (x, def) ->
       let (s, params, body) = def in
       assert(s = x);
       (match params, body with
@@ -416,7 +416,7 @@ let extract_macros ~selection x =
             | Cpp_token_c.DefineHint _ ->
                 failwith "weird, hint in regular header file"
             | Cpp_token_c.DefineBody xs ->
-                Common.join " " (xs +> List.map Token_helpers.str_of_tok),
+                Common.join " " (xs |> List.map Token_helpers.str_of_tok),
                 xs
           in
 

--- a/parsing_c/token_views_c.ml
+++ b/parsing_c/token_views_c.ml
@@ -84,12 +84,12 @@ let mk_token_extended x =
 
 let rebuild_tokens_extented toks_ext =
   let _tokens = ref [] in
-  toks_ext +> List.iter (fun tok ->
-    tok.new_tokens_before +> List.iter (fun x -> Common.push x _tokens);
+  toks_ext |> List.iter (fun tok ->
+    tok.new_tokens_before |> List.iter (fun x -> Common.push x _tokens);
     Common.push tok.tok _tokens
   );
   let tokens = List.rev !_tokens in
-  (tokens +> Common2.acc_map mk_token_extended)
+  (tokens |> Common2.acc_map mk_token_extended)
 
 
 
@@ -351,28 +351,28 @@ let rec mk_body_function_grouped xs =
 (* ------------------------------------------------------------------------- *)
 
 let rec iter_token_paren f xs =
-  xs +> List.iter (function
+  xs |> List.iter (function
   | PToken tok -> f tok;
   | Parenthised (xxs, info_parens) ->
-      info_parens +> List.iter f;
-      xxs +> List.iter (fun xs -> iter_token_paren f xs)
+      info_parens |> List.iter f;
+      xxs |> List.iter (fun xs -> iter_token_paren f xs)
   )
 
 let rec iter_token_brace f xs =
-  xs +> List.iter (function
+  xs |> List.iter (function
   | BToken tok -> f tok;
   | Braceised (xxs, tok1, tok2opt) ->
       f tok1; do_option f tok2opt;
-      xxs +> List.iter (fun xs -> iter_token_brace f xs)
+      xxs |> List.iter (fun xs -> iter_token_brace f xs)
   )
 
 let rec iter_token_ifdef f xs =
-  xs +> List.iter (function
-  | NotIfdefLine xs -> xs +> List.iter f;
+  xs |> List.iter (function
+  | NotIfdefLine xs -> xs |> List.iter f;
   | Ifdefbool (_, xxs, info_ifdef)
   | Ifdef (xxs, info_ifdef) ->
-      info_ifdef +> List.iter f;
-      xxs +> List.iter (iter_token_ifdef f)
+      info_ifdef |> List.iter f;
+      xxs |> List.iter (iter_token_ifdef f)
   )
 
 
@@ -380,7 +380,7 @@ let rec iter_token_ifdef f xs =
 
 let tokens_of_paren xs =
   let g = ref [] in
-  xs +> iter_token_paren (fun tok -> Common.push tok g);
+  xs |> iter_token_paren (fun tok -> Common.push tok g);
   List.rev !g
 
 
@@ -407,16 +407,16 @@ let tokens_of_paren_ordered xs =
   and aux_args (xxs, commas) =
     match xxs, commas with
     | [], [] -> ()
-    | [xs], [] -> xs +> List.iter aux_tokens_ordered
+    | [xs], [] -> xs |> List.iter aux_tokens_ordered
     | xs::ys::xxs, comma::commas ->
-        xs +> List.iter aux_tokens_ordered;
+        xs |> List.iter aux_tokens_ordered;
         Common.push comma g;
         aux_args (ys::xxs, commas)
     | _ -> raise Impossible
 
   in
 
-  xs +> List.iter aux_tokens_ordered;
+  xs |> List.iter aux_tokens_ordered;
   List.rev !g
 
 
@@ -437,7 +437,7 @@ let rec set_in_function_tag xs =
   (* ) { and the closing } is in column zero, then certainly a function *)
   | BToken ({tok = TCPar _ })::(Braceised (body, tok1, Some tok2))::xs
       when tok1.col <> 0 && tok2.col =|= 0 ->
-      body +> List.iter (iter_token_brace (fun tok ->
+      body |> List.iter (iter_token_brace (fun tok ->
         tok.where <- InFunction
       ));
       set_in_function_tag xs
@@ -446,7 +446,7 @@ let rec set_in_function_tag xs =
 
   | (Braceised (body, tok1, Some tok2))::xs
       when tok1.col =|= 0 && tok2.col =|= 0 ->
-      body +> List.iter (iter_token_brace (fun tok ->
+      body |> List.iter (iter_token_brace (fun tok ->
         tok.where <- InFunction
       ));
       set_in_function_tag xs
@@ -463,7 +463,7 @@ let rec set_in_other xs =
   | BToken ({tok = Tenum _})
     ::Braceised(body, tok1, tok2)::xs
     ->
-      body +> List.iter (iter_token_brace (fun tok ->
+      body |> List.iter (iter_token_brace (fun tok ->
         tok.where <- InEnum;
       ));
       set_in_other xs
@@ -471,14 +471,14 @@ let rec set_in_other xs =
   (* struct x { } *)
   | BToken ({tok = Tstruct _})::BToken ({tok = TIdent _})
     ::Braceised(body, tok1, tok2)::xs ->
-      body +> List.iter (iter_token_brace (fun tok ->
+      body |> List.iter (iter_token_brace (fun tok ->
         tok.where <- InStruct;
       ));
       set_in_other xs
   (* = { } *)
   | BToken ({tok = TEq _})
     ::Braceised(body, tok1, tok2)::xs ->
-      body +> List.iter (iter_token_brace (fun tok ->
+      body |> List.iter (iter_token_brace (fun tok ->
         tok.where <- InInitializer;
       ));
       set_in_other xs
@@ -486,7 +486,7 @@ let rec set_in_other xs =
   | BToken _::xs -> set_in_other xs
 
   | Braceised(body, tok1, tok2)::xs ->
-      body +> List.iter set_in_other;
+      body |> List.iter set_in_other;
       set_in_other xs
 
 

--- a/parsing_c/type_annoter_c.ml
+++ b/parsing_c/type_annoter_c.ml
@@ -299,22 +299,22 @@ let lookup_typedef a b =
 let rec find_final_type ty env =
 
   match Ast_c.unwrap_typeC ty with
-  | BaseType x  -> (BaseType x) +> Ast_c.rewrap_typeC ty
+  | BaseType x  -> (BaseType x) |> Ast_c.rewrap_typeC ty
 
-  | Pointer t -> (Pointer (find_final_type t env))  +> Ast_c.rewrap_typeC ty
-  | Array (e, t) -> Array (e, find_final_type t env) +> Ast_c.rewrap_typeC ty
+  | Pointer t -> (Pointer (find_final_type t env))  |> Ast_c.rewrap_typeC ty
+  | Array (e, t) -> Array (e, find_final_type t env) |> Ast_c.rewrap_typeC ty
 
-  | StructUnion (sopt, su) -> StructUnion (sopt, su)  +> Ast_c.rewrap_typeC ty
+  | StructUnion (sopt, su) -> StructUnion (sopt, su)  |> Ast_c.rewrap_typeC ty
 
-  | FunctionType t -> (FunctionType t) (* todo ? *) +> Ast_c.rewrap_typeC ty
-  | Enum  (s, enumt) -> (Enum  (s, enumt)) (* todo? *) +> Ast_c.rewrap_typeC ty
-  | EnumName s -> (EnumName s) (* todo? *) +> Ast_c.rewrap_typeC ty
+  | FunctionType t -> (FunctionType t) (* todo ? *) |> Ast_c.rewrap_typeC ty
+  | Enum  (s, enumt) -> (Enum  (s, enumt)) (* todo? *) |> Ast_c.rewrap_typeC ty
+  | EnumName s -> (EnumName s) (* todo? *) |> Ast_c.rewrap_typeC ty
 
   | StructUnionName (su, s) ->
       (try
           let ((structtyp,ii), env') = lookup_structunion (su, s) env in
           Ast_c.nQ, (StructUnion (Some s, structtyp), ii)
-          (* old: +> Ast_c.rewrap_typeC ty
+          (* old: |> Ast_c.rewrap_typeC ty
            * but must wrap with good ii, otherwise pretty_print_c
            * will be lost and raise some Impossible
            *)
@@ -356,7 +356,7 @@ let rec type_unfold_one_step ty env =
       (try
           let (((su,fields),ii), env') = lookup_structunion (su, s) env in
           Ast_c.nQ, (StructUnion (su, Some s, fields), ii)
-          (* old: +> Ast_c.rewrap_typeC ty
+          (* old: |> Ast_c.rewrap_typeC ty
            * but must wrap with good ii, otherwise pretty_print_c
            * will be lost and raise some Impossible
            *)
@@ -399,20 +399,20 @@ let rec typedef_fix ty env =
   | BaseType x  ->
       ty
   | Pointer t ->
-      Pointer (typedef_fix t env)  +> Ast_c.rewrap_typeC ty
+      Pointer (typedef_fix t env)  |> Ast_c.rewrap_typeC ty
   | Array (e, t) ->
-      Array (e, typedef_fix t env) +> Ast_c.rewrap_typeC ty
+      Array (e, typedef_fix t env) |> Ast_c.rewrap_typeC ty
   | StructUnion (su, sopt, fields) ->
       (* normalize, fold.
        * todo? but what if correspond to a nested struct def ?
        *)
       Type_c.structdef_to_struct_name ty
   | FunctionType ft ->
-      (FunctionType ft) (* todo ? *) +> Ast_c.rewrap_typeC ty
+      (FunctionType ft) (* todo ? *) |> Ast_c.rewrap_typeC ty
   | Enum  (s, enumt) ->
-      (Enum  (s, enumt)) (* todo? *) +> Ast_c.rewrap_typeC ty
+      (Enum  (s, enumt)) (* todo? *) |> Ast_c.rewrap_typeC ty
   | EnumName s ->
-      (EnumName s) (* todo? *) +> Ast_c.rewrap_typeC ty
+      (EnumName s) (* todo? *) |> Ast_c.rewrap_typeC ty
 
   (* we prefer StructUnionName to StructUnion when it comes to typed metavar *)
   | StructUnionName (su, s) -> ty
@@ -433,7 +433,7 @@ let rec typedef_fix ty env =
            * can have some weird mutually recursive typedef which
            * each new type alias search for its mutual def.
            *)
-          TypeName (name, Some (typedef_fix t' env')) +> Ast_c.rewrap_typeC ty
+          TypeName (name, Some (typedef_fix t' env')) |> Ast_c.rewrap_typeC ty
         with Not_found ->
           ty
       ))
@@ -652,7 +652,7 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
     | FunCall (((Ident (ident), typ), _ii) as e1, args) ->
 
         (* recurse *)
-        args +> List.iter (fun (e,ii) ->
+        args |> List.iter (fun (e,ii) ->
           (* could typecheck if arguments agree with prototype *)
           Visitor_c.vk_argument bigf e
         );
@@ -693,7 +693,7 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
                       Type_c.fake_function_type rettype args
                     in
 
-                    macrotype_opt +> Common.do_option (fun t ->
+                    macrotype_opt |> Common.do_option (fun t ->
                       pr2 ("Type_annotater: generate fake function type" ^
                               "for macro: " ^ s);
                       let tyinfo = make_info_def_fix t in
@@ -719,7 +719,7 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
     | FunCall (e, args) ->
         k expr;
 
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun typ ->
+        (Ast_c.get_type_expr e) |> Type_c.do_with_type (fun typ ->
           (* copy paste of above *)
           (match unwrap_unfold_env typ with
           | FunctionType (ret, params) -> make_info_def ret
@@ -781,7 +781,7 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
     | ArrayAccess (e, _) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
 
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t ->
+        (Ast_c.get_type_expr e) |> Type_c.do_with_type (fun t ->
           (* todo: maybe not good env !! *)
           match unwrap_unfold_env t with
           | Pointer x
@@ -794,7 +794,7 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
     | Unary (e, GetRef) ->
         k expr; (* recurse to set the types-ref of sub expressions *)
 
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t ->
+        (Ast_c.get_type_expr e) |> Type_c.do_with_type (fun t ->
           (* must generate an element so that '=' can be used
            * to compare type ?
            *)
@@ -815,7 +815,7 @@ let annotater_expr_visitor_subpart = (fun (k,bigf) expr ->
 
         k expr; (* recurse to set the types-ref of sub expressions *)
 
-        (Ast_c.get_type_expr e) +> Type_c.do_with_type (fun t ->
+        (Ast_c.get_type_expr e) |> Type_c.do_with_type (fun t ->
 
           let topt =
             match x with
@@ -982,14 +982,14 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
        * file, not inside include.
        *)
       | Include {i_content = opt} ->
-          opt +> Common.do_option (fun (filename, program) ->
+          opt |> Common.do_option (fun (filename, program) ->
             save_excursion Flag_parsing_c.verbose_type (fun () ->
               Flag_parsing_c.verbose_type := false;
 
               (* old: Visitor_c.vk_program bigf program;
                * opti: set the just_add_in_env
                *)
-              program +> List.iter (fun elem ->
+              program |> List.iter (fun elem ->
                 visit_toplevel ~just_add_in_env:true ~depth:(depth+1) elem
               )
             )
@@ -1042,7 +1042,7 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
     Visitor_c.kdecl = (fun (k, bigf) d ->
       (match d with
       | (DeclList (xs, ii)) ->
-          xs +> List.iter (fun ({v_namei = var; v_type = t;
+          xs |> List.iter (fun ({v_namei = var; v_type = t;
                                  v_storage = sto; v_local = local}, iicomma) ->
 
             (* to add possible definition in type found in Decl *)
@@ -1055,7 +1055,7 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
 	      |	Ast_c.LocalDecl -> Ast_c.LocalVar (offset t)
             in
 
-            var +> Common.do_option (fun (name, iniopt) ->
+            var |> Common.do_option (fun (name, iniopt) ->
               let s = Ast_c.str_of_name name in
 
               match sto with
@@ -1067,7 +1067,7 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
 
                   if need_annotate_body then begin
                     (* int x = sizeof(x) is legal so need process ini *)
-                    iniopt +> Common.do_option (fun (info, ini) ->
+                    iniopt |> Common.do_option (fun (info, ini) ->
                       Visitor_c.vk_ini bigf ini
                     );
                   end
@@ -1099,12 +1099,12 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
 
       | Enum (sopt, enums), ii ->
 
-          enums +> List.iter (fun ((name, eopt), iicomma) ->
+          enums |> List.iter (fun ((name, eopt), iicomma) ->
 
             let s = Ast_c.str_of_name name in
 
             if need_annotate_body
-            then eopt +> Common.do_option (fun (ieq, e) ->
+            then eopt |> Common.do_option (fun (ieq, e) ->
               Visitor_c.vk_expr bigf e
             );
             add_binding (EnumConstant (s, sopt)) true;
@@ -1151,7 +1151,7 @@ let rec visit_toplevel ~just_add_in_env ~depth elem =
 
               if need_annotate_body then
                 do_in_new_scope (fun () ->
-                  paramst +> List.iter (fun ({p_namei= nameopt; p_type= t},_)->
+                  paramst |> List.iter (fun ({p_namei= nameopt; p_type= t},_)->
                     match nameopt with
                     | Some name ->
                         let s = Ast_c.str_of_name name in
@@ -1222,7 +1222,7 @@ let rec (annotate_program2 :
   _scoped_env := env;
   _notyped_var := (Hashtbl.create 100);
 
-  prog +> List.map (fun elem ->
+  prog |> List.map (fun elem ->
     let beforeenv = !_scoped_env in
     visit_toplevel ~just_add_in_env:false ~depth:0 elem;
     let afterenv = !_scoped_env in
@@ -1273,7 +1273,7 @@ let annotate_test_expressions prog =
       | _ -> k st
     )
   } in
-  (prog +> List.iter (fun elem ->
+  (prog |> List.iter (fun elem ->
     Visitor_c.vk_toplevel bigf elem
   ))
 

--- a/parsing_c/type_c.ml
+++ b/parsing_c/type_c.ml
@@ -254,7 +254,7 @@ let (fake_function_type:
   let fake_cparen = Ast_c.rewrap_str ")" fake in
 
   let (tyargs: parameterType wrap2 list) =
-    args +> Common.map_filter (fun (arg,ii) ->
+    args |> Common.map_filter (fun (arg,ii) ->
       match arg with
       | Left e ->
           (match Ast_c.get_onlytype_expr e with
@@ -274,7 +274,7 @@ let (fake_function_type:
   if List.length args <> List.length tyargs
   then None
   else
-    rettype +> Common2.map_option (fun rettype ->
+    rettype |> Common2.map_option (fun rettype ->
       let (ftyp: functionType) = (rettype, (tyargs, (false,[]))) in
       let (t: fullType) =
         (Ast_c.nQ, (FunctionType ftyp, [fake_oparen;fake_cparen]))
@@ -348,10 +348,10 @@ let (type_field:
   let res = ref [] in
 
   let rec aux_fields fields =
-    fields +> List.iter (fun x ->
+    fields |> List.iter (fun x ->
       match x with
       | DeclarationField (FieldDeclList (onefield_multivars, iiptvirg)) ->
-          onefield_multivars +> List.iter (fun (fieldkind, iicomma) ->
+          onefield_multivars |> List.iter (fun (fieldkind, iicomma) ->
             match fieldkind with
             | Simple (Some name, t) | BitField (Some name, t, _, _) ->
                 let s = Ast_c.str_of_name name in

--- a/parsing_c/visitor_c.ml
+++ b/parsing_c/visitor_c.ml
@@ -309,11 +309,11 @@ let rec vk_expr = fun bigf expr ->
      *)
     | StatementExpr ((statxs, is)) ->
         iif is;
-        statxs +> List.iter (vk_statement_sequencable bigf);
+        statxs |> List.iter (vk_statement_sequencable bigf);
 
     | Constructor (t, initxs) ->
         vk_type bigf t;
-        initxs +> List.iter (fun (ini, ii) ->
+        initxs |> List.iter (fun (ini, ii) ->
           vk_ini bigf ini;
           vk_ii bigf ii;
         )
@@ -333,14 +333,14 @@ and vk_name = fun bigf ident ->
     match id with
     | RegularName (s, ii) -> iif ii
     | CppConcatenatedName xs ->
-        xs +> List.iter (fun ((x,ii1), ii2) ->
+        xs |> List.iter (fun ((x,ii1), ii2) ->
           iif ii2;
           iif ii1;
         );
     | CppVariadicName (s, ii) -> iif ii
     | CppIdentBuilder ((s,iis), xs) ->
         iif iis;
-        xs +> List.iter (fun ((x,iix), iicomma) ->
+        xs |> List.iter (fun ((x,iix), iicomma) ->
           iif iicomma;
           iif iix;
         )
@@ -365,7 +365,7 @@ and vk_statement = fun bigf (st: Ast_c.statement) ->
     | Labeled (Default st) -> statf st;
 
     | Compound statxs ->
-        statxs +> List.iter (vk_statement_sequencable bigf)
+        statxs |> List.iter (vk_statement_sequencable bigf)
     | ExprStatement (eopt) -> do_option (vk_expr bigf) eopt;
 
     | Selection  (If (e, st1, st2)) ->
@@ -408,9 +408,9 @@ and vk_statement_sequencable = fun bigf stseq ->
     | IfdefStmt ifdef ->
         vk_ifdef_directive bigf ifdef
     | IfdefStmt2 (ifdef, xxs) ->
-        ifdef +> List.iter (vk_ifdef_directive bigf);
-        xxs +> List.iter (fun xs ->
-          xs +> List.iter (vk_statement_sequencable bigf)
+        ifdef |> List.iter (vk_ifdef_directive bigf);
+        xxs |> List.iter (fun xs ->
+          xs |> List.iter (vk_statement_sequencable bigf)
         )
 
   in f (k, bigf) stseq
@@ -442,10 +442,10 @@ and vk_type = fun bigf t ->
         )
 
     | Enum  (sopt, enumt) ->
-        enumt +> List.iter (fun ((name, eopt), iicomma) ->
+        enumt |> List.iter (fun ((name, eopt), iicomma) ->
           vk_name bigf name;
           iif iicomma;
-          eopt +> Common.do_option (fun (info, e) ->
+          eopt |> Common.do_option (fun (info, e) ->
             iif [info];
             vk_expr bigf e
           )
@@ -483,7 +483,7 @@ and vk_decl = fun bigf d ->
   let f = bigf.kdecl in
   let rec k decl =
     match decl with
-    | DeclList (xs,ii) -> xs +> List.iter (fun (x,ii) ->
+    | DeclList (xs,ii) -> xs |> List.iter (fun (x,ii) ->
         iif ii;
         vk_onedecl bigf x;
       );
@@ -502,10 +502,10 @@ and vk_onedecl = fun bigf onedecl ->
       v_attr = attrs})  ->
 
     vk_type bigf t;
-    attrs +> List.iter (vk_attribute bigf);
-    var +> Common.do_option (fun (name, iniopt) ->
+    attrs |> List.iter (vk_attribute bigf);
+    var |> Common.do_option (fun (name, iniopt) ->
       vk_name bigf name;
-      iniopt +> Common.do_option (fun (info, ini) ->
+      iniopt |> Common.do_option (fun (info, ini) ->
       iif [info];
       vk_ini bigf ini;
       );
@@ -520,12 +520,12 @@ and vk_ini = fun bigf ini ->
     match ini with
     | InitExpr e -> vk_expr bigf e
     | InitList initxs ->
-        initxs +> List.iter (fun (ini, ii) ->
+        initxs |> List.iter (fun (ini, ii) ->
           inif ini;
           iif ii;
         )
     | InitDesignators (xs, e) ->
-        xs +> List.iter (vk_designator bigf);
+        xs |> List.iter (vk_designator bigf);
         inif e
 
     | InitFieldOld (s, e) -> inif e
@@ -549,7 +549,7 @@ and vk_designator = fun bigf design ->
 (* ------------------------------------------------------------------------ *)
 
 and vk_struct_fields = fun bigf fields ->
-  fields +> List.iter (vk_struct_field bigf);
+  fields |> List.iter (vk_struct_field bigf);
 
 and vk_struct_field = fun bigf field ->
   let iif ii = vk_ii bigf ii in
@@ -579,7 +579,7 @@ and vk_struct_field = fun bigf field ->
 
 and vk_struct_fieldkinds = fun bigf onefield_multivars ->
   let iif ii = vk_ii bigf ii in
-  onefield_multivars +> List.iter (fun (field, iicomma) ->
+  onefield_multivars |> List.iter (fun (field, iicomma) ->
     iif iicomma;
     match field with
     | Simple (nameopt, t) ->
@@ -611,17 +611,17 @@ and vk_def = fun bigf d ->
         ->
         iif ii;
         iif iib;
-        attrs +> List.iter (vk_attribute bigf);
+        attrs |> List.iter (vk_attribute bigf);
         vk_type bigf returnt;
-        paramst +> List.iter (fun (param,iicomma) ->
+        paramst |> List.iter (fun (param,iicomma) ->
           vk_param bigf param;
           iif iicomma;
         );
-        oldstyle +> Common.do_option (fun decls ->
-          decls +> List.iter (vk_decl bigf);
+        oldstyle |> Common.do_option (fun decls ->
+          decls |> List.iter (vk_decl bigf);
         );
 
-        statxs +> List.iter (vk_statement_sequencable bigf)
+        statxs |> List.iter (vk_statement_sequencable bigf)
   in f (k, bigf) d
 
 
@@ -647,7 +647,7 @@ and vk_toplevel = fun bigf p ->
   in f (k, bigf) p
 
 and vk_program = fun bigf xs ->
-  xs +> List.iter (vk_toplevel bigf)
+  xs |> List.iter (vk_toplevel bigf)
 
 and vk_ifdef_directive bigf directive =
   let iif ii =  vk_ii bigf ii in
@@ -670,7 +670,7 @@ and vk_cpp_directive bigf directive =
          * and pretty_print do not use visitor_c so no problem.
          *)
         iif ii;
-        copt +> Common.do_option (fun (file, asts) ->
+        copt |> Common.do_option (fun (file, asts) ->
           vk_program bigf asts
         );
     | Define ((s,ii), (defkind, defval)) ->
@@ -689,7 +689,7 @@ and vk_define_kind bigf defkind =
   | DefineVar -> ()
   | DefineFunc (params, ii) ->
       vk_ii bigf ii;
-      params +> List.iter (fun ((s,iis), iicomma) ->
+      params |> List.iter (fun ((s,iis), iicomma) ->
         vk_ii bigf iis;
         vk_ii bigf iicomma;
       )
@@ -749,7 +749,7 @@ and vk_node = fun bigf node ->
     | F.Decl decl -> vk_decl bigf decl
     | F.ExprStatement (st, (eopt, ii)) ->
         iif ii;
-        eopt +> do_option (vk_expr bigf)
+        eopt |> do_option (vk_expr bigf)
 
     | F.IfHeader (_, (e,ii))
     | F.SwitchHeader (_, (e,ii))
@@ -761,9 +761,9 @@ and vk_node = fun bigf node ->
     | F.ForHeader (_st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) ->
         iif i1; iif i2; iif i3;
         iif ii;
-        e1opt +> do_option (vk_expr bigf);
-        e2opt +> do_option (vk_expr bigf);
-        e3opt +> do_option (vk_expr bigf);
+        e1opt |> do_option (vk_expr bigf);
+        e2opt |> do_option (vk_expr bigf);
+        e3opt |> do_option (vk_expr bigf);
     | F.MacroIterHeader (_s, ((s,es), ii)) ->
         iif ii;
         vk_argument_list bigf es;
@@ -854,7 +854,7 @@ and vk_argument = fun bigf arg ->
 
 and vk_argument_list = fun bigf es ->
   let iif ii = vk_ii bigf ii in
-  es +> List.iter (fun (e, ii) ->
+  es |> List.iter (fun (e, ii) ->
     iif ii;
     vk_argument bigf e
   )
@@ -864,13 +864,13 @@ and vk_argument_list = fun bigf es ->
 and vk_param = fun bigf param  ->
   let iif ii = vk_ii bigf ii in
   let {p_namei = swrapopt; p_register = (b, iib); p_type=ft} = param in
-  swrapopt +> Common.do_option (vk_name bigf);
+  swrapopt |> Common.do_option (vk_name bigf);
   iif iib;
   vk_type bigf ft
 
 and vk_param_list = fun bigf ts ->
   let iif ii = vk_ii bigf ii in
-  ts +> List.iter (fun (param,iicomma) ->
+  ts |> List.iter (fun (param,iicomma) ->
     vk_param bigf param;
     iif iicomma;
   )
@@ -882,9 +882,9 @@ and vk_asmbody = fun bigf (string_list, colon_list) ->
   let iif ii = vk_ii bigf ii in
 
   iif string_list;
-  colon_list +> List.iter (fun (Colon xs, ii)  ->
+  colon_list |> List.iter (fun (Colon xs, ii)  ->
     iif ii;
-    xs +> List.iter (fun (x,iicomma) ->
+    xs |> List.iter (fun (x,iicomma) ->
       iif iicomma;
       (match x with
       | ColonMisc, ii -> iif ii
@@ -898,7 +898,7 @@ and vk_asmbody = fun bigf (string_list, colon_list) ->
 (* ------------------------------------------------------------------------ *)
 let vk_args_splitted = fun bigf args_splitted ->
   let iif ii = vk_ii bigf ii in
-  args_splitted +> List.iter (function
+  args_splitted |> List.iter (function
   | Left arg -> vk_argument bigf arg
   | Right ii -> iif ii
   )
@@ -906,7 +906,7 @@ let vk_args_splitted = fun bigf args_splitted ->
 
 let vk_define_params_splitted = fun bigf args_splitted ->
   let iif ii = vk_ii bigf ii in
-  args_splitted +> List.iter (function
+  args_splitted |> List.iter (function
   | Left (s, iis) -> vk_ii bigf iis
   | Right ii -> iif ii
   )
@@ -915,7 +915,7 @@ let vk_define_params_splitted = fun bigf args_splitted ->
 
 let vk_params_splitted = fun bigf args_splitted ->
   let iif ii = vk_ii bigf ii in
-  args_splitted +> List.iter (function
+  args_splitted |> List.iter (function
   | Left arg -> vk_param bigf arg
   | Right ii -> iif ii
   )
@@ -991,7 +991,7 @@ let rec vk_expr_s = fun bigf expr ->
   and k e =
     let ((unwrap_e, typ), ii) = e in
     (* !!! don't analyse optional type !!!
-     * old:  typ +> map_option (vk_type_s bigf) in
+     * old:  typ |> map_option (vk_type_s bigf) in
      *)
     let typ' = typ in
     let e' =
@@ -1000,7 +1000,7 @@ let rec vk_expr_s = fun bigf expr ->
       | Constant (c) -> Constant (c)
       | FunCall  (e, es)         ->
           FunCall (exprf e,
-                  es +> List.map (fun (e,ii) ->
+                  es |> List.map (fun (e,ii) ->
                     vk_argument_s bigf e, iif ii
                   ))
 
@@ -1030,7 +1030,7 @@ let rec vk_expr_s = fun bigf expr ->
       | Constructor (t, initxs) ->
           Constructor
             (vk_type_s bigf t,
-            (initxs +> List.map (fun (ini, ii) ->
+            (initxs |> List.map (fun (ini, ii) ->
               vk_ini_s bigf ini, vk_ii_s bigf ii)
             ))
 
@@ -1062,13 +1062,13 @@ and vk_name_s = fun bigf ident ->
     (match id with
     | RegularName (s,ii) -> RegularName (s, iif ii)
     | CppConcatenatedName xs ->
-        CppConcatenatedName (xs +> List.map (fun ((x,ii1), ii2) ->
+        CppConcatenatedName (xs |> List.map (fun ((x,ii1), ii2) ->
           (x, iif ii1), iif ii2
         ))
     | CppVariadicName (s, ii) -> CppVariadicName (s, iif ii)
     | CppIdentBuilder ((s,iis), xs) ->
         CppIdentBuilder ((s, iif iis),
-                        xs +> List.map (fun ((x,iix), iicomma) ->
+                        xs |> List.map (fun ((x,iix), iicomma) ->
                           ((x, iif iix), iif iicomma)))
     )
   in
@@ -1119,7 +1119,7 @@ and vk_statement_s = fun bigf st ->
           Iteration
             (MacroIteration
                 (s,
-                es +> List.map (fun (e, ii) ->
+                es |> List.map (fun (e, ii) ->
                   vk_argument_s bigf e, vk_ii_s bigf ii
                 ),
                 statf st
@@ -1153,8 +1153,8 @@ and vk_statement_sequencable_s = fun bigf stseq ->
         IfdefStmt (vk_ifdef_directive_s bigf ifdef)
     | IfdefStmt2 (ifdef, xxs) ->
         let ifdef' = List.map (vk_ifdef_directive_s bigf) ifdef in
-        let xxs' = xxs +> List.map (fun xs ->
-          xs +> vk_statement_sequencable_list_s bigf
+        let xxs' = xxs |> List.map (fun xs ->
+          xs |> vk_statement_sequencable_list_s bigf
         )
         in
         IfdefStmt2(ifdef', xxs')
@@ -1163,7 +1163,7 @@ and vk_statement_sequencable_s = fun bigf stseq ->
 and vk_statement_sequencable_list_s = fun bigf statxs ->
   let f = bigf.kstatementseq_list_s in
   let k xs =
-    xs +> List.map (vk_statement_sequencable_s bigf)
+    xs |> List.map (vk_statement_sequencable_s bigf)
   in
   f (k, bigf) statxs
 
@@ -1173,9 +1173,9 @@ and vk_asmbody_s = fun bigf (string_list, colon_list) ->
   let  iif ii = vk_ii_s bigf ii in
 
   iif string_list,
-  colon_list +> List.map (fun (Colon xs, ii) ->
+  colon_list |> List.map (fun (Colon xs, ii) ->
     Colon
-      (xs +> List.map (fun (x, iicomma) ->
+      (xs |> List.map (fun (x, iicomma) ->
         (match x with
         | ColonMisc, ii -> ColonMisc, iif ii
         | ColonExpr e, ii -> ColonExpr (vk_expr_s bigf e), iif ii
@@ -1208,17 +1208,17 @@ and vk_type_s = fun bigf t ->
             (typef returnt,
             (match paramst with
             | (ts, (b, iihas3dots)) ->
-                (ts +> List.map (fun (param,iicomma) ->
+                (ts |> List.map (fun (param,iicomma) ->
                   (vk_param_s bigf param, iif iicomma)),
                 (b, iif iihas3dots))
             ))
 
       | Enum  (sopt, enumt) ->
           Enum (sopt,
-               enumt +> List.map (fun ((name, eopt), iicomma) ->
+               enumt |> List.map (fun ((name, eopt), iicomma) ->
 
                  ((vk_name_s bigf name,
-                  eopt +> Common2.fmap (fun (info, e) ->
+                  eopt |> Common2.fmap (fun (info, e) ->
                     vk_info_s bigf info,
                     vk_expr_s bigf e
                  )),
@@ -1261,7 +1261,7 @@ and vk_decl_s = fun bigf d ->
     | MacroDecl ((s, args),ii) ->
         MacroDecl
           ((s,
-           args +> List.map (fun (e,ii) -> vk_argument_s bigf e, iif ii)
+           args |> List.map (fun (e,ii) -> vk_argument_s bigf e, iif ii)
            ),
           iif ii)
 
@@ -1272,16 +1272,16 @@ and vk_decl_s = fun bigf d ->
             v_local= local;
             v_attr = attrs}, iicomma) =
     {v_namei =
-      (var +> Common2.map_option (fun (name, iniopt) ->
+      (var |> Common2.map_option (fun (name, iniopt) ->
         vk_name_s bigf name,
-        iniopt +> Common2.map_option (fun (info, init) ->
+        iniopt |> Common2.map_option (fun (info, init) ->
           vk_info_s bigf info,
           vk_ini_s bigf init
         )));
      v_type = vk_type_s bigf t;
      v_storage = sto;
      v_local = local;
-     v_attr = attrs +> List.map (vk_attribute_s bigf);
+     v_attr = attrs |> List.map (vk_attribute_s bigf);
     },
     iif iicomma
 
@@ -1295,14 +1295,14 @@ and vk_ini_s = fun bigf ini ->
       match unwrap_ini with
       | InitExpr e -> InitExpr (vk_expr_s bigf e)
       | InitList initxs ->
-          InitList (initxs +> List.map (fun (ini, ii) ->
+          InitList (initxs |> List.map (fun (ini, ii) ->
             inif ini, vk_ii_s bigf ii)
           )
 
 
       | InitDesignators (xs, e) ->
           InitDesignators
-            (xs +> List.map (vk_designator_s bigf),
+            (xs |> List.map (vk_designator_s bigf),
             inif e
             )
 
@@ -1330,7 +1330,7 @@ and vk_designator_s = fun bigf design ->
 and vk_struct_fieldkinds_s = fun bigf onefield_multivars ->
   let iif ii = vk_ii_s bigf ii in
 
-  onefield_multivars +> List.map (fun (field, iicomma) ->
+  onefield_multivars |> List.map (fun (field, iicomma) ->
     (match field with
     | Simple (nameopt, t) ->
         Simple (Common2.map_option (vk_name_s bigf) nameopt,
@@ -1347,7 +1347,7 @@ and vk_struct_fields_s = fun bigf fields ->
 
   let iif ii = vk_ii_s bigf ii in
 
-  fields +> List.map (fun (field) ->
+  fields |> List.map (fun (field) ->
     (match field with
     | (DeclarationField (FieldDeclList (onefield_multivars, iiptvirg))) ->
         DeclarationField
@@ -1357,7 +1357,7 @@ and vk_struct_fields_s = fun bigf fields ->
     | MacroDeclField ((s, args),ii) ->
         MacroDeclField
           ((s,
-           args +> List.map (fun (e,ii) -> vk_argument_s bigf e, iif ii)
+           args |> List.map (fun (e,ii) -> vk_argument_s bigf e, iif ii)
            ),
           iif ii)
 
@@ -1386,17 +1386,17 @@ and vk_def_s = fun bigf d ->
         {f_name = s;
          f_type =
             (vk_type_s bigf returnt,
-            (paramst +> List.map (fun (param, iicomma) ->
+            (paramst |> List.map (fun (param, iicomma) ->
               (vk_param_s bigf param, iif iicomma)
             ), (b, iif iib)));
          f_storage = sto;
          f_body =
             vk_statement_sequencable_list_s bigf statxs;
          f_attr =
-            attrs +> List.map (vk_attribute_s bigf);
+            attrs |> List.map (vk_attribute_s bigf);
          f_old_c_style =
-            oldstyle +> Common2.map_option (fun decls ->
-              decls +> List.map (vk_decl_s bigf)
+            oldstyle |> Common2.map_option (fun decls ->
+              decls |> List.map (vk_decl_s bigf)
             );
         },
         iif ii
@@ -1414,7 +1414,7 @@ and vk_toplevel_s = fun bigf p ->
     | MacroTop (s, xs, ii) ->
         MacroTop
           (s,
-          xs +> List.map (fun (elem, iicomma) ->
+          xs |> List.map (fun (elem, iicomma) ->
             vk_argument_s bigf elem, iif iicomma
           ),
           iif ii
@@ -1427,7 +1427,7 @@ and vk_toplevel_s = fun bigf p ->
   in f (k, bigf) p
 
 and vk_program_s = fun bigf xs ->
-  xs +> List.map (vk_toplevel_s bigf)
+  xs |> List.map (vk_toplevel_s bigf)
 
 
 and vk_cpp_directive_s = fun bigf top ->
@@ -1444,7 +1444,7 @@ and vk_cpp_directive_s = fun bigf top ->
       -> Include {i_include = (s, iif ii);
                   i_rel_pos = h_rel_pos;
                   i_is_in_ifdef = b;
-                  i_content = copt +> Common2.map_option (fun (file, asts) ->
+                  i_content = copt |> Common2.map_option (fun (file, asts) ->
                     file, vk_program_s bigf asts
                   );
       }
@@ -1468,7 +1468,7 @@ and vk_define_kind_s  = fun bigf defkind ->
   | DefineVar -> DefineVar
   | DefineFunc (params, ii) ->
       DefineFunc
-        (params +> List.map (fun ((s,iis),iicomma) ->
+        (params |> List.map (fun ((s,iis),iicomma) ->
           ((s, vk_ii_s bigf iis), vk_ii_s bigf iicomma)
         ),
         vk_ii_s bigf ii
@@ -1523,7 +1523,7 @@ and vk_node_s = fun bigf node ->
 
     | F.Decl declb -> F.Decl (vk_decl_s bigf declb)
     | F.ExprStatement (st, (eopt, ii)) ->
-        F.ExprStatement (st, (eopt +> Common2.map_option (vk_expr_s bigf), iif ii))
+        F.ExprStatement (st, (eopt |> Common2.map_option (vk_expr_s bigf), iif ii))
 
     | F.IfHeader (st, (e,ii))     ->
         F.IfHeader    (st, (vk_expr_s bigf e, iif ii))
@@ -1536,15 +1536,15 @@ and vk_node_s = fun bigf node ->
 
     | F.ForHeader (st, (((e1opt,i1), (e2opt,i2), (e3opt,i3)), ii)) ->
         F.ForHeader (st,
-                    (((e1opt +> Common2.map_option (vk_expr_s bigf), iif i1),
-                     (e2opt +> Common2.map_option (vk_expr_s bigf), iif i2),
-                     (e3opt +> Common2.map_option (vk_expr_s bigf), iif i3)),
+                    (((e1opt |> Common2.map_option (vk_expr_s bigf), iif i1),
+                     (e2opt |> Common2.map_option (vk_expr_s bigf), iif i2),
+                     (e3opt |> Common2.map_option (vk_expr_s bigf), iif i3)),
                     iif ii))
 
     | F.MacroIterHeader (st, ((s,es), ii)) ->
         F.MacroIterHeader
           (st,
-          ((s, es +> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii)),
+          ((s, es |> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii)),
           iif ii))
 
 
@@ -1582,7 +1582,7 @@ and vk_node_s = fun bigf node ->
     | F.MacroTop (s, args, ii) ->
         F.MacroTop
           (s,
-          args +> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii),
+          args |> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii),
           iif ii)
 
 
@@ -1624,37 +1624,37 @@ and vk_node_s = fun bigf node ->
 and vk_param_s = fun bigf param ->
   let iif ii = vk_ii_s bigf ii in
   let {p_namei = swrapopt; p_register = (b, iib); p_type=ft} = param in
-  { p_namei = swrapopt +> Common2.map_option (vk_name_s bigf);
+  { p_namei = swrapopt |> Common2.map_option (vk_name_s bigf);
     p_register = (b, iif iib);
     p_type = vk_type_s bigf ft;
   }
 
 let vk_args_splitted_s = fun bigf args_splitted ->
   let iif ii = vk_ii_s bigf ii in
-  args_splitted +> List.map (function
+  args_splitted |> List.map (function
   | Left arg -> Left (vk_argument_s bigf arg)
   | Right ii -> Right (iif ii)
   )
 
 let vk_arguments_s = fun bigf args ->
   let iif ii = vk_ii_s bigf ii in
-  args +> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii)
+  args |> List.map (fun (e, ii) -> vk_argument_s bigf e, iif ii)
 
 
 let vk_params_splitted_s = fun bigf args_splitted ->
   let iif ii = vk_ii_s bigf ii in
-  args_splitted +> List.map (function
+  args_splitted |> List.map (function
   | Left arg -> Left (vk_param_s bigf arg)
   | Right ii -> Right (iif ii)
   )
 
 let vk_params_s = fun bigf args ->
   let iif ii = vk_ii_s bigf ii in
-  args +> List.map (fun (p,ii) -> vk_param_s bigf p, iif ii)
+  args |> List.map (fun (p,ii) -> vk_param_s bigf p, iif ii)
 
 let vk_define_params_splitted_s = fun bigf args_splitted ->
   let iif ii = vk_ii_s bigf ii in
-  args_splitted +> List.map (function
+  args_splitted |> List.map (function
   | Left (s, iis) -> Left (s, vk_ii_s bigf iis)
   | Right ii -> Right (iif ii)
   )

--- a/pl_info/parse_info.ml
+++ b/pl_info/parse_info.ml
@@ -100,7 +100,7 @@ let full_charpos_to_pos a =
   profile_code "Common.full_charpos_to_pos" (fun () -> full_charpos_to_pos2 a)
 
 let test_charpos file =
-  full_charpos_to_pos file +> dump +> pr2
+  full_charpos_to_pos file |> dump |> pr2
 
 
 

--- a/pl_info/statistics_code.ml
+++ b/pl_info/statistics_code.ml
@@ -133,7 +133,7 @@ let add_entities_stat st1 st2 =
 
 
 let sum_entities_stat_list xs =
-  xs +> List.fold_left add_entities_stat (default_entities_stat())
+  xs |> List.fold_left add_entities_stat (default_entities_stat())
 
 let div_pourcent_entities_stat st1 st2 =
   let (+++) n1 n2 =
@@ -224,6 +224,6 @@ let hash_of_entities_stat sum =
   end
 
 let assoc_of_entities_stat x =
-  x +> hash_of_entities_stat +> Common.hash_to_list
+  x |> hash_of_entities_stat |> Common.hash_to_list
 
 

--- a/pl_info/statistics_parsing.ml
+++ b/pl_info/statistics_parsing.ml
@@ -45,20 +45,20 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   let total = (List.length statxs) in
   let perfect =
     statxs
-      +> List.filter (function
+      |> List.filter (function
           {have_timeout = false; bad = 0} -> true | _ -> false)
-      +> List.length
+      |> List.length
   in
 
   if verbose then begin
   pr "\n\n\n---------------------------------------------------------------";
   pr "pbs with files:";
   statxs
-    +> List.filter (function
+    |> List.filter (function
       | {have_timeout = true} -> true
       | {bad = n} when n > 0 -> true
       | _ -> false)
-    +> List.iter (function
+    |> List.iter (function
         {filename = file; have_timeout = timeout; bad = n} ->
           pr (file ^ "  " ^ (if timeout then "TIMEOUT" else i_to_s n));
         );
@@ -67,10 +67,10 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   pr "files with lots of tokens passed/commentized:";
   let threshold_passed = 100 in
   statxs
-    +> List.filter (function
+    |> List.filter (function
       | {commentized = n} when n > threshold_passed -> true
       | _ -> false)
-    +> List.iter (function
+    |> List.iter (function
         {filename = file; commentized = n} ->
           pr (file ^ "  " ^ (i_to_s n));
         );
@@ -78,9 +78,9 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   pr "\n\n\n";
   end;
 
-  let good = statxs +> List.fold_left (fun acc {correct = x} -> acc+x) 0 in
-  let bad  = statxs +> List.fold_left (fun acc {bad = x} -> acc+x) 0  in
-  let passed = statxs +> List.fold_left (fun acc {commentized = x} -> acc+x) 0
+  let good = statxs |> List.fold_left (fun acc {correct = x} -> acc+x) 0 in
+  let bad  = statxs |> List.fold_left (fun acc {bad = x} -> acc+x) 0  in
+  let passed = statxs |> List.fold_left (fun acc {commentized = x} -> acc+x) 0
   in
   let total_lines = good + bad in
 
@@ -89,12 +89,12 @@ let print_parsing_stat_list ?(verbose=false) = fun statxs ->
   (spf "NB total files = %d; " total) ^
   (spf "NB total lines = %d; " total_lines) ^
   (spf "perfect = %d; " perfect) ^
-  (spf "pbs = %d; "     (statxs +> List.filter (function
+  (spf "pbs = %d; "     (statxs |> List.filter (function
       {have_timeout = b; bad = n} when n > 0 -> true | _ -> false)
-                               +> List.length)) ^
-  (spf "timeout = %d; " (statxs +> List.filter (function
+                               |> List.length)) ^
+  (spf "timeout = %d; " (statxs |> List.filter (function
       {have_timeout = true; bad = n} -> true | _ -> false)
-                               +> List.length)) ^
+                               |> List.length)) ^
   (spf "=========> %d" ((100 * perfect) / total)) ^ "%"
 
  );


### PR DESCRIPTION
The reverse-application operator "|>" has been standardized in OCaml
since release 4.01 and is available in the standard library.

This code had a mix of that (locally defined) and a locally defined
"+>" operator that was the same as "|>" (except it had somewhat higher
precedence.)